### PR TITLE
[CHORE] docker-compose.prod에서 web 컨테이너 제거 (#1)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,20 +50,6 @@ services:
     networks:
       - app-network
 
-  # 프론트엔드 (React + Vite + Nginx)
-  web:
-    build:
-      context: .
-      dockerfile: apps/web/Dockerfile
-      target: production
-    restart: always
-    depends_on:
-      - api
-    ports:
-      - "80:80"
-    networks:
-      - app-network
-
 volumes:
   mysql_data:
   redis_data:


### PR DESCRIPTION
## 🔍 PR 요약

- 운영에서는 프론트 컨테이너가 필요 없기 때문에 docker-compose.prod에서 web 서비스 제거했습니다.

## 🧾 관련 이슈

- close #1

## 🛠️ 주요 변경 사항

- docker-compose.prod.yml 파일 수정

## 📸 스크린샷 (선택)

<img width="1203" height="507" alt="image" src="https://github.com/user-attachments/assets/2abc65a6-40de-4a95-9827-8d72dc16ff0c" />

## 🧠 의도 및 배경

프론트 빌드(dist) → nginx가 정적 파일 서빙을 해주기 때문에 도커 컨테이너에는 api 백엔드만 실행되도록 했습니다.

## 💬 리뷰 요구사항(선택)

