### PR TITLE
[FEAT] 소켓 이벤트 핸들러 및 브로드캐스팅 구현 (#54)

### DIFF
--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -117,6 +117,7 @@ export class RoomGateway implements OnModuleInit {
     // 같은 방 다른 사람들에게 새 유저 입장 알림
     client.to(roomId).emit(SOCKET_EVENT.ROOM_USER_JOINED, {
       playerCount: room.currentPlayers.length,
+      spectatorCount: room.currentSpectators.length,
     });
   }
 
@@ -153,6 +154,7 @@ export class RoomGateway implements OnModuleInit {
       // 같은 방 다른 사람들에게 유저 퇴장 알림
       client.to(roomId).emit(SOCKET_EVENT.ROOM_USER_LEFT, {
         playerCount: updatedRoom.currentPlayers.length,
+        spectatorCount: updatedRoom.currentSpectators.length,
       });
     }
 

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -10,11 +10,13 @@ import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
 
+import { CHAT_TYPE } from '../../../../packages/constants/chat';
 import {
   SOCKET_ERROR,
   SOCKET_EVENT,
   SOCKET_NAMESPACE,
 } from '../../../../packages/constants/socket-event';
+import { type ChatMessage } from '../../../../packages/types/chat';
 import { RoomUser, UserRole } from '../../../../packages/types/user';
 import { RoomService } from './room.service';
 
@@ -156,5 +158,29 @@ export class RoomGateway implements OnModuleInit {
 
     // 소켓 룸에서 나가기
     await client.leave(roomId);
+  }
+
+  @SubscribeMessage(SOCKET_EVENT.SEND_CHAT)
+  handleSendChat(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { roomId: string; message: string; nickname?: string },
+  ) {
+    const { roomId, message, nickname } = data ?? {};
+    const trimmedMessage = message?.trim();
+
+    if (!roomId || !trimmedMessage) {
+      return;
+    }
+
+    const chatMessage: ChatMessage = {
+      type: CHAT_TYPE.USER,
+      nickname: nickname ?? '익명',
+      message: trimmedMessage,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, chatMessage);
+
+    return { success: true };
   }
 }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -114,11 +114,15 @@ export class RoomGateway implements OnModuleInit {
       username: username,
     });
 
