### PR TITLE
[FEAT] 실시간 배틀 목록 및 관전 기능 구현 (#83)

### DIFF
--- a/apps/api/src/battle/battle-redis.service.ts
+++ b/apps/api/src/battle/battle-redis.service.ts
@@ -56,5 +56,40 @@ export class BattleRedisService {
     const key = RedisKeys.battle(battleId);
     const roomKey = RedisKeys.battleByRoom(roomId);
     await this.redis.del(key, roomKey);
+
+    // 활성 배틀 목록에서 제거
+    await this.redis.srem(RedisKeys.activeBattles(), battleId);
+  }
+
+  async getActiveBattles(): Promise<Battle[]> {
+    // 활성 배틀 ID 목록 가져오기
+    const battleIds = await this.redis.smembers(RedisKeys.activeBattles());
+
+    if (battleIds.length === 0) {
+      return [];
+    }
+
+    // Pipeline으로 모든 배틀 정보 한 번에 조회
+    const pipeline = this.redis.pipeline();
+    battleIds.forEach((battleId) => {
+      pipeline.get(RedisKeys.battle(battleId));
+    });
+    const results = (await pipeline.exec()) as [Error | null, string | null][];
+
+    if (!results) return [];
+
+    // 배틀 정보 파싱
+    const battles: Battle[] = [];
+    results.forEach(([err, data]) => {
+      if (!err && data) {
+        try {
+          battles.push(JSON.parse(data) as Battle);
+        } catch (error) {
+          console.error('Failed to parse battle data:', error);
+        }
+      }
+    });
+
+    return battles;
   }
 }

--- a/apps/api/src/battle/battle.controller.ts
+++ b/apps/api/src/battle/battle.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { Battle } from '@packages/types/battle';
+
+import { BattleService } from './battle.service';
+
+@Controller('battles')
+export class BattleController {
+  constructor(private readonly battleService: BattleService) {}
+
+  @Get()
+  async getActiveBattles(): Promise<Battle[]> {
+    const battles = await this.battleService.getActiveBattles();
+
+    return battles;
+  }
+}

