### PR TITLE
[FEAT] 디자인 시스템 구축 및 메인 페이지 적용 (#50)

### DIFF
--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme') as Theme | null;
+    if (savedTheme) {
+      return savedTheme;
+    }
+
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return { theme, toggleTheme };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -31,7 +31,33 @@
   --color-neutral-muted: #6b7280;
   --color-neutral-soft: #f3f4f6;
 
-  --font-sans: 'Inter', 'Pretendard Variable', system-ui, -apple-system, sans-serif;
+  /* Typography System */
+  --font-sans: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+  --font-mono: 'Fira Code', 'D2Coding', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1rem; /* 12px / 16px */
+  
+  --text-sm: 0.875rem;
+  --text-sm--line-height: 1.25rem; /* 14px / 20px */
+  
+  --text-base: 1rem;
+  --text-base--line-height: 1.5rem; /* 16px / 24px */
+  
+  --text-lg: 1.125rem;
+  --text-lg--line-height: 1.75rem; /* 18px / 28px */
+  
+  --text-xl: 1.25rem;
+  --text-xl--line-height: 1.75rem; /* 20px / 28px */
+  
+  --text-2xl: 1.5rem;
+  --text-2xl--line-height: 2rem; /* 24px / 32px */
+  
+  --text-3xl: 1.875rem;
+  --text-3xl--line-height: 2.25rem; /* 30px / 36px */
+  
+  --text-4xl: 2.25rem;
+  --text-4xl--line-height: 2.5rem; /* 36px / 40px */
 }
 
 :root {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -60,6 +60,9 @@
   --color-ink: var(--black);
   --color-border-soft: var(--base-muted);
 
+  /* --- Radius --- */
+  --radius-24: 1.5rem; /* 24px */
+
   /* Typography System */
   --font-sans: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
   --font-mono: 'Fira Code', 'D2Coding', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,69 +1,93 @@
 @import 'tailwindcss';
 
 @theme {
-  --color-brand: #5631e7;
-  --color-surface: #f9fbfc; /* 메인페이지 배경 */
-  --color-ink: #0f172a;
-  --color-title: #2c2c2c;
-  --color-white: #ffffff;
+  /* --- Primitives (Blue Scale) --- */
+  --color-blue-01: #F1F7FB;
+  --color-blue-02: #E2E8F0;
+  --color-blue-03: #B8C2D3;
+  --color-blue-04: #555775;
+  --color-blue-05: #3D4759;
+  --color-blue-06: #161A32;
+  --color-blue-07: #0F172A;
+
+  --color-white: #FFFFFF;
   --color-black: #000000;
-  --color-border-soft: #0000001a; /* black/10 */
-  --color-overlay: #0000004d; /* black/30 */
 
-  /* CTA / gradients */
-  --color-cta-main-start: #6129d4;
-  --color-cta-main-end: #2d55ff;
-  --color-cta-modal-start: #5230e0;
-  --color-cta-modal-end: #2b5ee8;
+  /* --- Semantic Tokens (Themed) --- */
+  --color-base-primary: var(--base-primary);
+  --color-base-secondary: var(--base-secondary);
+  --color-base-tertiary: var(--base-tertiary);
+  --color-base-muted: var(--base-muted);
+  --color-base-faint: var(--base-faint);
 
-  /* 입장 모달 팔레트 */
-  --color-modal-border: #2f9dea;
-  --color-modal-accent-start: #5d39e4;
-  --color-modal-accent-end: #2d7bff;
-  --color-participant-gradient-start: #e9e4ff;
-  --color-participant-gradient-end: #d8e3ff;
-  --color-participant-icon: #5936e7;
-  --color-participant-check: #4a28c0;
-  --color-participant-badge: #26a65b;
-  --color-spectator-icon: #01a7c2;
-  --color-spectator-badge: #00b0b9;
-  --color-neutral-card-border: #e5e7eb;
-  --color-neutral-muted: #6b7280;
-  --color-neutral-soft: #f3f4f6;
+  --color-bg-layer-1: var(--bg-layer-1);
+  --color-bg-layer-2: var(--bg-layer-2);
+
+  /* --- App Specific Colors (Restored) --- */
+  --color-brand: #00E074;
+  
+  /* 전체 배경, 글씨, 테두리 색상 */
+  --color-surface: var(--bg-layer-1);
+  --color-ink: var(--black);
+  --color-border-soft: var(--base-muted);
 
   /* Typography System */
   --font-sans: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
   --font-mono: 'Fira Code', 'D2Coding', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   --text-xs: 0.75rem;
-  --text-xs--line-height: 1rem; /* 12px / 16px */
-  
+  --text-xs--line-height: 1rem;
   --text-sm: 0.875rem;
-  --text-sm--line-height: 1.25rem; /* 14px / 20px */
-  
+  --text-sm--line-height: 1.25rem;
   --text-base: 1rem;
-  --text-base--line-height: 1.5rem; /* 16px / 24px */
-  
+  --text-base--line-height: 1.5rem;
   --text-lg: 1.125rem;
-  --text-lg--line-height: 1.75rem; /* 18px / 28px */
-  
+  --text-lg--line-height: 1.75rem;
   --text-xl: 1.25rem;
-  --text-xl--line-height: 1.75rem; /* 20px / 28px */
-  
+  --text-xl--line-height: 1.75rem;
   --text-2xl: 1.5rem;
-  --text-2xl--line-height: 2rem; /* 24px / 32px */
-  
+  --text-2xl--line-height: 2rem;
   --text-3xl: 1.875rem;
-  --text-3xl--line-height: 2.25rem; /* 30px / 36px */
-  
+  --text-3xl--line-height: 2.25rem;
   --text-4xl: 2.25rem;
-  --text-4xl--line-height: 2.5rem; /* 36px / 40px */
+  --text-4xl--line-height: 2.5rem;
 }
 
+/* --- Theme Variables --- */
+/* Light Mode (Default) */
 :root {
+  --base-primary: var(--color-blue-06);
+  --base-secondary: var(--color-blue-04);
+  --base-tertiary: var(--color-blue-03);
+  --base-muted: var(--color-blue-02);
+  --base-faint: var(--color-white);
+  
+  --bg-layer-1: var(--color-blue-02);
+  --bg-layer-2: var(--color-white);
+  
+  --white: var(--color-white);
+  --black: var(--color-black);
+
+  /* Global Defaults */
   font-family: var(--font-sans);
-  background-color: var(--color-surface);
+  background-color: var(--bg-layer-1);
   color: var(--color-ink);
+  border-color: var(--color-border-soft);
+}
+
+/* Dark Mode */
+.dark {
+  --base-primary: var(--color-white);
+  --base-secondary: var(--color-blue-02);
+  --base-tertiary: var(--color-blue-03);
+  --base-muted: var(--color-blue-04);
+  --base-faint: var(--color-blue-05);
+
+  --bg-layer-1: var(--color-blue-07);
+  --bg-layer-2: var(--color-blue-06);
+
+  --black: var(--color-white);
+  --white: var(--color-black);
 }
 
 * {
@@ -72,67 +96,4 @@
 
 body {
   margin: 0;
-}
-
-.logo-gradient {
-  background: linear-gradient(90deg, #4b2cd3 0%, #008bcc 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-/* Custom utility classes for design palette */
-.bg-participant-card {
-  background: linear-gradient(
-    180deg,
-    var(--color-participant-gradient-start) 0%,
-    var(--color-participant-gradient-end) 100%
-  );
-}
-
-.bg-cta-main {
-  background: linear-gradient(135deg, var(--color-cta-main-start), var(--color-cta-main-end));
-}
-
-.bg-cta-modal {
-  background: linear-gradient(90deg, var(--color-cta-modal-start), var(--color-cta-modal-end));
-}
-
-.bg-modal-accent {
-  background: linear-gradient(
-    135deg,
-    var(--color-modal-accent-start),
-    var(--color-modal-accent-end)
-  );
-}
-
-.bg-participant-icon {
-  background-color: var(--color-participant-icon);
-}
-
-.text-spectator-icon {
-  color: var(--color-spectator-icon);
-}
-
-.bg-participant-check {
-  background-color: var(--color-participant-check);
-}
-
-.bg-participant-badge {
-  background-color: var(--color-participant-badge);
-}
-
-.bg-spectator-badge {
-  background-color: var(--color-spectator-badge);
-}
-
-.border-soft {
-  border-color: var(--color-border-soft);
-}
-
-.border-neutral-card {
-  border-color: var(--color-neutral-card-border);
-}
-
-.bg-overlay {
-  background-color: var(--color-overlay);
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10,6 +10,35 @@
   --color-blue-06: #161A32;
   --color-blue-07: #0F172A;
 
+  /* --- Primitives (Green Scale - Main) --- */
+  --color-green-01: #99F3C7;
+  --color-green-02: #99F3C7;
+  --color-green-03: #66ECAC;
+  --color-green-04: #33E690;
+  --color-green-05: #00E074;
+  --color-green-06: #16A34A;
+
+  /* --- Primitives (Pink Scale - Main) --- */
+  --color-pink-01: #FFD1D9;
+  --color-pink-02: #FFD1D9;
+  --color-pink-03: #FFA3B2;
+  --color-pink-04: #FF748C;
+  --color-pink-05: #FF3B5C;
+
+  /* --- Primitives (Tier) --- */
+  --color-tier-bronze: #A16207;
+  --color-tier-silver: #6B7280;
+  --color-tier-gold: #EAB308;
+  --color-tier-platinum: #06B6D4;
+  --color-tier-diamond: #60A5FA;
+  --color-tier-ruby: #F43F5E;
+  --color-tier-master: #A855F7;
+
+  /* --- Primitives (Etc) --- */
+  --color-red-01: #FF3B5C;
+  --color-error-01: #F74F3B;
+  --color-neon-01: #00FFCC;
+
   --color-white: #FFFFFF;
   --color-black: #000000;
 
@@ -24,7 +53,7 @@
   --color-bg-layer-2: var(--bg-layer-2);
 
   /* --- App Specific Colors (Restored) --- */
-  --color-brand: #00E074;
+  --color-brand: var(--color-green-05);
   
   /* 전체 배경, 글씨, 테두리 색상 */
   --color-surface: var(--bg-layer-1);

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,7 +1,10 @@
 import { ROOM_CONFIG } from '@shared/constants/socket-event';
 import type { UserRole } from '@shared/types/user';
+import { Moon, Sun } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { useTheme } from '@/hooks/useTheme';
 
 import { JoinModal } from '../components/JoinModal';
 import { useBattleSocketStore } from '../stores/battleSocketStore';
@@ -10,6 +13,7 @@ const DEFAULT_ROOM_ID = '1';
 
 function MainPage() {
   const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
   const [isModalOpen, setModalOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState<UserRole>('player');
   const [joinError, setJoinError] = useState('');
@@ -77,32 +81,46 @@ function MainPage() {
 
   return (
     <div className="min-h-screen">
-      <header className="mb-2 flex items-center gap-3 border-b border-soft bg-white px-10 py-6 shadow-sm">
-        <div className="grid h-12 w-12 rounded-2xl bg-brand shadow-lg"></div>
-        <div className="flex flex-col">
-          <span className="text-lg font-extrabold tracking-tight logo-gradient">CODE RENA</span>
+      <header className="border-b border-border-soft bg-bg-layer-2 shadow-sm">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-10 py-2">
+          <div className="flex items-center gap-3">
+            <div className="grid h-12 w-12 rounded-2xl bg-brand shadow-lg"></div>
+            <div className="flex flex-col">
+              <span className="text-lg font-extrabold tracking-tight logo-gradient">CODE RENA</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <button className="rounded-24 bg-base-muted px-4 py-2 text-base font-medium text-ink shadow-sm transition hover:scale-105 active:scale-95">
+              로그인
+            </button>
+            <button
+              onClick={toggleTheme}
+              className="rounded-full bg-base-muted p-2 text-ink shadow-sm transition hover:scale-110 active:scale-95"
+              aria-label="Toggle theme"
+            >
+              {theme === 'dark' ? <Sun size={24} /> : <Moon size={24} />}
+            </button>
+          </div>
         </div>
       </header>
 
-      <main className="mx-auto flex max-w-5xl flex-col gap-10 pt-10 px-10 pb-16 bg-surface">
-        <div className="flex items-start gap-3">
-          <div className="h-10 w-1 rounded-full bg-brand" />
-          <div className="space-y-1">
-            <h1 className="text-3xl font-bold">대결 로비</h1>
-            <p className="text-sm text-slate-600">실시간 코딩 대결에 참여하세요</p>
-          </div>
-        </div>
-
-        <div className="relative flex-1">
-          <div className="rounded-2xl border border-soft bg-white px-12 py-16 text-center shadow-sm">
+      <main className="mx-auto flex max-w-5xl flex-col gap-10 pt-10 px-10 pb-16">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-red-01" />
+            <h1 className="text-3xl font-bold">LIVE</h1>
+            <h1 className="text-3xl font-bold text-brand">BATTLE</h1>
             <button
               type="button"
               onClick={handleStartBattle}
-              className="rounded-2xl bg-cta-main px-8 py-4 text-lg font-semibold text-white shadow-md transition hover:scale-[1.02]"
+              className="ml-auto rounded-24 bg-brand px-8 py-4 text-lg font-semibold shadow-md transition hover:scale-[1.02]"
             >
-              배틀 시작하기
+              자동 매칭
             </button>
           </div>
+          <p className="text-sm text-base-primary">
+            현재 진행 중인 배틀을 관전하고 고수들의 코딩을 배워보세요
+          </p>
         </div>
       </main>
 


### PR DESCRIPTION
## 🔍 PR 요약

피그마에 정의된 시멘틱 태그 등을 TailwindCSS 디자인 토큰 코드로 정의

## 🧾 관련 이슈

- close #50 

## 🛠️ 주요 변경 사항
apps/web/src/index.css
- **Color**
  - Blue Scale Primitives: blue-01 ~ blue-07 컬러 팔레트 정의
  - 메인 컬러: Green Scale, Pink Scale 팔레트 정의
  - 티어 컬러: Bronze ~ Master 팔레트 정의
  - 이외 컬러: Etc 팔레트 정의
- **Light/Dark Color** 
  - Semantic Tokens (Themed) 정의: `base-primary`, `bg-layer-1` 등의 의미론적 변수를 사용하여 Light/Dark 모드 전환 시 자동으로 색상이 변경되도록 설정
  - 예: `bg-layer-1`은 라이트 모드에서 blue-02(#E2E8F0), 다크 모드에서 blue-07(#0F172A)가 된다.
- **Text**
  - 글씨체: 기본 Pretendard로 설정
  - 글씨 크기: text-xs ~ text-4xl
  - 글씨 간격: 이에 맞춘 line-height
- **Radius**
  - 테두리 각도: 1.5rem; /* 24px */ 으로 설정

apps/web/src/hooks/useTheme.ts 추가
- Light/Dark 상태를 localStorage에 저장하여 유지하는 로직을 훅으로 분리

apps/web/src/pages/MainPage.tsx
- 메인페이지에 디자인 시스템 적용한 코드로 변경

## 📸 스크린샷 (선택)
```
  /* Global Defaults */
  font-family: var(--font-sans);
  background-color: var(--bg-layer-1);
  color: var(--color-ink);
  border-color: var(--color-border-soft);
```

- 라이트 모드
<img width="1500" height="751" alt="image" src="https://github.com/user-attachments/assets/79f72ea1-5def-4a44-bb3f-c002cf201d09" />

- 다크모드
<img width="1496" height="661" alt="image" src="https://github.com/user-attachments/assets/9ada0f24-570a-4fa7-a8c0-aad5d61e8148" />

## 🧠 의도 및 배경

- 초기 디자인 시스템을 정의하여 향후 프론트엔드 개발 시 공통된 시스템을 적용하여 UI 일관성 및 코드 통일성을 높이기 위함

## 💬 리뷰 요구사항(선택)
추가적으로 디자인 시스템 구축할만한 것이 있다면 말씀해주세요!
