### PR TITLE
[FEAT] 배틀 서비스 로직 구현 (#30)

### DIFF
--- a/apps/api/src/battle/battle.service.spec.ts
+++ b/apps/api/src/battle/battle.service.spec.ts
@@ -1,0 +1,130 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BattleService } from './battle.service';
+import { RedisService } from '../redis/redis.service';
+import { CreateBattleDTO } from '../../../../packages/types/battle';
+import { BATTLE_CONFIG } from '../../../../packages/constants/battle';
+
+describe('BattleService', () => {
+  let service: BattleService;
+  let mockRedisService: Partial<RedisService>;
+
+  beforeEach(async () => {
+    mockRedisService = {
+      createBattle: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BattleService,
+        {
+          provide: RedisService,
+          useValue: mockRedisService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<BattleService>(BattleService);
+  });
+
+  it('정의되어야 한다', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createBattle', () => {
+    it('올바른 구조로 배틀을 생성해야 한다', async () => {
+      const dto: CreateBattleDTO = {
+        roomId: 'room-123',
+        users: ['user-1', 'user-2'],
+        config: {
+          duration: 600,
+        },
+      };
+
+      const result = await service.createBattle(dto);
+
+      expect(result).toBeDefined();
+      expect(result.battleId).toMatch(/^battle-\d+$/);
+      expect(result.roomId).toBe('room-123');
+      expect(result.status).toBe('running');
+      expect(result.config.duration).toBe(600);
+      expect(result.users).toHaveLength(2);
+      expect(result.startedAt).toBeInstanceOf(Date);
+    });
+
+    it('올바른 초기 상태로 사용자를 생성해야 한다', async () => {
+      const dto: CreateBattleDTO = {
+        roomId: 'room-123',
+        users: ['user-1'],
+        config: {
+          duration: 300,
+        },
+      };
+
+      const result = await service.createBattle(dto);
+
+      const user = result.users[0];
+      expect(user.userId).toBe('user-1');
+      expect(user.battleId).toBe(result.battleId);
+      expect(user.code).toBe('');
+      expect(user.language).toBe(BATTLE_CONFIG.DEFAULT_LANGUAGE);
+      expect(user.progress.passedCount).toBe(0);
+      expect(user.progress.totalCount).toBe(0);
+      expect(user.isConnected).toBe(true);
+      expect(user.isFinished).toBe(false);
+    });
+
+    it('duration이 제공되지 않으면 기본값을 사용해야 한다', async () => {
+      const dto: CreateBattleDTO = {
+        roomId: 'room-123',
+        users: ['user-1'],
+        config: {},
+      };
+
+      const result = await service.createBattle(dto);
+
+      expect(result.config.duration).toBe(BATTLE_CONFIG.DURATION);
+    });
+
+    it('배틀을 Redis에 저장해야 한다', async () => {
+      const dto: CreateBattleDTO = {
+        roomId: 'room-123',
+        users: ['user-1'],
+        config: {
+          duration: 300,
+        },
+      };
+
+      const result = await service.createBattle(dto);
+
+      expect(mockRedisService.createBattle).toHaveBeenCalledTimes(1);
+      expect(mockRedisService.createBattle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battleId: result.battleId,
+          roomId: 'room-123',
+          status: 'running',
+        })
+      );
+    });
+
+    it('여러 사용자를 처리해야 한다', async () => {
+      const dto: CreateBattleDTO = {
+        roomId: 'room-123',
+        users: ['user-1', 'user-2', 'user-3'],
+        config: {
+          duration: 300,
+        },
+      };
+
+      const result = await service.createBattle(dto);
+
+      expect(result.users).toHaveLength(3);
+      expect(result.users[0].userId).toBe('user-1');
+      expect(result.users[1].userId).toBe('user-2');
+      expect(result.users[2].userId).toBe('user-3');
+
+      result.users.forEach((user) => {
+        expect(user.battleId).toBe(result.battleId);
+      });
+    });
+  });
+});

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from "@nestjs/common";
+import { Battle, BattleUser, CreateBattleDTO } from '../../../../packages/types/battle';
+import { BATTLE_CONFIG } from '../../../../packages/constants/battle';
+import { RedisService } from './../redis/redis.service';
+
+@Injectable()
+export class BattleService {
+    constructor(
+        private readonly redisService: RedisService
+    ) { }
+
+    async createBattle(dto: CreateBattleDTO): Promise<Battle> {
+        // TODO: 배틀 ID 생성 로직 추가
+        const battleId = `battle-${Date.now()}`;
+
+        const users: BattleUser[] = dto.users.map(userId => ({
+            userId,
+            battleId,
+            code: '',
+            language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
+            progress: {
+                passedCount: 0,
+                totalCount: 0,
+            },
+            isConnected: true,
+            isFinished: false,
+        }));
+
+
+        const battle: Battle = {
+            battleId,
+            roomId: dto.roomId,
+            status: 'running',
+            config: {
+                duration: dto.config.duration || BATTLE_CONFIG.DURATION,
+            },
+            startedAt: new Date(),
+            users,
+        }
+
+        await this.redisService.createBattle(battle);
+
+        return battle;
+    }
+}