--- a/apps/api/src/battle/battle.module.ts
+++ b/apps/api/src/battle/battle.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { BattleController } from '@/battle/battle.controller';
 import { BattleGateway } from '@/battle/battle.gateway';
 import { BattleService } from '@/battle/battle.service';
 import { BattleRedisService } from '@/battle/battle-redis.service';
 
 @Module({
+  controllers: [BattleController],
   providers: [BattleService, BattleRedisService, BattleGateway],
   exports: [BattleService],
 })

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -13,8 +13,10 @@ export class BattleService {
     // TODO: 배틀 ID 생성 로직 추가
     const battleId = `battle-${Date.now()}`;
 
-    const users: BattleUser[] = dto.users.map((userId) => ({
-      userId,
+    const users: BattleUser[] = dto.users.map((user) => ({
+      userId: user.userId,
+      username: user.username,
+      avatarUrl: user.avatarUrl,
       battleId,
       code: '',
       language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
@@ -56,9 +58,13 @@ export class BattleService {
     if (existingUser) {
       existingUser.isConnected = true;
       existingUser.disconnectedAt = undefined;
+      existingUser.username = user.username;
+      existingUser.avatarUrl = user.avatarUrl;
     } else {
       const newBattleUser: BattleUser = {
         userId: user.userId,
+        username: user.username,
+        avatarUrl: user.avatarUrl,
         battleId: battle.battleId,
         code: '',
         language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
@@ -126,5 +132,9 @@ export class BattleService {
     if (battleId) {
       await this.battleRedisService.deleteBattle(battleId, roomId);
     }
+  }
+
+  async getActiveBattles(): Promise<Battle[]> {
+    return this.battleRedisService.getActiveBattles();
   }
 }

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -60,6 +60,7 @@ export class RoomService {
       const player1: RoomUser = {
         userId: user1.userId,
         username: user1.username,
+        avatarUrl: user1.avatarUrl,
         socketId: user1.socketId, // MatchingUser에 보관된 socketId 활용
         roomId: roomId,
         role: 'player',
@@ -69,6 +70,7 @@ export class RoomService {
       const player2: RoomUser = {
         userId: user2.userId,
         username: user2.username,
+        avatarUrl: user2.avatarUrl,
         socketId: user2.socketId,
         roomId: roomId,
         role: 'player',
@@ -88,7 +90,11 @@ export class RoomService {
         config: {
           duration: BATTLE_CONFIG.DURATION,
         },
-        users: room.currentPlayers.map((player) => player.userId),
+        users: room.currentPlayers.map((player) => ({
+          userId: player.userId,
+          username: player.username,
+          avatarUrl: player.avatarUrl,
+        })),
       });
 
       this.logger.log(

--- a/apps/web/src/apis/battle.ts
+++ b/apps/web/src/apis/battle.ts
@@ -1,0 +1,9 @@
+import type { Battle } from '@shared/types/battle';
+
+import { axiosInstance } from './axios';
+
+// 활성 배틀 목록 조회 API
+export const getActiveBattles = async (): Promise<Battle[]> => {
+  const response = await axiosInstance.get('/battles');
+  return response.data;
+};

--- a/apps/web/src/components/ActiveBattle/ActiveBattleCard.tsx
+++ b/apps/web/src/components/ActiveBattle/ActiveBattleCard.tsx
@@ -1,0 +1,53 @@
+import type { Battle } from '@shared/types/battle';
+
+interface ActiveBattleCardProps {
+  battle: Battle;
+  onJoin: (roomId: string) => void;
+}
+
+function getElapsedMinutes(startedAt: Date | undefined): number {
+  const now = Date.now();
+  return Math.floor((now - new Date(startedAt || now).getTime()) / 60000);
+}
+
+export default function ActiveBattleCard({ battle, onJoin }: ActiveBattleCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onJoin(battle.roomId)}
+      className="bg-base-faint rounded-xl p-6 hover:bg-base-lower transition-colors cursor-pointer text-left"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <div className="h-2 w-2 rounded-full bg-red-01 animate-pulse" />
+          <span className="text-sm font-semibold text-red-01">LIVE</span>
+        </div>
+        <span className="text-sm text-base-primary">
+          {getElapsedMinutes(battle.startedAt)}분 전
+        </span>
+      </div>
+
+      <div className="flex items-center gap-4">
+        {battle.users.slice(0, 2).map((user) => (
+          <div key={user.userId} className="flex-1">
+            <div className="flex items-center gap-2">
+              {user.avatarUrl && (
+                <img
+                  src={user.avatarUrl}
+                  alt={user.username}
+                  className="h-8 w-8 rounded-full object-cover"
+                />
+              )}
+              <div className="text-lg font-bold truncate">{user.username}</div>
+            </div>
+            <div className="mt-2 text-sm text-base-secondary">
+              진행률: {user.progress.passedCount}/{user.progress.totalCount}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 text-sm text-base-primary">관전하기</div>
+    </button>
+  );
+}

--- a/apps/web/src/components/ActiveBattle/ActiveBattleList.tsx
+++ b/apps/web/src/components/ActiveBattle/ActiveBattleList.tsx
@@ -1,0 +1,27 @@
+import type { Battle } from '@shared/types/battle';
+
+import ActiveBattleCard from './ActiveBattleCard';
+
+interface ActiveBattleListProps {
+  battles: Battle[];
+  onJoinBattle: (roomId: string) => void;
+}
+
+export default function ActiveBattleList({ battles, onJoinBattle }: ActiveBattleListProps) {
+  if (battles.length === 0) {
+    return (
+      <div className="text-center py-20 text-base-primary">
+        <p className="text-xl">진행 중인 배틀이 없습니다</p>
+        <p className="mt-2">자동 매칭으로 새로운 배틀을 시작해보세요!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      {battles.map((battle) => (
+        <ActiveBattleCard key={battle.battleId} battle={battle} onJoin={onJoinBattle} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,5 +1,9 @@
+import type { Battle } from '@shared/types/battle';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import * as battleApi from '@/apis/battle';
+import ActiveBattleList from '@/components/ActiveBattle/ActiveBattleList';
 import Header from '@/components/Header/Header';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useMatchingStore } from '@/stores/matchingStore';
@@ -11,6 +15,28 @@ function MainPage() {
   const connect = useBattleSocketStore((state) => state.connect);
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
+
+  const [battles, setBattles] = useState<Battle[]>([]);
+
+  // 활성 배틀 목록 가져오기
+  useEffect(() => {
+    const fetchBattles = async () => {
+      try {
+        const activeBattles = await battleApi.getActiveBattles();
+        setBattles(activeBattles);
+      } catch (error) {
+        console.error('배틀 목록 조회 실패:', error);
+      }
+    };
+
+    fetchBattles();
+
+    // TODO: 웹소켓으로 실시간 업데이트 처리
+    // 5초마다 갱신
+    const interval = setInterval(fetchBattles, 5000);
+
+    return () => clearInterval(interval);
+  }, []);
 
   const handleStartBattle = async () => {
     if (!user?.id) {
@@ -42,6 +68,11 @@ function MainPage() {
     }
   };
 
+  // 관전자로 입장
+  const handleJoinAsSpectator = (roomId: string) => {
+    navigate(`/room/${roomId}?mode=spectator`);
+  };
+
   return (
     <div className="min-h-screen">
       <Header />
@@ -63,6 +94,9 @@ function MainPage() {
             현재 진행 중인 배틀을 관전하고 고수들의 코딩을 배워보세요
           </p>
         </div>
+
+        {/* 배틀 목록 */}
+        <ActiveBattleList battles={battles} onJoinBattle={handleJoinAsSpectator} />
       </main>
     </div>
   );

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -19,6 +19,8 @@ export interface Battle {
 export interface BattleUser {
   userId: string;
   battleId: string;
+  username: string;
+  avatarUrl?: string;
   code: string;
   language: string;
 
@@ -40,7 +42,11 @@ export interface CreateBattleDTO {
   config: {
     duration?: number;
   };
-  users: string[];
+  users: Array<{
+    userId: string;
+    username: string;
+    avatarUrl?: string;
+  }>;
 }
 
 export interface UpdateBattleUserDTO {


### PR DESCRIPTION

## 🔍 PR 요약

- MainPage에 진행 중인 배틀 카드 목록 표시
- 배틀 카드에 플레이어 아바타/이름/진행률 표시
- 카드 클릭 시 관전자 모드로 입장
- GET /battles API 및 활성 배틀 관리 로직 추가

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #83 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- apps/api/src/battle/battle-redis.service.ts : 진행중인 배틀 목록 반
- packages/types/battle.ts : 배틀 타입 수정(username, avatarUrl, ...)
- apps/api/src/battle/battle.service.ts : 배틀 타입 수정에 따른 변경
- apps/web/src/pages/MainPage.tsx
  - 주기적으로 API 요청을 하여 진행 중인 배틀 목록 요청
  - ActiveBattleList, ActiveBattleCard를 활용하여 배틀 목록 렌더링

## 📸 스크린샷 (선택)

<img width="1522" height="809" alt="image" src="https://github.com/user-attachments/assets/8dff07b3-6755-4ae6-90a9-f8c87caf4dd8" />

<img width="1370" height="648" alt="image" src="https://github.com/user-attachments/assets/42a7348d-5148-4374-bb41-4bc8ecd3bdb5" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 관전 페이지에 접속할 수 있도록 구현

## 💬 리뷰 요구사항(선택)

- 단순하게 배틀 중인 목록만 보이도록 했기 때문에 추후 수정이 필요할 것 같습니다 (UI, 코드 등).
- 이벤트가 아닌 API로 간단하게 구현하였기 때문에 이 부분도 수정이 필요할 것 같습니다.