### PR TITLE
[FEAT] Room - Battle 자동 연결 (MVP) (#41)

### DIFF
--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -78,6 +78,23 @@ export class BattleService {
     return battle;
   }
 
+  // 배틀 나가기
+  async leaveBattle(roomId: string, userId: string): Promise<Battle | null> {
+    const battleId = await this.battleRedisService.getBattleIdByRoomId(roomId);
+    if (!battleId) return null;
+
+    const battle = await this.battleRedisService.getBattle(battleId);
+    if (!battle) return null;
+
+    // MVP 단계에서는 배틀 퇴장시 배틀 참가자에서 제외
+    // TODO: 참가자 다시 입장시 복구 로직 추가 (disconnectedAt 등 활용)
+    battle.users = battle.users.filter((u) => u.userId !== userId);
+
+    await this.battleRedisService.updateBattle(battle);
+
+    return battle;
+  }
+
   async getBattle(battleId: string): Promise<Battle | null> {
     // TODO: 권한 체크 추가 (사용자가 해당 배틀에 접근 가능한지 또는 비밀번호 존재 등)
     return this.battleRedisService.getBattle(battleId);

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
+import { BattleService } from '@/battle/battle.service';
+
 import {
   SOCKET_ERROR,
   SOCKET_EVENT,
@@ -20,7 +22,10 @@ import { RoomService } from './room.service';
 export class RoomGateway implements OnModuleInit {
   @WebSocketServer() server: Server;
 
-  constructor(private readonly roomService: RoomService) {}
+  constructor(
+    private readonly roomService: RoomService,
+    private readonly battleService: BattleService,
+  ) {}
 
   async onModuleInit() {
     await this.roomService.createRoom('1');
@@ -86,6 +91,13 @@ export class RoomGateway implements OnModuleInit {
     await this.roomService.saveRoom(room);
 
     await client.join(roomId);
+
+    // 방 입장 시 배틀 입장
+
+    // 참가자일 경우 배틀에도 참가
+    if (requestedRole === 'player') {
+      await this.battleService.joinBattle(roomId, newUser);
+    }
 
     client.emit(SOCKET_EVENT.ROOM_STATE_SYNC, {
       roomId: room.roomId,

--- a/apps/api/src/room/room.module.ts
+++ b/apps/api/src/room/room.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { BattleModule } from '@/battle/battle.module';
+
 import { RoomGateway } from './room.gateway';
 import { RoomService } from './room.service';
 
 @Module({
+  imports: [BattleModule],
   providers: [RoomService, RoomGateway],
 })
 export class RoomModule {}

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -1,19 +1,34 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { BATTLE_CONFIG } from '@packages/constants/battle';
 import Redis from 'ioredis';
 
 import { ROOM_CONFIG } from '../../../../packages/constants/socket-event';
 import { Room } from '../../../../packages/types/room';
+import { BattleService } from '../battle/battle.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { RedisKeys } from '../redis/redis-key.constant';
 
 @Injectable()
 export class RoomService {
-  constructor(@Inject(REDIS_CLIENT) private readonly redis: Redis) {}
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+    private readonly BattleService: BattleService,
+  ) {}
 
   async createRoom(roomId: string): Promise<Room> {
     const room = this.createDefaultRoom(roomId);
     const key = RedisKeys.room(room.roomId);
     await this.redis.set(key, JSON.stringify(room));
+
+    // 룸 생성 후 배틀 생성
+    await this.BattleService.createBattle({
+      roomId: room.roomId,
+      config: {
+        duration: BATTLE_CONFIG.DURATION,
+      },
+      users: [],
+    });
+
     return room;
   }
 


### PR DESCRIPTION
## 🔍 PR 요약

Room 로직과 Battle 로직 결합

## 🧾 관련 이슈

- close #41 
- close #20 

## 🛠️ 주요 변경 사항

- apps/api/src/battle/battle.service.ts : 배틀 입장과 배틀 나가는 로직 추가
  - `joinBattle` : 배틀 입장 (배틀 입장 시 모두 참가자로 간주)
  - `leaveBattle` : 배틀 나가기 (MVP 단계라서 참가자 재접속 불가)
- apps/api/src/room/room.gateway.ts : 방 입장 시 배틀 자동 입장
  - 참가자일 경우 배틀 자동 입장 로직  추가
  - BattleService 의존성 주입
- apps/api/src/room/room.module.ts : `BattleModule` import
- apps/api/src/room/room.service.ts : 방 생성 시 배틀 자동 생성 (MVP)
  - createBattle 호출
  - BattleService 의존성 주입


## 🧠 의도 및 배경

- MVP 단계에서 방 생성시 자동으로 배틀 입장

## 💬 리뷰 요구사항(선택)

