### PR TITLE
[FEAT] Room 생성 로직 수정 (#66)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -66,7 +66,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -75,6 +75,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@packages/(.*)$": "<rootDir>/../../packages/$1"
+    }
   }
 }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -1,4 +1,3 @@
-import { OnModuleInit } from '@nestjs/common';
 import {
   ConnectedSocket,
   MessageBody,
@@ -19,17 +18,13 @@ import { RoomUser, UserRole } from '../../../../packages/types/user';
 import { RoomService } from './room.service';
 
 @WebSocketGateway({ namespace: SOCKET_NAMESPACE.GAME })
-export class RoomGateway implements OnModuleInit {
+export class RoomGateway {
   @WebSocketServer() server: Server;
 
   constructor(
     private readonly roomService: RoomService,
     private readonly battleService: BattleService,
   ) {}
-
-  async onModuleInit() {
-    await this.roomService.createRoom('1');
-  }
 
   @SubscribeMessage(SOCKET_EVENT.CHECK_ROOM_AVAILABILITY)
   async handleCheckRoomAvailability(

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -1,50 +1,101 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { BATTLE_CONFIG } from '@packages/constants/battle';
+import { MatchingUser } from '@packages/types/matching';
+import { RoomUser } from '@packages/types/user';
 import Redis from 'ioredis';
 
 import { ROOM_CONFIG } from '../../../../packages/constants/socket-event';
-import { Room, RoomAvailabilityResponseDTO } from '../../../../packages/types/room';
+import { Room, RoomAvailabilityResponseDTO, RoomSettings } from '../../../../packages/types/room';
 import { BattleService } from '../battle/battle.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { RedisKeys } from '../redis/redis-key.constant';
 
 @Injectable()
 export class RoomService {
+  private readonly logger = new Logger(RoomService.name);
+
   constructor(
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly BattleService: BattleService,
   ) {}
 
-  async createRoom(roomId: string): Promise<Room> {
-    const room = this.createDefaultRoom(roomId);
-    const key = RedisKeys.room(room.roomId);
-    await this.redis.set(key, JSON.stringify(room));
+  // 기본 방 생성
+  async createRoom(params: Partial<Room> = {}): Promise<Room> {
+    const roomId = params.roomId || `room-${Date.now()}-${Math.random().toString(36)}`;
 
-    // 룸 생성 후 배틀 생성
-    await this.BattleService.createBattle({
-      roomId: room.roomId,
-      config: {
-        duration: BATTLE_CONFIG.DURATION,
-      },
-      users: [],
-    });
+    const defaultSettings: RoomSettings = {
+      maxPlayers: ROOM_CONFIG.MAX_PLAYERS,
+    };
 
-    return room;
-  }
-
-  private createDefaultRoom(roomId: string): Room {
-    return {
+    const newRoom: Room = {
       roomId,
-      title: `배틀룸 ${roomId}`,
-      hostId: 'system',
-      status: 'waiting',
+      title: params.title || `배틀룸 ${roomId.substring(8)}`,
+      hostId: params.hostId || 'system',
+      status: params.status || 'waiting',
       createdAt: new Date(),
-      currentPlayers: [],
+      currentPlayers: params.currentPlayers || [],
       currentSpectators: [],
       settings: {
-        maxPlayers: ROOM_CONFIG.MAX_PLAYERS,
+        ...defaultSettings,
+        ...params.settings,
       },
     };
+
+    const key = RedisKeys.room(newRoom.roomId);
+    await this.redis.set(key, JSON.stringify(newRoom));
+
+    return newRoom;
+  }
+
+  // 매칭된 유저들로 방 생성 및 배틀 시작
+  async createMatchedRoom(user1: MatchingUser, user2: MatchingUser): Promise<Room> {
+    try {
+      // 방 생성: 유저 정보와 즉시 시작 상태 주입
+      const now = new Date();
+      const roomId = `room-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
+      const player1: RoomUser = {
+        userId: user1.userId,
+        username: user1.username,
+        socketId: user1.socketId, // MatchingUser에 보관된 socketId 활용
+        roomId: roomId,
+        role: 'player',
+        joinedAt: now,
+      };
+
+      const player2: RoomUser = {
+        userId: user2.userId,
+        username: user2.username,
+        socketId: user2.socketId,
+        roomId: roomId,
+        role: 'player',
+        joinedAt: now,
+      };
+
+      const room = await this.createRoom({
+        roomId,
+        title: `${user1.username} vs ${user2.username}`,
+        status: 'in-battle',
+        currentPlayers: [player1, player2],
+      });
+
+      // 배틀 생성
+      await this.BattleService.createBattle({
+        roomId: room.roomId,
+        config: {
+          duration: BATTLE_CONFIG.DURATION,
+        },
+        users: room.currentPlayers.map((player) => player.userId),
+      });
+
+      this.logger.log(
+        `Created matched room ${room.roomId} for users ${user1.userId} and ${user2.userId}`,
+      );
+      return room;
+    } catch (error: unknown) {
+      if (error instanceof Error)
+        this.logger.error(`Failed to create matched room: ${error.message}`);
+      throw error;
+    }
   }
 
   async getRoom(roomId: string): Promise<Room | null> {

--- a/apps/api/test/room.gateway.spec.ts
+++ b/apps/api/test/room.gateway.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { BattleService } from '@/battle/battle.service';
+
 import { RoomGateway } from '../src/room/room.gateway';
 import { RoomService } from '../src/room/room.service';
 
 describe('RoomGateway', () => {
-  let _gateway: RoomGateway;
+  let gateway: RoomGateway;
   let _roomService: RoomService;
 
   beforeEach(async () => {
@@ -19,10 +21,20 @@ describe('RoomGateway', () => {
           provide: RoomService,
           useValue: mockRoomService,
         },
+        {
+          provide: BattleService,
+          useValue: { createBattle: jest.fn() },
+        },
       ],
     }).compile();
 
-    _gateway = module.get<RoomGateway>(RoomGateway);
+    gateway = module.get<RoomGateway>(RoomGateway);
     _roomService = module.get<RoomService>(RoomService);
+  });
+
+  describe('RoomGateway', () => {
+    it('should be defined', () => {
+      expect(gateway).toBeDefined();
+    });
   });
 });

--- a/apps/api/test/room.gateway.spec.ts
+++ b/apps/api/test/room.gateway.spec.ts
@@ -4,8 +4,8 @@ import { RoomGateway } from '../src/room/room.gateway';
 import { RoomService } from '../src/room/room.service';
 
 describe('RoomGateway', () => {
-  let gateway: RoomGateway;
-  let roomService: RoomService;
+  let _gateway: RoomGateway;
+  let _roomService: RoomService;
 
   beforeEach(async () => {
     const mockRoomService = {
@@ -22,18 +22,7 @@ describe('RoomGateway', () => {
       ],
     }).compile();
 
-    gateway = module.get<RoomGateway>(RoomGateway);
-    roomService = module.get<RoomService>(RoomService);
-  });
-
-  describe('onModuleInit', () => {
-    it('모듈 초기화 시 roomId 1번 방을 생성해야 한다', async () => {
-      const createRoomSpy = jest.spyOn(roomService, 'createRoom');
-
-      await gateway.onModuleInit();
-
-      expect(createRoomSpy).toHaveBeenCalledTimes(1);
-      expect(createRoomSpy).toHaveBeenCalledWith('1');
-    });
+    _gateway = module.get<RoomGateway>(RoomGateway);
+    _roomService = module.get<RoomService>(RoomService);
   });
 });

--- a/apps/api/test/room.service.spec.ts
+++ b/apps/api/test/room.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { MatchingUser } from '@packages/types/matching';
 
 import { ROOM_CONFIG } from '../../../packages/constants/socket-event';
+import { BattleService } from '../src/battle/battle.service';
 import { REDIS_CLIENT } from '../src/redis/redis.module';
 import { RedisKeys } from '../src/redis/redis-key.constant';
 import { RoomService } from '../src/room/room.service';
@@ -8,10 +10,15 @@ import { RoomService } from '../src/room/room.service';
 describe('RoomService', () => {
   let service: RoomService;
   let mockRedis: { set: jest.Mock };
+  let mockBattleService: { createBattle: jest.Mock };
 
   beforeEach(async () => {
     mockRedis = {
       set: jest.fn().mockResolvedValue('OK'),
+    };
+
+    mockBattleService = {
+      createBattle: jest.fn().mockResolvedValue({}),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -21,6 +28,10 @@ describe('RoomService', () => {
           provide: REDIS_CLIENT,
           useValue: mockRedis,
         },
+        {
+          provide: BattleService,
+          useValue: mockBattleService,
+        },
       ],
     }).compile();
 
@@ -28,16 +39,16 @@ describe('RoomService', () => {
   });
 
   describe('createRoom', () => {
-    it('올바른 구조의 Room 객체를 생성해야 한다', async () => {
-      const result = await service.createRoom('1');
+    it('인자 없이 호출해도 고유한 roomId를 포함한 객체를 생성해야 한다', async () => {
+      const result = await service.createRoom();
 
+      // roomId가 'room-'으로 시작하는지 확인 (Date.now 기반 패턴)
+      expect(result.roomId).toMatch(/^room-/);
       expect(result).toMatchObject({
-        roomId: '1',
-        title: '배틀룸 1',
+        title: expect.stringContaining('배틀룸') as string,
         hostId: 'system',
         status: 'waiting',
         currentPlayers: [],
-        currentSpectators: [],
         settings: {
           maxPlayers: ROOM_CONFIG.MAX_PLAYERS,
         },
@@ -45,10 +56,40 @@ describe('RoomService', () => {
       expect(result.createdAt).toBeInstanceOf(Date);
     });
 
-    it('Redis에 방 정보를 저장해야 한다', async () => {
-      await service.createRoom('1');
+    it('params로 넘긴 값이 기본값을 덮어씌워야 한다', async () => {
+      const customTitle = '나만의 방';
+      const result = await service.createRoom({ title: customTitle, status: 'in-battle' });
 
-      expect(mockRedis.set).toHaveBeenCalledWith(RedisKeys.room('1'), expect.any(String));
+      expect(result.title).toBe(customTitle);
+      expect(result.status).toBe('in-battle');
+    });
+
+    it('Redis에 올바른 키값으로 데이터를 저장해야 한다', async () => {
+      const result = await service.createRoom();
+
+      expect(mockRedis.set).toHaveBeenCalledWith(RedisKeys.room(result.roomId), expect.any(String));
+    });
+  });
+
+  describe('createMatchedRoom', () => {
+    const mockUser1 = { userId: 'user1', username: '플레이어1', socketId: 'sid1' } as MatchingUser;
+    const mockUser2 = { userId: 'user2', username: '플레이어2', socketId: 'sid2' } as MatchingUser;
+
+    it('유저 정보가 매핑된 방을 생성하고 배틀 서비스를 호출해야 한다', async () => {
+      const result = await service.createMatchedRoom(mockUser1, mockUser2);
+
+      // 1. 결과 확인
+      expect(result.currentPlayers).toHaveLength(2);
+      expect(result.status).toBe('in-battle');
+      expect(result.currentPlayers[0].roomId).toBe(result.roomId);
+
+      // 2. BattleService 호출 확인
+      expect(mockBattleService.createBattle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomId: result.roomId,
+          users: expect.arrayContaining(['user1', 'user2']) as string[],
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

ROOM 생성 로직 수정 및 테스트 코드 작성

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #66 
- #60 
- #62 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- apps/api/package.json : 테스트 코드 경로 수정
- apps/api/src/room/room.gateway.ts : onModuleInit 관련 로직 삭제
- apps/api/src/room/room.service.ts
  - createRoom : 대기방 생성을 위한 함수
  - createMatchedRoom : 자동 매칭 후 대기방과 배틀 생성 함수
- apps/api/test/room.gateway.spec.ts : 테스트 코드 수정
- apps/api/test/room.service.spec.ts : 테스트 코드 수정


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 기존 서버 실행 시 ROOM 자동 생성 로직 제거가 필요함
- ROOM 생성 시 roomId를 넣어주는 방식은 어색하기 때문에 이를 수정할 필요가 있음

## 💬 리뷰 요구사항(선택)

- 매칭 알고리즘을 구현하는 도중 ROOM 서비스 로직을 수정해야 해서 작성한 PR 입니다.