### PR TITLE
[FEAT] 매칭 대기 및 성공 화면 UI (#63)

### DIFF
--- a/apps/web/src/components/Matching/LoadingSpinner.tsx
+++ b/apps/web/src/components/Matching/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+export default function LoadingSpinner() {
+  return (
+    <div className="flex justify-center">
+      <div className="relative w-20 h-20">
+        <div className="absolute inset-0 border-4 border-green-01 rounded-full" />
+        <div className="absolute inset-0 border-4 border-green-05 border-t-transparent rounded-full animate-spin" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/MatchingStats.tsx
+++ b/apps/web/src/components/Matching/MatchingStats.tsx
@@ -1,0 +1,11 @@
+import StatCard from './StatCard';
+
+export default function MatchingStats() {
+  return (
+    <div className="flex gap-4 mt-8">
+      <StatCard value="24" label="대기 중인 플레이어" />
+      <StatCard value="8" label="진행 중인 배틀" />
+      <StatCard value="10s" label="평균 매칭 시간" />
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -1,0 +1,80 @@
+import { Check } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function MatchingSuccess() {
+  const navigate = useNavigate();
+  const [countdown, setCountdown] = useState(5);
+
+  // 카운트다운 로직
+  useEffect(() => {
+    if (countdown === 0) {
+      // TODO: 실제 roomId로 변경 필요
+      navigate('/room/test-room');
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setCountdown((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [countdown, navigate]);
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center justify-center gap-10 select-none">
+      {/* 매칭 성공 메시지 */}
+      <div className="text-center">
+        <div className="flex justify-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-05">
+            <Check className="h-9 w-9" strokeWidth={3} />
+          </div>
+        </div>
+        <h1 className="text-4xl font-bold mt-6">매칭 성공!</h1>
+        <p className="mt-2 text-lg text-base-primary">2명의 플레이어가 모였습니다</p>
+      </div>
+
+      {/* VS 카드 */}
+      <div className="flex items-center justify-center gap-24 w-2/3 max-w-6xl mx-auto bg-base-faint rounded-3xl py-12">
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex h-24 w-24 items-center justify-center rounded-full bg-blue-500 text-4xl font-bold text-white">
+            Y
+          </div>
+          <div className="flex flex-col items-center">
+            <p className="text-2xl font-bold">You</p>
+            <div className="mt-2 flex items-center justify-center gap-1 text-sm">
+              <span>🏆</span>
+              <span className="font-semibold text-base-secondary">Gold</span>
+            </div>
+            <p className="mt-1 text-base text-base-secondary">승률: 72%</p>
+          </div>
+        </div>
+
+        <div className="text-4xl font-black text-green-05 drop-shadow-lg">VS</div>
+
+        <div className="flex flex-col items-center gap-4">
+          <div className="flex h-24 w-24 items-center justify-center rounded-full bg-blue-500 text-4xl font-bold text-white">
+            C
+          </div>
+          <div className="flex flex-col items-center">
+            <p className="text-2xl font-bold">You</p>
+            <div className="mt-2 flex items-center justify-center gap-1 text-sm">
+              <span>🏆</span>
+              <span className="font-semibold text-base-secondary">Gold</span>
+            </div>
+            <p className="mt-1 text-base text-base-secondary">승률: 72%</p>
+          </div>
+        </div>
+      </div>
+
+      {/* 카운트다운 */}
+      <div className="text-center">
+        {countdown > 0 ? (
+          <div className="text-9xl font-black text-green-05">{countdown}</div>
+        ) : (
+          <div className="text-9xl font-black italic text-green-05 animate-bounce">FIGHT!</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/MatchingTimer.tsx
+++ b/apps/web/src/components/Matching/MatchingTimer.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export default function MatchingTimer({ time }: Props) {
   return (
-    <div className="items-center justify-center gap-2 rounded-3xl bg-base-muted px-5 flex py-2">
+    <div className="flex items-center justify-center gap-2 rounded-3xl bg-base-muted px-5 py-2">
       <span className="w-2 h-2 bg-red-500 rounded-full" />
       <span className="text-base-secondary">대기 시간: {time}초</span>
     </div>

--- a/apps/web/src/components/Matching/MatchingTimer.tsx
+++ b/apps/web/src/components/Matching/MatchingTimer.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  time: number;
+}
+
+export default function MatchingTimer({ time }: Props) {
+  return (
+    <div className="items-center justify-center gap-2 rounded-3xl bg-base-muted px-5 flex py-2">
+      <span className="w-2 h-2 bg-red-500 rounded-full" />
+      <span className="text-base-secondary">대기 시간: {time}초</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/MatchingWait.tsx
+++ b/apps/web/src/components/Matching/MatchingWait.tsx
@@ -1,0 +1,34 @@
+import LoadingSpinner from './LoadingSpinner';
+import MatchingStats from './MatchingStats';
+import MatchingTimer from './MatchingTimer';
+
+interface Props {
+  waitTime: number;
+}
+
+export default function MatchingWait({ waitTime }: Props) {
+  return (
+    <div className="max-w-4xl mx-auto select-none">
+      <div className="flex flex-col bg-base-faint rounded-3xl shadow-lg p-16 gap-8">
+        {/* 로딩 스피너 */}
+        <LoadingSpinner />
+
+        {/* 매칭 상태 메시지 */}
+        <div className="flex flex-col gap-4">
+          <h1 className="text-4xl font-bold text-center">상대를 찾는 중...</h1>
+          <p className="text-base-primary font-bold text-center">
+            티어에서 비슷한 실력의 상대를 매칭하고 있습니다
+          </p>
+        </div>
+
+        {/* 대기 시간 */}
+        <div className="flex justify-center">
+          <MatchingTimer time={waitTime} />
+        </div>
+
+        {/* 통계 카드 */}
+        <MatchingStats />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/MatchingWaitModal.tsx
+++ b/apps/web/src/components/Matching/MatchingWaitModal.tsx
@@ -1,5 +1,7 @@
 import { Clock } from 'lucide-react';
 
+import Button from '@/components/ui/Button';
+
 interface Props {
   onContinue: () => void;
   onCancel: () => void;
@@ -24,18 +26,12 @@ export default function WaitConfirmModal({ onContinue, onCancel }: Props) {
         </p>
 
         <div className="flex gap-4">
-          <button
-            onClick={onCancel}
-            className="flex-1 rounded-lg bg-base-muted px-6 py-3 font-semibold transition hover:scale-105 active:scale-95"
-          >
+          <Button variant="muted" onClick={onCancel} className="flex-1 px-6 py-3">
             매칭 취소
-          </button>
-          <button
-            onClick={onContinue}
-            className="flex-1 rounded-lg bg-green-05 px-6 py-3 font-semibold transition hover:scale-105 active:scale-95"
-          >
+          </Button>
+          <Button onClick={onContinue} className="flex-1 px-6 py-3">
             계속 대기
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/Matching/MatchingWaitModal.tsx
+++ b/apps/web/src/components/Matching/MatchingWaitModal.tsx
@@ -1,0 +1,43 @@
+import { Clock } from 'lucide-react';
+
+interface Props {
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+export default function WaitConfirmModal({ onContinue, onCancel }: Props) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="mx-4 w-full max-w-md rounded-3xl bg-base-faint p-8 shadow-2xl text-base-primary select-none">
+        <div className="mb-4 flex justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-05/20">
+            <Clock className="h-8 w-8 text-green-05" />
+          </div>
+        </div>
+
+        <h3 className="mb-2 text-center text-xl font-bold">매칭 지연</h3>
+
+        <p className="mb-8 text-center text-base leading-relaxed">
+          매칭 시간이 길어지고 있습니다.
+          <br />
+          계속 대기하시겠습니까?
+        </p>
+
+        <div className="flex gap-4">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-lg bg-base-muted px-6 py-3 font-semibold transition hover:scale-105 active:scale-95"
+          >
+            매칭 취소
+          </button>
+          <button
+            onClick={onContinue}
+            className="flex-1 rounded-lg bg-green-05 px-6 py-3 font-semibold transition hover:scale-105 active:scale-95"
+          >
+            계속 대기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/StatCard.tsx
+++ b/apps/web/src/components/Matching/StatCard.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  value: string | number;
+  label: string;
+}
+
+export default function StatCard({ value, label }: Props) {
+  return (
+    <div className="bg-bg-layer-1 rounded-2xl py-6 px-12 text-center">
+      <div className="text-3xl font-bold text-green-05">{value}</div>
+      <div className="text-sm text-base-secondary mt-2">{label}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/StatCard.tsx
+++ b/apps/web/src/components/Matching/StatCard.tsx
@@ -5,7 +5,7 @@ interface Props {
 
 export default function StatCard({ value, label }: Props) {
   return (
-    <div className="bg-bg-layer-1 rounded-2xl py-6 px-12 text-center">
+    <div className="flex-1 min-w-50 bg-bg-layer-1 rounded-2xl py-6 px-12 text-center">
       <div className="text-3xl font-bold text-green-05">{value}</div>
       <div className="text-sm text-base-secondary mt-2">{label}</div>
     </div>

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -1,0 +1,33 @@
+import type { ButtonHTMLAttributes, ElementType, ReactNode } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'green' | 'black' | 'muted';
+  children: ReactNode;
+  icon?: ElementType;
+  iconSize?: number;
+}
+
+export default function Button({
+  variant = 'green',
+  className = '',
+  children,
+  icon: Icon,
+  iconSize,
+  ...props
+}: ButtonProps) {
+  const baseStyles =
+    'font-bold rounded-lg transition hover:scale-105 active:scale-95 flex items-center justify-center select-none cursor-pointer';
+
+  const variantStyles = {
+    green: 'bg-green-05 text-base-primary',
+    black: 'bg-black text-white',
+    muted: 'bg-base-muted text-base-primary',
+  };
+
+  return (
+    <button className={`${baseStyles} ${variantStyles[variant]} ${className}`} {...props}>
+      {Icon && <Icon size={iconSize} />}
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from '@/App.tsx';
 import BattlePage from '@/pages/BattlePage.tsx';
 import MainPage from '@/pages/MainPage.tsx';
+import MatchingPage from '@/pages/MatchingPage.tsx';
 
 const router = createBrowserRouter([
   {
@@ -16,6 +17,10 @@ const router = createBrowserRouter([
       {
         index: true,
         element: <MainPage />,
+      },
+      {
+        path: '/matching',
+        element: <MatchingPage />,
       },
       {
         path: '/room/:roomId',

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,83 +1,15 @@
-import { ROOM_CONFIG } from '@shared/constants/socket-event';
-import type { UserRole } from '@shared/types/user';
 import { Moon, Sun } from 'lucide-react';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useTheme } from '@/hooks/useTheme';
 
-import { JoinModal } from '../components/JoinModal';
-import { useBattleSocketStore } from '../stores/battleSocketStore';
-
-const DEFAULT_ROOM_ID = '1';
-
 function MainPage() {
   const navigate = useNavigate();
   const { theme, toggleTheme } = useTheme();
-  const [isModalOpen, setModalOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<UserRole>('player');
-  const [joinError, setJoinError] = useState('');
-  const [isJoining, setIsJoining] = useState(false);
-  const connect = useBattleSocketStore((state) => state.connect);
-  const requestRoomAvailability = useBattleSocketStore((state) => state.requestRoomAvailability);
-  const roomAvailability = useBattleSocketStore((state) => state.roomAvailability);
-  const joinRoom = useBattleSocketStore((state) => state.joinRoom);
-  const subscribeRoomAvailability = useBattleSocketStore(
-    (state) => state.subscribeRoomAvailability,
-  );
-  const unsubscribeRoomAvailability = useBattleSocketStore(
-    (state) => state.unsubscribeRoomAvailability,
-  );
-
-  const handleCloseModal = () => {
-    setModalOpen(false);
-    setJoinError('');
-    setIsJoining(false);
-    unsubscribeRoomAvailability();
-  };
-
-  const participants = {
-    count: roomAvailability?.playerCount ?? 0,
-    limit: ROOM_CONFIG.MAX_PLAYERS,
-  };
-  const spectators = {
-    count: 0,
-    limit: Infinity,
-  };
 
   const handleStartBattle = () => {
-    setJoinError('');
-    connect();
-    requestRoomAvailability({ roomId: DEFAULT_ROOM_ID }).catch((error) => {
-      setJoinError(error instanceof Error ? error.message : '인원 정보를 불러오지 못했습니다.');
-    });
-    subscribeRoomAvailability(DEFAULT_ROOM_ID);
-    setModalOpen(true);
+    navigate('/matching');
   };
-
-  const handleJoinRoom = async () => {
-    setJoinError('');
-    setIsJoining(true);
-    try {
-      const response = await joinRoom({ roomId: DEFAULT_ROOM_ID, requestedRole: selectedRole });
-      const role = response.role ?? selectedRole;
-      const search = role === 'spectator' ? '?mode=spectator' : '';
-      setModalOpen(false);
-      navigate(`/room/${response.roomId}${search}`);
-    } catch (error) {
-      setJoinError(
-        error instanceof Error ? error.message : '입장에 실패했습니다. 잠시 후 다시 시도해주세요.',
-      );
-    } finally {
-      setIsJoining(false);
-    }
-  };
-
-  // useEffect(() => {
-  //   return () => {
-  //     disconnect();
-  //   };
-  // }, [disconnect]);
 
   return (
     <div className="min-h-screen">
@@ -123,18 +55,6 @@ function MainPage() {
           </p>
         </div>
       </main>
-
-      <JoinModal
-        open={isModalOpen}
-        onClose={handleCloseModal}
-        selectedRole={selectedRole}
-        onSelectRole={setSelectedRole}
-        onJoin={handleJoinRoom}
-        joining={isJoining}
-        error={joinError}
-        participants={participants}
-        spectators={spectators}
-      />
     </div>
   );
 }

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,7 +1,21 @@
+import { useEffect, useState } from 'react';
+
+import MatchingWait from '@/components/Matching/MatchingWait';
+
 function MatchingPage() {
+  const [waitTime, setWaitTime] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setWaitTime((prev) => prev + 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
   return (
-    <div className="min-h-screen">
-      <h1>매칭 페이지</h1>
+    <div className="flex min-h-screen items-center justify-center">
+      <MatchingWait waitTime={waitTime} />
     </div>
   );
 }

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,0 +1,9 @@
+function MatchingPage() {
+  return (
+    <div className="min-h-screen">
+      <h1>매칭 페이지</h1>
+    </div>
+  );
+}
+
+export default MatchingPage;

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,21 +1,38 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import MatchingWait from '@/components/Matching/MatchingWait';
+import WaitConfirmModal from '@/components/Matching/MatchingWaitModal';
 
 function MatchingPage() {
+  const navigate = useNavigate();
   const [waitTime, setWaitTime] = useState(0);
+  const [showModal, setShowModal] = useState(false);
 
+  // 타이머
   useEffect(() => {
     const timer = setInterval(() => {
-      setWaitTime((prev) => prev + 1);
+      setWaitTime((prev) => {
+        if ((prev + 1) % 60 === 0) setShowModal(true);
+        return prev + 1;
+      });
     }, 1000);
 
     return () => clearInterval(timer);
   }, []);
 
+  const handleContinue = () => {
+    setShowModal(false);
+  };
+
+  const handleCancel = () => {
+    navigate('/');
+  };
+
   return (
     <div className="flex min-h-screen items-center justify-center">
       <MatchingWait waitTime={waitTime} />
+      {showModal && <WaitConfirmModal onContinue={handleContinue} onCancel={handleCancel} />}
     </div>
   );
 }


### PR DESCRIPTION
## 🔍 PR 요약

매칭 대기 및 성공 화면 UI 구현 

## 🧾 관련 이슈

- close #63 

## 🛠️ 주요 변경 사항

### 매칭 대기 화면
- `MatchingWait` 컴포넌트: 대기 화면 메인 레이아웃
- `LoadingSpinner`: 매칭 중 로딩 애니메이션
- `MatchingTimer`: 대기 시간 타이머 표시
- `MatchingStats`: 매칭 통계 정보 (현재 대기 인원, 평균 대기 시간)
- `StatCard`: 통계 카드 컴포넌트
- `MatchingWaitModal`: 1분마다 대기 시 안내 모달
  - 매칭 취소: 메인 페이지로 이동
  - 계속 대기: 모달 닫기

### 매칭 성공 화면
- `MatchingSuccess` 컴포넌트: 매칭 성공 후 표시 화면

### 공통 컴포넌트
- `Button` 컴포넌트: 재사용 가능한 버튼 (variant: primary/secondary)

## 📸 스크린샷

### 매칭 대기
<img width="1917" height="910" alt="image" src="https://github.com/user-attachments/assets/f4c520b3-bc50-470d-b9ab-b6375c1ba0c5" />

### 매칭 지연 모달
<img width="1918" height="910" alt="image" src="https://github.com/user-attachments/assets/9b6bc19c-4282-45a1-96f4-ceb9d8d2c072" />

### 매칭 완료
<img width="1915" height="907" alt="image" src="https://github.com/user-attachments/assets/01f4257c-eb47-4a1e-a4e6-77fde22722a3" />

## 🧠 의도 및 배경

- 매칭 시스템의 UI를 우선 구현
- 현재는 하드코딩된 데이터로 동작하며, 추후 소켓/API 연동하여 데이터 바인딩 진행할 예정

## 💬 리뷰 요구사항

UI 구조와 디자인은 이후 작업에서도 개선할 예정입니다.
디자인적으로 수정이나 개선이 필요하다고 느껴지는 부분이 있다면 의견 주시면 감사하겠습니다!

버튼을 재사용 가능하도록 컴포넌트로 분리했습니다. 
이후 버튼이 필요할 때 사용해 주시면 좋을 것 같고, 스타일이나 동작에 대한 개선이 필요하면 자유롭게 수정해 주세요!
