### PR TITLE
chore: api dockerfile, nginx 파일 수정 (#1)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -35,10 +35,14 @@ FROM node:22-alpine AS production
 RUN corepack enable && corepack prepare pnpm@10.20.0 --activate
 WORKDIR /app
 
+# Docker에서는 Husky CI 필요없음
+ENV HUSKY=0
+
 # 프로덕션 의존성만 설치
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json ./apps/api/
-RUN pnpm install --prod --frozen-lockfile
+COPY packages ./packages
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # 빌드된 파일 복사
 COPY --from=builder /app/apps/api/dist ./apps/api/dist

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,33 +1,34 @@
 server {
     listen 80;
-    server_name localhost;
-    root /usr/share/nginx/html;
+    server_name _;
+
+    root /var/www/port30/web;
     index index.html;
 
-    # Gzip 압축 설정
+    # gzip
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json;
+    gzip_types text/plain text/css application/json application/javascript text/xml text/javascript;
 
-    # React Router (SPA) 지원
+    # SPA (React Router)
     location / {
         try_files $uri $uri/ /index.html;
     }
 
     # 정적 파일 캐싱
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+        expires 30d;
+        add_header Cache-Control "public";
     }
 
-    # API 프록시 (선택사항)
-    location /api {
-        proxy_pass http://api:3000;
+    # API 프록시 (호스트 nginx 기준)
+    location /api/ {
+        proxy_pass http://127.0.0.1:3000/;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
- dockerfile: 프로덕션 설치에서 스크립트 실행 막기
- nginx
  - apps/web/dist 빌드 결과물을 nginx로 정적 서빙하도록 설정
  - /api 요청을 백엔드 서버(127.0.0.1:3000)로 프록시하도록 변경