-    // 같은 방 다른 사람들에게 새 유저 입장 알림
-    client.to(roomId).emit(SOCKET_EVENT.ROOM_USER_JOINED, {
+    // 방의 모든 사람에게 새 유저 입장 알림 (본인 포함)
+    this.server.to(roomId).emit(SOCKET_EVENT.ROOM_USER_JOINED, {
       playerCount: room.currentPlayers.length,
       spectatorCount: room.currentSpectators.length,
     });
+
+    // 최신 인원 정보를 브로드캐스트
+    const availability = await this.roomService.getRoomAvailability(roomId);
+    this.server.to(roomId).emit(SOCKET_EVENT.ROOM_AVAILABILITY, availability);
   }
 
   @SubscribeMessage(SOCKET_EVENT.LEAVE_ROOM)
@@ -151,11 +155,15 @@ export class RoomGateway implements OnModuleInit {
     const updatedRoom = await this.roomService.removeUser(roomId, userId);
 
     if (updatedRoom) {
-      // 같은 방 다른 사람들에게 유저 퇴장 알림
-      client.to(roomId).emit(SOCKET_EVENT.ROOM_USER_LEFT, {
+      // 방의 모든 사람에게 유저 퇴장 알림 (본인 제외)
+      this.server.to(roomId).emit(SOCKET_EVENT.ROOM_USER_LEFT, {
         playerCount: updatedRoom.currentPlayers.length,
         spectatorCount: updatedRoom.currentSpectators.length,
       });
+
+      // 최신 인원 정보를 브로드캐스트
+      const availability = await this.roomService.getRoomAvailability(roomId);
+      this.server.to(roomId).emit(SOCKET_EVENT.ROOM_AVAILABILITY, availability);
     }
 
     // 소켓 룸에서 나가기

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -156,7 +156,7 @@ export class RoomGateway implements OnModuleInit {
 
     if (updatedRoom) {
       // 방의 모든 사람에게 유저 퇴장 알림 (본인 제외)
-      this.server.to(roomId).emit(SOCKET_EVENT.ROOM_USER_LEFT, {
+      client.to(roomId).emit(SOCKET_EVENT.ROOM_USER_LEFT, {
         playerCount: updatedRoom.currentPlayers.length,
         spectatorCount: updatedRoom.currentSpectators.length,
       });

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -62,13 +62,14 @@ export class RoomService {
     const room = await this.getRoom(roomId);
 
     if (!room) {
-      return { roomId, playerCount: 0, isAvailable: false };
+      return { roomId, playerCount: 0, spectatorCount: 0, isAvailable: false };
     }
 
     const playerCount = room.currentPlayers.length;
+    const spectatorCount = room.currentSpectators.length;
     const isAvailable = playerCount < ROOM_CONFIG.MAX_PLAYERS;
 
-    return { roomId, playerCount, isAvailable };
+    return { roomId, playerCount, spectatorCount, isAvailable };
   }
 
   async saveRoom(room: Room): Promise<void> {

--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -46,7 +46,7 @@ function BattleHeader({ theme, onToggleTheme }: BattleHeaderProps) {
           className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-base-faint text-base-primary transition hover:brightness-110"
           aria-label="테마 전환"
         >
-          {theme === 'dark' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
+          {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
         </button>
         <button
           onClick={handleLeave}

--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -13,6 +13,7 @@ function BattleHeader({ theme, onToggleTheme }: BattleHeaderProps) {
   const navigate = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
   const leaveRoom = useBattleSocketStore((state) => state.leaveRoom);
+  const spectatorCount = useBattleSocketStore((state) => state.spectatorCount);
 
   const handleLeave = () => {
     if (roomId) {
@@ -37,7 +38,7 @@ function BattleHeader({ theme, onToggleTheme }: BattleHeaderProps) {
       <div className="flex items-center gap-3">
         <div className="inline-flex items-center gap-1.5 rounded-full bg-base-faint px-5 py-2 text-sm font-medium text-base-primary">
           <Eye className="h-4 w-4 text-base-secondary" strokeWidth={2.5} />
-          <span className="text-base-primary">23</span>
+          <span className="text-base-primary">{spectatorCount}</span>
         </div>
         <button
           type="button"

--- a/apps/web/src/components/Battle/BattleProblem.tsx
+++ b/apps/web/src/components/Battle/BattleProblem.tsx
@@ -14,7 +14,7 @@ const examples = [
 
 function BattleProblem() {
   return (
-    <section className="flex flex-col gap-5 rounded-2xl bg-(--bg-layer-2) p-5 text-base-primary xl:h-full xl:min-h-0 xl:overflow-y-auto">
+    <section className="flex flex-col gap-5 rounded-2xl bg-(--bg-layer-2) border border-border-soft p-5 text-base-primary xl:h-full xl:min-h-0 xl:overflow-y-auto">
       <div className="flex items-start justify-between">
         <div className="space-y-5">
           <h1 className="text-2xl font-bold text-base-primary">두 수의 합 찾기</h1>

--- a/apps/web/src/components/Battle/Player/BattleSituation.tsx
+++ b/apps/web/src/components/Battle/Player/BattleSituation.tsx
@@ -8,7 +8,7 @@ function BattleProgress() {
   ];
   return (
     <>
-      <section className="flex flex-col gap-5 rounded-2xl  bg-(--bg-layer-2) p-5 text-base-primary xl:h-full xl:min-h-0 xl:overflow-y-auto">
+      <section className="flex flex-col gap-5 rounded-2xl  bg-(--bg-layer-2) p-5 border border-border-soft text-base-primary xl:h-full xl:min-h-0 xl:overflow-y-auto">
         <div className="flex items-start justify-between">
           <div className="space-y-1">
             <p className="text-sm font-semibold text-base-secondary">플레이어</p>

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -64,7 +64,7 @@ function CodeEditor() {
 
   return (
     <>
-      <section className="flex flex-col overflow-hidden rounded-2xl  bg-(--bg-layer-2) text-base-primary xl:h-full xl:min-h-0">
+      <section className="flex flex-col overflow-hidden rounded-2xl bg-(--bg-layer-2) border border-border-soft text-base-primary xl:h-full xl:min-h-0">
         <div className="flex items-center justify-between gap-3 border-b border-base-muted bg-(bg-layer-2) px-4 py-2 text-sm font-semibold">
           <div className="flex items-center gap-1.5">
             <Code className="h-5 w-5 text-green-05" strokeWidth={2.5} />

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -80,8 +80,8 @@ function ChatSpectator() {
 
   return (
     <>
-      <section className="relative flex h-full min-h-90 sm:min-h-130 max-h-[calc(100vh-200px)] max-lg:max-h-none flex-col overflow-hidden rounded-2xl border border-border-soft bg-(--bg-layer-2) text-base-primary shadow-sm">
-        <div className="flex items-center justify-between border-b border-border-soft bg-(--bg-layer-2) px-4 py-3">
+      <section className="relative flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
+        <div className="flex items-center justify-between border-b border-border-soft bg-[var(--bg-layer-2)] px-4 py-3">
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 items-center justify-center rounded-full">
               <MessagesSquare className="h-5 w-5 text-green-05 stroke-[2.5]" />
@@ -89,7 +89,7 @@ function ChatSpectator() {
             <p className="text-md font-semibold">실시간 채팅</p>
           </div>
         </div>
-        <div className="chat-scroll flex-1 min-h-0 space-y-3 overflow-y-auto bg-(--bg-layer-2) px-4 py-4">
+        <div className="chat-scroll flex-1 min-h-0 space-y-3 overflow-y-auto bg-[var(--bg-layer-2)] px-4 py-4">
           <div className="flex justify-center">
             <div className="w-full max-w-[95%] rounded-lg bg-base-muted px-4 py-2 text-center text-xs font-semibold text-base-secondary">
               관전 모드에 오신 것을 환영합니다!
@@ -134,7 +134,7 @@ function ChatSpectator() {
                   </div>
                   <div
                     className={`inline-flex rounded-2xl px-4 py-2 text-sm leading-relaxed ${
-                      isMine ? 'bg-green-02 text-base-primary' : 'bg-base-muted text-base-primary'
+                      isMine ? 'bg-green-03 text-black' : 'bg-base-muted'
                     }`}
                   >
                     <p className="whitespace-pre-wrap">{msg.message}</p>
@@ -152,7 +152,7 @@ function ChatSpectator() {
           })}
           <div ref={bottomRef} />
         </div>
-        <div className="flex items-end gap-2 border-t border-border-soft bg-(--bg-layer-2) px-3 py-2">
+        <div className="flex items-end gap-2 border-t border-border-soft bg-[var(--bg-layer-2)] px-3 py-2">
           <textarea
             value={input}
             onChange={(event) => setInput(event.target.value)}

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -1,41 +1,28 @@
 import { CHAT_TYPE } from '@shared/constants/chat';
+import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { ChatMessage } from '@shared/types/chat';
 import { MessagesSquare } from 'lucide-react';
 import { type KeyboardEventHandler, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
-const initialMessages: ChatMessage[] = [
-  {
-    type: CHAT_TYPE.USER,
-    nickname: 'CodeFan123',
-    message: 'CodeMaster 화이팅!',
-    timestamp: new Date().toISOString(),
-  },
-  {
-    type: CHAT_TYPE.USER,
-    nickname: 'AlgoLover',
-    message: '이 문제 어렵네요 ㄷㄷ',
-    timestamp: new Date().toISOString(),
-  },
-  {
-    type: CHAT_TYPE.USER,
-    nickname: 'DevWatcher',
-    message: 'AlgoKing 진행도 빠르다',
-    timestamp: new Date().toISOString(),
-  },
-  {
-    type: CHAT_TYPE.SYSTEM,
-    nickname: 'System',
-    message: 'CodeMaster님이 테스트를 통과했습니다!',
-    timestamp: new Date().toISOString(),
-  },
-];
+import { useBattleSocketStore } from '@/stores/battleSocketStore';
+import { useRoomStore } from '@/stores/roomStore';
+
+const initialMessages: ChatMessage[] = [];
 
 function ChatSpectator() {
+  const { roomId = '1' } = useParams<{ roomId: string }>();
+  const me = useRoomStore((state) => state.me);
+  const socket = useBattleSocketStore((state) => state.socket);
+  const connectSocket = useBattleSocketStore((state) => state.connect);
+
+  const myNickname = useMemo(() => {
+    const fallback = socket?.id ? `User-${socket.id.slice(-4)}` : '관전자';
+    return me?.username ?? fallback;
+  }, [me, socket]);
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
   const [input, setInput] = useState('');
   const bottomRef = useRef<HTMLDivElement>(null);
-
-  const nickname = useMemo(() => '나', []);
 
   useEffect(() => {
     // 새 메시지가 추가되면 리스트 하단으로 스크롤
@@ -44,10 +31,25 @@ function ChatSpectator() {
     });
   }, [messages.length]);
 
+  useEffect(() => {
+    const activeSocket = socket ?? connectSocket();
+    if (!activeSocket) return;
+
+    const handleReceiveChat = (msg: ChatMessage) => {
+      setMessages((prev) => [...prev, { ...msg, isMine: msg.nickname === myNickname }]);
+    };
+
+    activeSocket.on(SOCKET_EVENT.RECEIVE_CHAT, handleReceiveChat);
+
+    return () => {
+      activeSocket.off(SOCKET_EVENT.RECEIVE_CHAT, handleReceiveChat);
+    };
+  }, [socket, connectSocket, myNickname]);
+
   const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
 
   const getAvatarTone = (isMine: boolean) =>
-    isMine ? 'bg-green-04 text-white' : 'bg-blue-04 text-white';
+    isMine ? 'bg-[var(--color-green-04)] text-white' : 'bg-[var(--color-blue-04)] text-white';
 
   const formatTime = (timestamp: string) => {
     const date = new Date(timestamp);
@@ -59,15 +61,12 @@ function ChatSpectator() {
     const trimmed = input.trim();
     if (!trimmed) return;
 
-    const outgoing: ChatMessage = {
-      type: CHAT_TYPE.USER,
-      nickname,
+    const activeSocket = socket ?? connectSocket();
+    activeSocket?.emit(SOCKET_EVENT.SEND_CHAT, {
+      roomId,
       message: trimmed,
-      timestamp: new Date().toISOString(),
-      isMine: true,
-    };
-
-    setMessages((prev) => [...prev, outgoing]);
+      nickname: myNickname,
+    });
     setInput('');
   };
 
@@ -99,7 +98,7 @@ function ChatSpectator() {
           {messages.map((msg, index) => {
             const key = `${msg.timestamp}-${index}`;
             const isSystem = msg.type === CHAT_TYPE.SYSTEM;
-            const isMine = msg.isMine ?? msg.nickname === nickname;
+            const isMine = msg.isMine ?? msg.nickname === myNickname;
             const displayName = isMine ? '나' : msg.nickname;
 
             if (isSystem) {
@@ -135,7 +134,7 @@ function ChatSpectator() {
                   </div>
                   <div
                     className={`inline-flex rounded-2xl px-4 py-2 text-sm leading-relaxed ${
-                      isMine ? 'bg-green-02 text-black' : 'bg-base-muted text-base-primary'
+                      isMine ? 'bg-green-02 text-base-primary' : 'bg-base-muted text-base-primary'
                     }`}
                   >
                     <p className="whitespace-pre-wrap">{msg.message}</p>

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -116,7 +116,7 @@ function CodeSpectator() {
           ))}
         </div>
 
-        <div className="flex flex-col overflow-hidden rounded-2xl bg-(bg-layer-2) text-base-primary shadow-inner shadow-slate-950/10 xl:flex-1 xl:min-h-0">
+        <div className="flex flex-col overflow-hidden rounded-2xl border border-border-soft bg-(bg-layer-2) text-base-primary shadow-inner shadow-slate-950/10 xl:flex-1 xl:min-h-0">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-soft bg-(--bg-layer-2) px-4 py-3 text-sm font-semibold">
             <div className="flex items-center gap-2">
               <Code className="h-5 w-5 text-green-05" strokeWidth={2.5} />

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -39,16 +39,13 @@ function CodeSpectator() {
     };
   }, [connect, roomId, selectedId, socket]);
 
-  const participants = useMemo(
-    () =>
-      players.length >= 2
-        ? players.slice(0, 2)
-        : [
-            { userId: 'player-a', username: 'Player A' },
-            { userId: 'player-b', username: 'Player B' },
-          ],
-    [players],
-  );
+  const participants = useMemo(() => {
+    if (players.length > 0) return players.slice(0, 2);
+    return [
+      { userId: 'player-a', username: 'Player A' },
+      { userId: 'player-b', username: 'Player B' },
+    ];
+  }, [players]);
 
   const firstParticipantId = participants[0]?.userId ?? null;
 

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -26,8 +26,8 @@ function BattlePage() {
   }, [me, resumeSession, roomId, isSpectator]);
 
   return (
-    <div className="min-h-svh overflow-auto text-ink dark:bg-slate-950 dark:text-slate-50 xl:h-screen xl:overflow-hidden">
-      <div className="flex min-h-svh bg-base-muted flex-col gap-3 px-3 py-3 xl:h-full xl:w-full xl:gap-4 xl:px-6 xl:py-4">
+    <div className="min-h-svh overflow-auto xl:h-screen xl:overflow-hidden">
+      <div className="flex min-h-svh flex-col gap-3 px-3 py-3 xl:h-full xl:w-full xl:gap-4 xl:px-6 xl:py-4">
         <BattleHeader theme={theme} onToggleTheme={toggleTheme} />
         <div className="flex-1 min-h-0 overflow-visible xl:overflow-hidden">
           {isSpectator ? <BattleSpectator /> : <BattlePlayer />}

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -1,14 +1,29 @@
-import { useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import BattleHeader from '@/components/Battle/BattleHeader';
 import BattlePlayer from '@/components/Battle/Player/BattlePlayer';
 import BattleSpectator from '@/components/Battle/Spectator/BattleSpectator';
 import { useTheme } from '@/hooks/useTheme';
+import { useBattleSocketStore } from '@/stores/battleSocketStore';
+import { useRoomStore } from '@/stores/roomStore';
 
 function BattlePage() {
+  const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
   const [searchParams] = useSearchParams();
   const isSpectator = searchParams.get('mode') === 'spectator';
   const { theme, toggleTheme } = useTheme();
+  const resumeSession = useBattleSocketStore((state) => state.resumeSession);
+  const me = useRoomStore((state) => state.me);
+
+  const roomId = roomIdParam ?? searchParams.get('roomId') ?? '1';
+
+  useEffect(() => {
+    if (me) return;
+    resumeSession({ roomId, roleHint: isSpectator ? 'spectator' : 'player' }).catch(() => {
+      // 복구 실패 시 무시하고 사용자가 다시 입장하게 둡니다.
+    });
+  }, [me, resumeSession, roomId, isSpectator]);
 
   return (
     <div className="min-h-svh overflow-auto text-ink dark:bg-slate-950 dark:text-slate-50 xl:h-screen xl:overflow-hidden">

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -93,6 +93,8 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
     new Promise((resolve, reject) => {
       const socket = get().connect();
       let settled = false;
+      const targetRoomId = payload.roomId;
+      const { setMe } = useRoomStore.getState();
       const cleanup = () => {
         settled = true;
         socket.off(SOCKET_EVENT.ROOM_STATE_ROLE, handleSync);
@@ -101,7 +103,7 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
       };
 
       const handlePlayers = (payload: RoomPlayerPayload) => {
-        if (payload.roomId !== payload.roomId) return;
+        if (payload.roomId !== targetRoomId) return;
         const { setPlayers } = useRoomStore.getState();
         setPlayers(
           payload.players.map((p) => ({
@@ -115,6 +117,14 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
 
       const handleSync = (response: RoomStateSyncPayload) => {
         if (settled) return;
+        if (response.roomId === targetRoomId) {
+          setMe({
+            roomId: response.roomId,
+            role: response.role,
+            userId: response.userId ?? socket.id,
+            username: response.username ?? `User-${socket.id.slice(-4)}`,
+          });
+        }
         cleanup();
         resolve({ roomId: response.roomId, role: response.role });
       };

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -118,11 +118,12 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
       const handleSync = (response: RoomStateSyncPayload) => {
         if (settled) return;
         if (response.roomId === targetRoomId) {
+          const safeSocketId = socket.id ?? '';
           setMe({
             roomId: response.roomId,
             role: response.role,
-            userId: response.userId ?? socket.id,
-            username: response.username ?? `User-${socket.id.slice(-4)}`,
+            userId: response.userId ?? socket.id ?? '',
+            username: response.username ?? `User-${safeSocketId.slice(-4)}`,
           });
         }
         cleanup();

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -41,6 +41,7 @@ interface BattleSocketState {
   socket: Socket | null;
   isConnected: boolean;
   roomAvailability: RoomAvailabilityResponseDTO | null;
+  spectatorCount: number;
   availabilityListener: ((payload: RoomAvailabilityResponseDTO) => void) | null;
   joinedListener: ((payload: { playerCount: number }) => void) | null;
   leftListener: ((payload: { playerCount: number }) => void) | null;
@@ -60,6 +61,7 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
   socket: null,
   isConnected: false,
   roomAvailability: null,
+  spectatorCount: 0,
   availabilityListener: null,
   joinedListener: null,
   leftListener: null,
@@ -189,10 +191,13 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
 
     const handleAvailability = (payload: RoomAvailabilityResponseDTO) => {
       if (payload.roomId !== roomId) return;
-      set({ roomAvailability: payload });
+      set({
+        roomAvailability: payload,
+        spectatorCount: payload.spectatorCount ?? get().spectatorCount,
+      });
     };
 
-    const handleJoined = (payload: { playerCount: number }) => {
+    const handleJoined = (payload: { playerCount: number; spectatorCount?: number }) => {
       set((state) => {
         if (!state.roomAvailability) return state;
         return {
@@ -200,11 +205,12 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
             ...state.roomAvailability,
             playerCount: payload.playerCount,
           },
+          spectatorCount: payload.spectatorCount ?? state.spectatorCount,
         };
       });
     };
 
-    const handleLeft = (payload: { playerCount: number }) => {
+    const handleLeft = (payload: { playerCount: number; spectatorCount?: number }) => {
       set((state) => {
         if (!state.roomAvailability) return state;
         return {
@@ -212,6 +218,7 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
             ...state.roomAvailability,
             playerCount: payload.playerCount,
           },
+          spectatorCount: payload.spectatorCount ?? state.spectatorCount,
         };
       });
     };

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -13,6 +13,30 @@ import { create } from 'zustand';
 import { connectBattleSocket, disconnectBattleSocket } from '../lib/battleSocket';
 import { useRoomStore } from './roomStore';
 
+const SESSION_KEY = 'battle-session';
+
+type StoredSession = {
+  roomId: string;
+  role: string;
+};
+
+const saveSession = (session: StoredSession) => {
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // ignore
+  }
+};
+
+const loadSession = (): StoredSession | null => {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    return raw ? (JSON.parse(raw) as StoredSession) : null;
+  } catch {
+    return null;
+  }
+};
+
 interface BattleSocketState {
   socket: Socket | null;
   isConnected: boolean;
@@ -29,6 +53,7 @@ interface BattleSocketState {
   leaveRoom: (roomId: string) => void;
   subscribeRoomAvailability: (roomId: string) => void;
   unsubscribeRoomAvailability: () => void;
+  resumeSession: (options?: { roomId?: string; roleHint?: string }) => Promise<void>;
 }
 
 export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
@@ -125,6 +150,10 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
             userId: response.userId ?? socket.id ?? '',
             username: response.username ?? `User-${safeSocketId.slice(-4)}`,
           });
+          saveSession({
+            roomId: response.roomId,
+            role: response.role,
+          });
         }
         cleanup();
         resolve({ roomId: response.roomId, role: response.role });
@@ -218,5 +247,20 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
     }
 
     set({ availabilityListener: null, joinedListener: null, leftListener: null });
+  },
+  // 저장된 세션(roomId/role)으로 자동 재입장 (간단 버전)
+  resumeSession: async (options?: { roomId?: string; roleHint?: string }) => {
+    const session = loadSession();
+    if (!session) return;
+    if (options?.roomId && options.roomId !== session.roomId) return;
+
+    const requestedRole =
+      (session.role as 'player' | 'spectator') ??
+      (options?.roleHint as 'player' | 'spectator') ??
+      'spectator';
+    await get().joinRoom({
+      roomId: session.roomId,
+      requestedRole,
+    });
   },
 }));

--- a/packages/types/room.ts
+++ b/packages/types/room.ts
@@ -38,6 +38,7 @@ export interface RoomAvailabilityResponseDTO {
   roomId: string;
   playerCount: number;
   isAvailable: boolean;
+  spectatorCount?: number;
 }
 
 // 방 입장 요청/응답


### PR DESCRIPTION
## 🔍 PR 요약

- 관전자 채팅을 실제 소켓 이벤트(SEND_CHAT/RECEIVE_CHAT)로 연동해 실시간 송수신 및 올바른 isMine/닉네임 렌더링 구현
- 입퇴장/관전자 수 브로드캐스트를 전체에 전송하여 인원 수 동기화, 재연결 시 간단 세션으로 동일 사용자 재입장 지원

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #54

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- FE: ChatSpectator가 SOCKET_EVENT.SEND/RECEIVE_CHAT으로 실시간 송수신, ROOM_STATE_ROLE 기반 me 저장으로 isMine 판정/닉네임 일관화
- CodeSpectator가 실제 플레이어 목록/코드 업데이트를 안정적으로 반영, socket.id undefined 대비 추가
- sessionStorage에 roomId/role/userId/username 저장 후 resumeSession으로 새로고침 시 자동 재입장
- spectatorCount 상태를 store에 추가해 ROOM_AVAILABILITY/JOIN/LEFT로 갱신, BattleHeader에서 실시간 관전자 수 표시 
- JoinRoomRequest에 userId/username 옵션 추가, 기존 userId 전달 시 socketId 교체; ROOM_USER_JOINED/LEFT를 전체로 emit하고 ROOM_AVAILABILITY에 spectatorCount 포함·즉시 재계산

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.


https://github.com/user-attachments/assets/72dcec1d-d2fe-4de7-9b5a-d4333420f094



## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 관전자 채팅/코드 공유에서 올바른 사용자 식별과 실시간 동기화를 보장하고, 입퇴장 후에도 관전자 수·채팅이 즉시 반영되도록 개선
- 새로고침/재연결 시에도 동일 사용자로 복귀해 관전 경험을 끊김 없이 유지하기 위함

## 💬 리뷰 요구사항(선택)

- 현재 일단은 간단하게 재접속(새로고침 시) JOIN_ROOM을 다시 보내서 서버가 같은 userID로 소켓을 매칭하도록 의도했는데 새롭게 생성된 userId로 접속이 되어서.. 일단은 새로고침 부분을 완벽하게 수정하지 못했습니다.
- 추후에 로그인이 구현된 이후에 명확한 유저 정보나, 채팅 히스토리, 코드 스냅샷 등의 내용을 서버가 다시 내려주는 로직을 구현해야할 것 같아요