### PR TITLE
[FEAT] Battle Type 추가 (#18)

### DIFF
--- a/packages/constants/battle.ts
+++ b/packages/constants/battle.ts
@@ -1,0 +1,29 @@
+export const BATTLE_CONFIG = {
+    DURATION: 30 * 60, // 기본 배틀 시간: 30분 (초 단위)
+    DEFAULT_LANGUAGE: 'javascript',
+} as const;
+
+export const BATTLE_EVENTS = {
+    // 배틀 생성 및 시작
+    BATTLE_CREATED: 'battle-created',
+    BATTLE_STARTED: 'battle-started',
+    BATTLE_ENDED: 'battle-ended',
+
+    // 코드 변경
+    CODE_CHANGE: 'code-change',
+    CODE_UPDATED: 'code-updated',
+
+    // 유저 상태 변경
+    USER_CONNECTED: 'user-connected',
+    USER_DISCONNECTED: 'user-disconnected',
+    USER_FINISHED: 'user-finished',
+
+    // 진행 상황 업데이트
+    PROGRESS_UPDATE: 'progress-update',
+    
+    // 유저 진행률
+    USER_TEST_RESULT: 'user-test-result',
+
+    // 배틀 상태 업데이트
+    BATTLE_STATUS_UPDATE: 'battle-status-update',
+} as const;

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -1,0 +1,35 @@
+export type BattleStatus = 'running' | 'completed';
+
+export type BattleResult = 'win' | 'lose' | 'draw';
+
+export interface Battle {
+    battleId: string;
+    roomId: string;
+    status: BattleStatus;
+
+    config: {
+        duration: number;
+    }
+    startedAt?: Date;
+    endedAt?: Date;
+
+    users: BattleUser[];
+}
+
+export interface BattleUser {
+    userId: string;
+    code: string;
+    language: string;
+
+    progress: {
+        passedCount: number;
+        totalCount: number;
+    };
+
+    isConnected: boolean;
+    isFinished: boolean;
+    finishedAt?: Date;
+    disconnectedAt?: Date;
+
+    result?: BattleResult;
+}

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -18,6 +18,7 @@ export interface Battle {
 
 export interface BattleUser {
     userId: string;
+    battleId: string;
     code: string;
     language: string;
 
@@ -32,4 +33,24 @@ export interface BattleUser {
     disconnectedAt?: Date;
 
     result?: BattleResult;
+}
+
+export interface CreateBattleDTO {
+    roomId: string;
+    config: {
+        duration: number;
+    }
+    users: string[];
+}
+
+export interface UpdateBattleUserDTO {
+    userId: string;
+    battleId: string;
+    code?: string;
+
+    progress: {
+        passedCount: number;
+        totalCount: number;
+    };
+    isFinished?: boolean;
 }


### PR DESCRIPTION
## 🔍 PR 요약

- 배틀과 관련된 공통 타입을 선언했습니다.

## 🧾 관련 이슈

- #18 

## 🛠️ 주요 변경 사항

- packages/types/battle.ts 작성
- packages/constants/battle.ts 작성

배틀과 배틀 유저에 대한 타입 선언
유저의 커넥션 유무와 배틀 상태에 관한 정보 선언
배틀과 관련된 상수 선언(기본 설정값, 관련 이벤트명)


## 🧠 의도 및 배경
- 추후 배틀 페이지와 관련된 로직을 처리하기 위함
- 배틀 데이터 영속성을 위함

## 💬 리뷰 요구사항(선택)

- 타입들이 괜찮은지 확인해주시면 좋겠습니다.
- 빼야하거나 추가해야 할 컬럼이 있으면 알려주세요.
