### PR TITLE
[FEAT] 메세지 검증 및 참가자/관전자 프로필 아바타 연동 (#55)

### DIFF
--- a/apps/api/src/battle/battle.gateway.ts
+++ b/apps/api/src/battle/battle.gateway.ts
@@ -6,11 +6,26 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { BATTLE_EVENTS } from '@packages/constants/battle';
-import { SOCKET_NAMESPACE } from '@packages/constants/socket-event';
+import { CHAT_TYPE } from '@packages/constants/chat';
+import { SOCKET_EVENT, SOCKET_NAMESPACE } from '@packages/constants/socket-event';
 import { type UpdateUserCodeDTO } from '@packages/types/battle';
+import { type ChatMessage } from '@packages/types/chat';
 import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
+
+interface UserTestResultPayload {
+  roomId: string;
+  userId: string;
+  username?: string;
+  passed: boolean;
+}
+
+interface UserFinishedPayload {
+  roomId: string;
+  userId: string;
+  username?: string;
+}
 
 @WebSocketGateway({
   namespace: SOCKET_NAMESPACE.GAME,
@@ -43,5 +58,39 @@ export class BattleGateway {
       console.error('Error handling code change:', error);
       return { success: false, message: 'Internal server error' };
     }
+  }
+
+  @SubscribeMessage(BATTLE_EVENTS.USER_TEST_RESULT)
+  handleUserTestResult(@MessageBody() payload: UserTestResultPayload) {
+    const { roomId, username, passed } = payload;
+    if (!roomId) return;
+
+    const message = passed
+      ? `${username ?? '플레이어'}님이 테스트를 통과했습니다!`
+      : `${username ?? '플레이어'}님이 테스트를 통과하지 못했습니다.`;
+
+    const systemMessage: ChatMessage = {
+      type: CHAT_TYPE.SYSTEM,
+      nickname: 'System',
+      message,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, systemMessage);
+  }
+
+  @SubscribeMessage(BATTLE_EVENTS.USER_FINISHED)
+  handleUserFinished(@MessageBody() payload: UserFinishedPayload) {
+    const { roomId, username } = payload;
+    if (!roomId) return;
+
+    const systemMessage: ChatMessage = {
+      type: CHAT_TYPE.SYSTEM,
+      nickname: 'System',
+      message: `${username ?? '플레이어'}님이 코드를 제출했습니다!`,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, systemMessage);
   }
 }

--- a/apps/api/src/battle/battle.gateway.ts
+++ b/apps/api/src/battle/battle.gateway.ts
@@ -8,24 +8,15 @@ import {
 import { BATTLE_EVENTS } from '@packages/constants/battle';
 import { CHAT_TYPE } from '@packages/constants/chat';
 import { SOCKET_EVENT, SOCKET_NAMESPACE } from '@packages/constants/socket-event';
-import { type UpdateUserCodeDTO } from '@packages/types/battle';
+import {
+  type UpdateUserCodeDTO,
+  type UserFinishedPayload,
+  type UserTestResultPayload,
+} from '@packages/types/battle';
 import { type ChatMessage } from '@packages/types/chat';
 import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
-
-interface UserTestResultPayload {
-  roomId: string;
-  userId: string;
-  username?: string;
-  passed: boolean;
-}
-
-interface UserFinishedPayload {
-  roomId: string;
-  userId: string;
-  username?: string;
-}
 
 @WebSocketGateway({
   namespace: SOCKET_NAMESPACE.GAME,

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -50,9 +50,16 @@ export class RoomGateway implements OnModuleInit {
   @SubscribeMessage(SOCKET_EVENT.JOIN_ROOM)
   async handleJoinRoom(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { roomId: string; requestedRole: UserRole },
+    @MessageBody()
+    data: {
+      roomId: string;
+      requestedRole: UserRole;
+      userId?: string;
+      username?: string;
+      avatarUrl?: string;
+    },
   ) {
-    const { roomId, requestedRole } = data;
+    const { roomId, requestedRole, userId, username, avatarUrl } = data;
 
     const room = await this.roomService.getRoom(roomId);
 
@@ -74,21 +81,40 @@ export class RoomGateway implements OnModuleInit {
       return;
     }
 
-    const username = `User-${Date.now().toString().slice(-4)}`;
+    const resolvedUserId = userId ?? client.id;
+    const resolvedUsername = username ?? `User-${resolvedUserId.slice(-4)}`;
+    const resolvedAvatar = avatarUrl;
 
-    const newUser: RoomUser = {
-      roomId: roomId,
-      userId: client.id,
-      username: username,
-      socketId: client.id,
-      role: requestedRole,
-      joinedAt: new Date(),
-    };
+    // 기존 유저 재접속 처리: 동일 userId가 있으면 socketId만 교체
+    const existingPlayer = room.currentPlayers.find((u) => u.userId === resolvedUserId);
+    const existingSpectator = room.currentSpectators.find((u) => u.userId === resolvedUserId);
 
-    if (requestedRole === 'player') {
-      room.currentPlayers.push(newUser);
+    let newUser: RoomUser | null = null;
+
+    if (existingPlayer) {
+      existingPlayer.socketId = client.id;
+      existingPlayer.username = resolvedUsername;
+      existingPlayer.avatarUrl = resolvedAvatar;
+    } else if (existingSpectator) {
+      existingSpectator.socketId = client.id;
+      existingSpectator.username = resolvedUsername;
+      existingSpectator.avatarUrl = resolvedAvatar;
     } else {
-      room.currentSpectators.push(newUser);
+      newUser = {
+        roomId: roomId,
+        userId: resolvedUserId,
+        username: resolvedUsername,
+        socketId: client.id,
+        role: requestedRole,
+        avatarUrl: resolvedAvatar,
+        joinedAt: new Date(),
+      };
+
+      if (requestedRole === 'player') {
+        room.currentPlayers.push(newUser);
+      } else {
+        room.currentSpectators.push(newUser);
+      }
     }
 
     await this.roomService.saveRoom(room);
@@ -97,7 +123,10 @@ export class RoomGateway implements OnModuleInit {
 
     // 참가자일 경우 배틀에도 참가
     if (requestedRole === 'player') {
-      await this.battleService.joinBattle(roomId, newUser);
+      const playerUser = existingPlayer ?? newUser;
+      if (playerUser) {
+        await this.battleService.joinBattle(roomId, playerUser);
+      }
     }
 
     // 방 전체에 최신 참여자 목록 브로드캐스트
@@ -110,8 +139,9 @@ export class RoomGateway implements OnModuleInit {
     client.emit(SOCKET_EVENT.ROOM_STATE_ROLE, {
       roomId: room.roomId,
       role: requestedRole,
-      userId: client.id,
-      username: username,
+      userId: resolvedUserId,
+      username: resolvedUsername,
+      avatarUrl: resolvedAvatar,
     });
 
     // 방의 모든 사람에게 새 유저 입장 알림 (본인 포함)
@@ -173,9 +203,9 @@ export class RoomGateway implements OnModuleInit {
   @SubscribeMessage(SOCKET_EVENT.SEND_CHAT)
   handleSendChat(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { roomId: string; message: string; nickname?: string },
+    @MessageBody() data: { roomId: string; message: string; nickname?: string; avatarUrl?: string },
   ) {
-    const { roomId, message, nickname } = data ?? {};
+    const { roomId, message, nickname, avatarUrl } = data ?? {};
     const trimmedMessage = message?.trim();
 
     if (!roomId || !trimmedMessage) {
@@ -187,6 +217,7 @@ export class RoomGateway implements OnModuleInit {
       nickname: nickname ?? '익명',
       message: trimmedMessage,
       timestamp: new Date().toISOString(),
+      avatarUrl,
     };
 
     this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, chatMessage);

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -23,6 +23,8 @@ import { RoomService } from './room.service';
 @WebSocketGateway({ namespace: SOCKET_NAMESPACE.GAME })
 export class RoomGateway implements OnModuleInit {
   @WebSocketServer() server: Server;
+  private rateLimitMap: Map<string, { count: number; windowStart: number; blockedUntil: number }> =
+    new Map();
 
   constructor(
     private readonly roomService: RoomService,
@@ -212,10 +214,46 @@ export class RoomGateway implements OnModuleInit {
       return;
     }
 
+    // Rate limit: 2초 내 5회 초과 시 2초간 차단
+    const now = Date.now();
+    const limiter = this.rateLimitMap.get(client.id) ?? {
+      count: 0,
+      windowStart: now,
+      blockedUntil: 0,
+    };
+
+    if (now < limiter.blockedUntil) {
+      client.emit(SOCKET_EVENT.ERROR, {
+        code: SOCKET_ERROR.UNKNOWN,
+        message: '채팅 전송이 잠시 제한되었습니다. 잠시 후 다시 시도해주세요.',
+      });
+      return;
+    }
+
+    if (now - limiter.windowStart > 2000) {
+      limiter.windowStart = now;
+      limiter.count = 0;
+    }
+
+    limiter.count += 1;
+    if (limiter.count > 5) {
+      limiter.blockedUntil = now + 2000;
+      this.rateLimitMap.set(client.id, limiter);
+      client.emit(SOCKET_EVENT.ERROR, {
+        code: SOCKET_ERROR.UNKNOWN,
+        message: '너무 빠르게 입력하고 있습니다. 2초 후 다시 시도해주세요.',
+      });
+      return;
+    }
+
+    this.rateLimitMap.set(client.id, limiter);
+
+    const safeMessage = this.sanitizeMessage(trimmedMessage);
+
     const chatMessage: ChatMessage = {
       type: CHAT_TYPE.USER,
       nickname: nickname ?? '익명',
-      message: trimmedMessage,
+      message: safeMessage,
       timestamp: new Date().toISOString(),
       avatarUrl,
     };
@@ -223,5 +261,17 @@ export class RoomGateway implements OnModuleInit {
     this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, chatMessage);
 
     return { success: true };
+  }
+
+  private sanitizeMessage(message: string): string {
+    // 간단한 escape 처리로 스크립트 실행 방지
+    const escaped = message
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+    return escaped.replace(/javascript:/gi, '').replace(/on\w+="[^"]*"/gi, '');
   }
 }

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -96,9 +96,35 @@ function CodeEditor() {
           <div className="text-xs text-base-secondary">
             테스트: <span className="text-green-05">0/10</span> 통과
           </div>
-          <button className="rounded-lg bg-green-05 px-4 py-2 text-xs font-bold text-white shadow-lg shadow-emerald-500/30 transition hover:brightness-110">
-            제출하기
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                if (!socket) return;
+                socket.emit(BATTLE_EVENTS.USER_TEST_RESULT, {
+                  roomId,
+                  username: me?.username ?? '플레이어',
+                  passed: true,
+                });
+              }}
+              className="rounded-lg bg-base-muted px-3 py-2 text-xs font-semibold text-base-primary transition hover:brightness-110"
+            >
+              테스트 메시지
+            </button>
+            <button
+              className="rounded-lg bg-green-05 px-4 py-2 text-xs font-bold text-white shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
+              type="button"
+              onClick={() => {
+                if (!socket) return;
+                socket.emit(BATTLE_EVENTS.USER_FINISHED, {
+                  roomId,
+                  username: me?.username ?? '플레이어',
+                });
+              }}
+            >
+              제출하기
+            </button>
+          </div>
         </div>
       </section>
     </>

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -20,6 +20,7 @@ function ChatSpectator() {
     const fallback = socket?.id ? `User-${socket.id.slice(-4)}` : '관전자';
     return me?.username ?? fallback;
   }, [me, socket]);
+  const myAvatar = useMemo(() => me?.avatarUrl, [me]);
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
   const [input, setInput] = useState('');
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -66,6 +67,7 @@ function ChatSpectator() {
       roomId,
       message: trimmed,
       nickname: myNickname,
+      avatarUrl: myAvatar,
     });
     setInput('');
   };
@@ -118,9 +120,17 @@ function ChatSpectator() {
               >
                 {!isMine && (
                   <div
-                    className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold ${getAvatarTone(false)}`}
+                    className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold overflow-hidden ${getAvatarTone(false)}`}
                   >
-                    {getInitial(displayName)}
+                    {msg.avatarUrl ? (
+                      <img
+                        src={msg.avatarUrl}
+                        alt={displayName}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      getInitial(displayName)
+                    )}
                   </div>
                 )}
                 <div className={`max-w-[82%] space-y-1 ${isMine ? 'items-end text-right' : ''}`}>
@@ -142,9 +152,17 @@ function ChatSpectator() {
                 </div>
                 {isMine && (
                   <div
-                    className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold ${getAvatarTone(true)}`}
+                    className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold overflow-hidden ${getAvatarTone(true)}`}
                   >
-                    {getInitial(displayName)}
+                    {msg.avatarUrl ? (
+                      <img
+                        src={msg.avatarUrl}
+                        alt={displayName}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      getInitial(displayName)
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -15,6 +15,7 @@ function ChatSpectator() {
   const me = useRoomStore((state) => state.me);
   const socket = useBattleSocketStore((state) => state.socket);
   const connectSocket = useBattleSocketStore((state) => state.connect);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const myNickname = useMemo(() => {
     const fallback = socket?.id ? `User-${socket.id.slice(-4)}` : '관전자';
@@ -28,7 +29,12 @@ function ChatSpectator() {
   useEffect(() => {
     // 새 메시지가 추가되면 리스트 하단으로 스크롤
     requestAnimationFrame(() => {
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      const list = listRef.current;
+      if (list) {
+        list.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
+      } else {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
     });
   }, [messages.length]);
 
@@ -82,7 +88,7 @@ function ChatSpectator() {
 
   return (
     <>
-      <section className="relative flex h-full min-h-0 flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
+      <section className="relative flex h-full min-h-0 max-h-[70vh] sm:max-h-[80vh] xl:max-h-none flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
         <div className="flex items-center justify-between border-b border-border-soft bg-[var(--bg-layer-2)] px-4 py-3">
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 items-center justify-center rounded-full">
@@ -91,7 +97,10 @@ function ChatSpectator() {
             <p className="text-md font-semibold">실시간 채팅</p>
           </div>
         </div>
-        <div className="chat-scroll flex-1 min-h-0 space-y-3 overflow-y-auto bg-[var(--bg-layer-2)] px-4 py-4">
+        <div
+          ref={listRef}
+          className="chat-scroll flex-1 min-h-0 space-y-3 overflow-y-auto bg-[var(--bg-layer-2)] px-4 py-4 pb-16"
+        >
           <div className="flex justify-center">
             <div className="w-full max-w-[95%] rounded-lg bg-base-muted px-4 py-2 text-center text-xs font-semibold text-base-secondary">
               관전 모드에 오신 것을 환영합니다!

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -153,7 +153,7 @@ function ChatSpectator() {
                   </div>
                   <div
                     className={`inline-flex rounded-2xl px-4 py-2 text-sm leading-relaxed ${
-                      isMine ? 'bg-green-03 text-black' : 'bg-base-muted'
+                      isMine ? 'bg-green-04 text-black-static' : 'bg-base-muted'
                     }`}
                   >
                     <p className="whitespace-pre-wrap">{msg.message}</p>

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -42,10 +42,22 @@ function CodeSpectator() {
   const participants = useMemo(() => {
     if (players.length > 0) return players.slice(0, 2);
     return [
-      { userId: 'player-a', username: 'Player A' },
-      { userId: 'player-b', username: 'Player B' },
+      {
+        roomId: roomId,
+        role: 'spectator',
+        userId: 'player-a',
+        username: 'Player A',
+        avatarUrl: undefined,
+      },
+      {
+        roomId: roomId,
+        role: 'spectator',
+        userId: 'player-b',
+        username: 'Player B',
+        avatarUrl: undefined,
+      },
     ];
-  }, [players]);
+  }, [players, roomId]);
 
   const firstParticipantId = participants[0]?.userId ?? null;
 
@@ -92,9 +104,17 @@ function CodeSpectator() {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   <span
-                    className={`flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white ${player.bg}`}
+                    className={`flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white ${player.bg} overflow-hidden`}
                   >
-                    {player.userId[0]}
+                    {player.avatarUrl ? (
+                      <img
+                        src={player.avatarUrl}
+                        alt={player.username}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      player.userId[0]
+                    )}
                   </span>
                   <div className="space-y-1">
                     <p className="text-base font-semibold text-base-primary">{player.username}</p>

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -12,12 +12,16 @@ import { create } from 'zustand';
 
 import { connectBattleSocket, disconnectBattleSocket } from '../lib/battleSocket';
 import { useRoomStore } from './roomStore';
+import { useUserStore } from './userStore';
 
 const SESSION_KEY = 'battle-session';
 
 type StoredSession = {
   roomId: string;
   role: string;
+  userId?: string;
+  username?: string;
+  avatarUrl?: string;
 };
 
 const saveSession = (session: StoredSession) => {
@@ -119,8 +123,15 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
   joinRoom: (payload: JoinRoomRequest) =>
     new Promise((resolve, reject) => {
       const socket = get().connect();
+      const profile = useUserStore.getState().user;
+      const payloadWithUser: JoinRoomRequest = {
+        ...payload,
+        userId: payload.userId ?? profile?.id,
+        username: payload.username ?? profile?.username,
+        avatarUrl: payload.avatarUrl ?? profile?.avatarUrl,
+      };
       let settled = false;
-      const targetRoomId = payload.roomId;
+      const targetRoomId = payloadWithUser.roomId;
       const { setMe } = useRoomStore.getState();
       const cleanup = () => {
         settled = true;
@@ -138,6 +149,7 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
             role: p.role,
             userId: p.userId,
             username: p.username,
+            avatarUrl: p.avatarUrl,
           })),
         );
       };
@@ -151,10 +163,14 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
             role: response.role,
             userId: response.userId ?? socket.id ?? '',
             username: response.username ?? `User-${safeSocketId.slice(-4)}`,
+            avatarUrl: response.avatarUrl,
           });
           saveSession({
             roomId: response.roomId,
             role: response.role,
+            userId: response.userId ?? socket.id ?? '',
+            username: response.username ?? `User-${safeSocketId.slice(-4)}`,
+            avatarUrl: response.avatarUrl,
           });
         }
         cleanup();
@@ -171,13 +187,17 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
       socket.on(SOCKET_EVENT.ROOM_PLAYERS, handlePlayers);
       socket.on(SOCKET_EVENT.ERROR, handleError);
 
-      socket.emit(SOCKET_EVENT.JOIN_ROOM, payload, (response: JoinRoomResponse | undefined) => {
-        if (settled) return;
-        if (response) {
-          cleanup();
-          resolve(response);
-        }
-      });
+      socket.emit(
+        SOCKET_EVENT.JOIN_ROOM,
+        payloadWithUser,
+        (response: JoinRoomResponse | undefined) => {
+          if (settled) return;
+          if (response) {
+            cleanup();
+            resolve(response);
+          }
+        },
+      );
     }),
   // 방 나가기 요청을 보낸다.
   leaveRoom: (roomId: string) => {
@@ -268,6 +288,9 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
     await get().joinRoom({
       roomId: session.roomId,
       requestedRole,
+      userId: session.userId,
+      username: session.username,
+      avatarUrl: session.avatarUrl,
     });
   },
 }));

--- a/apps/web/src/stores/roomStore.ts
+++ b/apps/web/src/stores/roomStore.ts
@@ -1,7 +1,13 @@
 import type { UserRole } from '@shared/types/user';
 import { create } from 'zustand';
 
-export type Player = { roomId: string; role: UserRole; userId: string; username: string };
+export type Player = {
+  roomId: string;
+  role: UserRole;
+  userId: string;
+  username: string;
+  avatarUrl?: string;
+};
 type CodeMap = Record<string, string>;
 
 type State = {

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -61,3 +61,16 @@ export interface UpdateUserCodeDTO {
   code: string;
   language: string;
 }
+
+export interface UserTestResultPayload {
+  roomId: string;
+  userId: string;
+  username?: string;
+  passed: boolean;
+}
+
+export interface UserFinishedPayload {
+  roomId: string;
+  userId: string;
+  username?: string;
+}

--- a/packages/types/chat.ts
+++ b/packages/types/chat.ts
@@ -3,5 +3,6 @@ export interface ChatMessage {
   nickname: string;
   message: string;
   timestamp: string; // ISO string
+  avatarUrl?: string;
   isMine?: boolean;
 }

--- a/packages/types/room.ts
+++ b/packages/types/room.ts
@@ -45,6 +45,9 @@ export interface RoomAvailabilityResponseDTO {
 export interface JoinRoomRequest {
   roomId: string;
   requestedRole: UserRole;
+  userId?: string;
+  username?: string;
+  avatarUrl?: string;
 }
 
 export interface JoinRoomResponse {
@@ -58,6 +61,7 @@ export interface RoomStateSyncPayload {
   role: UserRole;
   userId: string;
   username: string;
+  avatarUrl?: string;
   battleId?: string;
 }
 

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -4,6 +4,7 @@ export type UserRole = 'player' | 'spectator';
 export interface User {
   userId: string;
   username: string;
+  avatarUrl?: string;
 }
 
 // 방에 들어간 사용자


### PR DESCRIPTION
## 🔍 PR 요약

> 추가 Issue를 생성해야할까 고민했지만 채팅 추가 구현의 일부분이라서 아바타 프로필 추가는 현재 브랜치에서 다루겠습니다!

- 로그인 프로필(닉네임·아바타)을 소켓 입장/채팅에 연결해, 방/채팅/참가자 카드에서 실제 사용자 프로필이 표시되도록 개선
- 관전자/참가자 입퇴장 후 인원 수 동기화 및 재연결 시 동일 프로필로 복귀하는 간단 세션 유지
- 테스트/제출 이벤트를 시스템 채팅(SYSTEM)으로 브로드캐스트해 채팅창에서 즉시 알림 표시
- 채팅 메세지를 통한 악의적인 코드 방지 및 도배 메세지 제한 

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #55 
- close #54

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- FE: joinRoom 호출 시 userStore의 userId/username/avatarUrl을 payload에 포함, ROOM_STATE_ROLE/ROOM_PLAYERS로 내려온 avatarUrl까지 roomStore·세션에 저장
- FE: ChatSpectator/CodeSpectator 아바타 영역이 avatarUrl을 우선 표시(없으면 이니셜), isMine 판정·닉네임 일관성 유지
- FE: 세션 저장 필드 확장(roomId/role/userId/username/avatarUrl)으로 새로고침 후 동일 프로필로 재입장
- BE: JoinRoomRequest에 avatarUrl 수용, 동일 userId 재접속 시 socketId/username/avatarUrl만 교체, ROOM_STATE_ROLE에 avatarUrl 포함해 응답
- BE: 채팅 SEND_CHAT/RECEIVE_CHAT에 avatarUrl 전파, 방 상태(RoomUser)에 프로필 저장
- BE: USER_TEST_RESULT/USER_FINISHED 이벤트 수신 시 SYSTEM 채팅 메시지로 브로드캐스트, FE CodeEditor에서 테스트/제출 버튼으로 emit 가능
- BE: 악의적인 코드 방지를 위한 간단 XSS escape, 2초 내 5회 초과 시 2초간 차단하는 레이트 리미트 및 에러 안내 적용

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### 깃헙 프로필 연동

<img width="1898" height="1009" alt="채팅 로그인 이후 구현" src="https://github.com/user-attachments/assets/b8ede8eb-bb4f-4b43-b6c7-24b3ad070d5f" />

### 재접속 이후

<img width="1912" height="1015" alt="채팅 로그인 이후 재접속" src="https://github.com/user-attachments/assets/2f31d236-1737-4402-a6d6-e3fe09c1a628" />

### 채팅 UI 스크롤 테스트


https://github.com/user-attachments/assets/90ad5f5a-e018-4171-8365-dc21a3b18a99


### 참가자 진행 상황 결과 -> 채팅

https://github.com/user-attachments/assets/3dca0ad6-6eb7-46f7-a9ae-5eab771a0782

### 채팅 도배 제한

https://github.com/user-attachments/assets/07e7055c-df1d-4fc3-9aff-29aa2484f2a1


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 관전 채팅/코드 공유에서 실제 로그인 프로필을 반영해 사용자 식별을 명확히 하고, 재접속 시에도 동일 프로필로 이어지도록 개선
- 인원 수·채팅이 즉시 반영되도록 소켓·프로필 전달 경로를 정비
- 관전자가 채팅으로 악의적인 행동을 하는 것을 막기 위한 구현 추가

## 💬 리뷰 요구사항(선택)

- 향후 채팅 히스토리나 코드 스냅샷을 서버가 재전송하는 로직을 추가하면 새로고침 후에도 상태 복원이 가능할 것 같습니다.
- 현재는 브라우저가 태그/이벤트를 실행하지 못하고 단순 텍스트로 렌더됩니다.
> 다만 이건 간단한 방어라 100% 완벽하진 않고, 실제 운영에서는 `sanitize-html` 같은 검증된 라이브러리로 허용 태그/속성을 화이트리스트하는 방식도 고려해야할 것 같아요