--- a/apps/api/src/redis/redis-key.constant.ts
+++ b/apps/api/src/redis/redis-key.constant.ts
@@ -1,0 +1,10 @@
+export class RedisKeys {
+  // Battle 관련
+  static battle(battleId: string): string {
+    return `battle:${battleId}`;
+  }
+
+  static battleByRoom(roomId: string): string {
+    return `battle:room:${roomId}`;
+  }
+}

--- a/apps/api/src/redis/redis.module.ts
+++ b/apps/api/src/redis/redis.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
+import { RedisService } from './redis.service';
 
 export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
 
@@ -27,7 +28,8 @@ export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
       },
       inject: [ConfigService],
     },
+    RedisService,
   ],
-  exports: [REDIS_CLIENT],
+  exports: [REDIS_CLIENT, RedisService],
 })
 export class RedisModule {}

--- a/apps/api/src/redis/redis.service.spec.ts
+++ b/apps/api/src/redis/redis.service.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RedisService } from './redis.service';
+import { REDIS_CLIENT } from './redis.module';
+import { Battle } from '../../../../packages/types/battle';
+
+describe('RedisService', () => {
+  let service: RedisService;
+  let mockRedis: any;
+
+  beforeEach(async () => {
+    mockRedis = {
+      set: jest.fn().mockResolvedValue('OK'),
+      get: jest.fn(),
+      del: jest.fn().mockResolvedValue(1),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RedisService,
+        {
+          provide: REDIS_CLIENT,
+          useValue: mockRedis,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RedisService>(RedisService);
+  });
+
+  it('정의되어야 한다', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createBattle', () => {
+    it('올바른 키로 배틀을 Redis에 저장해야 한다', async () => {
+      const battle: Battle = {
+        battleId: 'battle-123',
+        roomId: 'room-456',
+        status: 'running',
+        config: {
+          duration: 300,
+        },
+        startedAt: new Date('2025-01-01'),
+        users: [
+          {
+            userId: 'user-1',
+            battleId: 'battle-123',
+            code: '',
+            language: 'javascript',
+            progress: {
+              passedCount: 0,
+              totalCount: 0,
+            },
+            isConnected: true,
+            isFinished: false,
+          },
+        ],
+      };
+
+      await service.createBattle(battle);
+
+      expect(mockRedis.set).toHaveBeenCalledTimes(2);
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'battle:battle-123',
+        JSON.stringify(battle)
+      );
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'battle:room:room-456',
+        'battle-123'
+      );
+    });
+
+    it('Redis 실패 시 에러를 던져야 한다', async () => {
+      mockRedis.set.mockRejectedValueOnce(new Error('Redis error'));
+
+      const battle: Battle = {
+        battleId: 'battle-123',
+        roomId: 'room-456',
+        status: 'running',
+        config: { duration: 300 },
+        startedAt: new Date(),
+        users: [],
+      };
+
+      await expect(service.createBattle(battle)).rejects.toThrow('Redis error');
+    });
+  });
+
+  describe('getBattle', () => {
+    it('Redis에서 배틀을 조회해야 한다', async () => {
+      const battle: Battle = {
+        battleId: 'battle-123',
+        roomId: 'room-456',
+        status: 'running',
+        config: { duration: 300 },
+        startedAt: new Date('2025-01-01'),
+        users: [],
+      };
+
+      mockRedis.get.mockResolvedValueOnce(JSON.stringify(battle));
+
+      const result = await service.getBattle('battle-123');
+
+      expect(mockRedis.get).toHaveBeenCalledWith('battle:battle-123');
+      expect(result).toEqual({
+        ...battle,
+        startedAt: battle.startedAt.toISOString(),
+      });
+    });
+
+    it('배틀이 존재하지 않으면 null을 반환해야 한다', async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+
+      const result = await service.getBattle('non-existent-battle');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/redis/redis.service.ts
+++ b/apps/api/src/redis/redis.service.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import { REDIS_CLIENT } from './redis.module';
+import { Battle } from '../../../../packages/types/battle';
+import { RedisKeys } from './redis-key.constant';
+
+@Injectable()
+export class RedisService {
+  constructor(
+    @Inject(REDIS_CLIENT)
+    private readonly redis: Redis,
+  ) { }
+
+  async createBattle(battle: Battle): Promise<void> {
+    try {
+      const key = RedisKeys.battle(battle.battleId);
+      await this.redis.set(key, JSON.stringify(battle));
+
+      // roomId로 battleId 매핑 저장
+      const roomKey = RedisKeys.battleByRoom(battle.roomId);
+      await this.redis.set(roomKey, battle.battleId);
+
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async getBattle(battleId: string): Promise<Battle | null> {
+    const key = RedisKeys.battle(battleId);
+    const data = await this.redis.get(key);
+
+    if (!data) {
+      return null;
+    }
+
+    return JSON.parse(data) as Battle;
+  }
+}

--- a/packages/constants/battle.ts
+++ b/packages/constants/battle.ts
@@ -1,0 +1,29 @@
+export const BATTLE_CONFIG = {
+    DURATION: 30 * 60, // 기본 배틀 시간: 30분 (초 단위)
+    DEFAULT_LANGUAGE: 'javascript',
+} as const;
+
+export const BATTLE_EVENTS = {
+    // 배틀 생성 및 시작
+    BATTLE_CREATED: 'battle-created',
+    BATTLE_STARTED: 'battle-started',
+    BATTLE_ENDED: 'battle-ended',
+
+    // 코드 변경
+    CODE_CHANGE: 'code-change',
+    CODE_UPDATED: 'code-updated',
+
+    // 유저 상태 변경
+    USER_CONNECTED: 'user-connected',
+    USER_DISCONNECTED: 'user-disconnected',
+    USER_FINISHED: 'user-finished',
+
+    // 진행 상황 업데이트
+    PROGRESS_UPDATE: 'progress-update',
+    
+    // 유저 진행률
+    USER_TEST_RESULT: 'user-test-result',
+
+    // 배틀 상태 업데이트
+    BATTLE_STATUS_UPDATE: 'battle-status-update',
+} as const;

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -1,0 +1,35 @@
+export type BattleStatus = 'running' | 'completed';
+
+export type BattleResult = 'win' | 'lose' | 'draw';
+
+export interface Battle {
+    battleId: string;
+    roomId: string;
+    status: BattleStatus;
+
+    config: {
+        duration: number;
+    }
+    startedAt?: Date;
+    endedAt?: Date;
+
+    users: BattleUser[];
+}
+
+export interface BattleUser {
+    userId: string;
+    code: string;
+    language: string;
+
+    progress: {
+        passedCount: number;
+        totalCount: number;
+    };
+
+    isConnected: boolean;
+    isFinished: boolean;
+    finishedAt?: Date;
+    disconnectedAt?: Date;
+
+    result?: BattleResult;
+}

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -18,6 +18,7 @@ export interface Battle {
 
 export interface BattleUser {
     userId: string;
+    battleId: string;
     code: string;
     language: string;
 
@@ -32,4 +33,24 @@ export interface BattleUser {
     disconnectedAt?: Date;
 
     result?: BattleResult;
+}
+
+export interface CreateBattleDTO {
+    roomId: string;
+    config: {
+        duration: number;
+    }
+    users: string[];
+}
+
+export interface UpdateBattleUserDTO {
+    userId: string;
+    battleId: string;
+    code?: string;
+
+    progress: {
+        passedCount: number;
+        totalCount: number;
+    };
+    isFinished?: boolean;
 }


### PR DESCRIPTION
## 🔍 PR 요약

배틀과 관련된 서비스 로직을 구현했습니다.

## 🧾 관련 이슈

- Close #30 

## 🛠️ 주요 변경 사항

- apps/api/src/battle/battle.service.ts
- apps/api/src/redis/redis-key.constant.ts
- apps/api/src/redis/redis.module.ts
- apps/api/src/redis/redis.service.ts

- apps/api/src/battle/battle.service.spec.ts
- apps/api/src/redis/redis.service.spec.ts

배틀 생성 서비스 로직 구현
Redis 에 배틀 데이터 저장
생성 로직 관련 테스트 코드 작성

## 📸 스크린샷 (선택)
- 테스트 코드 커버리지
<img width="606" height="322" alt="image" src="https://github.com/user-attachments/assets/68d57776-7338-4356-9a3f-4e843a008c27" />


## 🧠 의도 및 배경

- 코드 변경과 관련된 로직을 구현하기 위해서는 배틀 생성과 관련된 로직이 필요하다고 생각했습니다.

## 💬 리뷰 요구사항(선택)

- 먼저 PR을 올리게 되면 제 코드가 기준이 될 수도 있다고 생각이 들어서 조심스럽습니다.