### PR TITLE
[FEAT] 실시간 배틀 목록 확인 (#86)

### DIFF
--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -6,6 +6,8 @@ import { MatchingUser } from '@packages/types/matching';
 import { Room } from '@packages/types/room';
 import { Server, Socket } from 'socket.io';
 
+import { RoomService } from '@/room/room.service';
+
 import { MatchingService } from './matching.service';
 
 @WebSocketGateway({ namespace: SOCKET_NAMESPACE.GAME })
@@ -16,6 +18,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
   constructor(
     @Inject(forwardRef(() => MatchingService))
     private readonly matchingService: MatchingService,
+    private readonly roomService: RoomService,
   ) {}
 
   async handleDisconnect(client: Socket) {
@@ -104,5 +107,11 @@ export class MatchingGateway implements OnGatewayDisconnect {
     this.server.to(socketId).emit(SOCKET_EVENT.OPPONENT_DISCONNECTED, {
       message: '상대방의 연결이 끊겨 매칭이 취소되었습니다.',
     });
+  }
+
+  // Redis I/O 후 방 목록을 모든 클라이언트에게 브로드캐스트
+  async broadcastRoomList(): Promise<void> {
+    const rooms = await this.roomService.listRooms();
+    this.server.emit(SOCKET_EVENT.ROOM_LIST, rooms);
   }
 }

--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -112,6 +112,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
   // Redis I/O 후 방 목록을 모든 클라이언트에게 브로드캐스트
   async broadcastRoomList(): Promise<void> {
     const rooms = await this.roomService.listRooms();
-    this.server.emit(SOCKET_EVENT.ROOM_LIST, rooms);
+    const publicRooms = this.roomService.toPublicRooms(rooms);
+    this.server.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 }

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -287,7 +287,9 @@ export class MatchingService {
 
   // 매칭 성공 시 Room & Battle 생성
   private async createMatch(user1: MatchingUser, user2: MatchingUser) {
-    return await this.roomService.createMatchedRoom(user1, user2);
+    const result = await this.roomService.createMatchedRoom(user1, user2);
+    await this.matchingGateway.broadcastRoomList();
+    return result;
   }
 
   // 매칭 지연 유저 알림

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -33,7 +33,8 @@ export class RoomGateway {
   @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
   async handleRoomListRequest(@ConnectedSocket() client: Socket) {
     const rooms = await this.roomService.listRooms();
-    client.emit(SOCKET_EVENT.ROOM_LIST, rooms);
+    const publicRooms = this.roomService.toPublicRooms(rooms);
+    client.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 
   @SubscribeMessage(SOCKET_EVENT.CHECK_ROOM_AVAILABILITY)

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -30,6 +30,12 @@ export class RoomGateway {
     private readonly battleService: BattleService,
   ) {}
 
+  @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
+  async handleRoomListRequest(@ConnectedSocket() client: Socket) {
+    const rooms = await this.roomService.listRooms();
+    client.emit(SOCKET_EVENT.ROOM_LIST, rooms);
+  }
+
   @SubscribeMessage(SOCKET_EVENT.CHECK_ROOM_AVAILABILITY)
   async handleCheckRoomAvailability(
     @ConnectedSocket() client: Socket,

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -11,6 +11,11 @@ import { BattleService } from '../battle/battle.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { RedisKeys } from '../redis/redis-key.constant';
 
+type PublicRoom = Omit<Room, 'currentPlayers' | 'currentSpectators'> & {
+  currentPlayers: Array<Omit<RoomUser, 'socketId'>>;
+  currentSpectators: Array<Omit<RoomUser, 'socketId'>>;
+};
+
 @Injectable()
 export class RoomService {
   private readonly logger = new Logger(RoomService.name);
@@ -178,7 +183,8 @@ export class RoomService {
   }
 
   // 클라이언트에 노출할 때 socketId 등 민감 정보를 제거한 방 데이터
-  toPublicRooms(rooms: Room[]): Room[] {
+
+  toPublicRooms(rooms: Room[]): PublicRoom[] {
     return rooms.map((room) => ({
       ...room,
       currentPlayers: room.currentPlayers.map(({ socketId: _socketId, ...rest }) => rest),

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -152,4 +152,28 @@ export class RoomService {
     await this.redis.del(key);
     this.logger.log(`Deleted room ${roomId}`);
   }
+
+  async listRooms(): Promise<Room[]> {
+    // 방 정보를 담고 있는 모든 키 조회
+    const keys = await this.redis.keys(RedisKeys.room('*'));
+    if (!keys.length) return [];
+
+    // 파이프라인으로 한 번에 조회 후 파싱
+    const pipeline = this.redis.pipeline();
+    keys.forEach((key) => pipeline.get(key));
+    const results = (await pipeline.exec()) as [Error | null, string | null][];
+
+    const rooms: Room[] = [];
+    results.forEach(([err, value]) => {
+      if (err || !value) return;
+      try {
+        const parsed = JSON.parse(value) as Room;
+        rooms.push(parsed);
+      } catch (e) {
+        this.logger.warn(`Failed to parse room data: ${e}`);
+      }
+    });
+
+    return rooms;
+  }
 }

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -176,4 +176,13 @@ export class RoomService {
 
     return rooms;
   }
+
+  // 클라이언트에 노출할 때 socketId 등 민감 정보를 제거한 방 데이터
+  toPublicRooms(rooms: Room[]): Room[] {
+    return rooms.map((room) => ({
+      ...room,
+      currentPlayers: room.currentPlayers.map(({ socketId: _socketId, ...rest }) => rest),
+      currentSpectators: room.currentSpectators.map(({ socketId: _socketId, ...rest }) => rest),
+    }));
+  }
 }

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Header from '@/components/Header/Header';
@@ -9,8 +10,23 @@ function MainPage() {
   const navigate = useNavigate();
   const user = useUserStore((state) => state.user);
   const connect = useBattleSocketStore((state) => state.connect);
+  const subscribeRoomList = useBattleSocketStore((state) => state.subscribeRoomList);
+  const unsubscribeRoomList = useBattleSocketStore((state) => state.unsubscribeRoomList);
+  const requestRoomList = useBattleSocketStore((state) => state.requestRoomList);
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
+
+  useEffect(() => {
+    // 소켓 연결 후 방 목록 수신 구독 + 초기 요청
+    const socket = connect();
+    if (!socket.connected) socket.connect();
+    subscribeRoomList();
+    requestRoomList();
+
+    return () => {
+      unsubscribeRoomList();
+    };
+  }, [connect, subscribeRoomList, unsubscribeRoomList, requestRoomList]);
 
   const handleStartBattle = async () => {
     if (!user?.id) {

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -7,6 +7,7 @@ import type {
   RoomPlayerPayload,
   RoomStateSyncPayload,
 } from '@shared/types/room';
+import type { Room } from '@shared/types/room';
 import type { Socket } from 'socket.io-client';
 import { create } from 'zustand';
 
@@ -46,7 +47,9 @@ interface BattleSocketState {
   isConnected: boolean;
   roomAvailability: RoomAvailabilityResponseDTO | null;
   spectatorCount: number;
+  rooms: Room[];
   availabilityListener: ((payload: RoomAvailabilityResponseDTO) => void) | null;
+  roomListListener: ((rooms: Room[]) => void) | null;
   joinedListener: ((payload: { playerCount: number }) => void) | null;
   leftListener: ((payload: { playerCount: number }) => void) | null;
   connect: () => Socket;
@@ -59,6 +62,9 @@ interface BattleSocketState {
   subscribeRoomAvailability: (roomId: string) => void;
   unsubscribeRoomAvailability: () => void;
   resumeSession: (options?: { roomId?: string; roleHint?: string }) => Promise<void>;
+  subscribeRoomList: () => void;
+  unsubscribeRoomList: () => void;
+  requestRoomList: () => void;
 }
 
 export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
@@ -66,7 +72,9 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
   isConnected: false,
   roomAvailability: null,
   spectatorCount: 0,
+  rooms: [],
   availabilityListener: null,
+  roomListListener: null,
   joinedListener: null,
   leftListener: null,
   // 단일 소켓 인스턴스를 유지하고 기본 연결 상태를 관리합니다.
@@ -292,5 +300,28 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
       username: session.username,
       avatarUrl: session.avatarUrl,
     });
+  },
+  subscribeRoomList: () => {
+    const socket = get().connect();
+    const handleRoomList = (rooms: Room[]) => set({ rooms });
+
+    // 기존 리스너 제거 후 등록
+    const { roomListListener } = get();
+    if (roomListListener) {
+      socket.off(SOCKET_EVENT.ROOM_LIST, roomListListener);
+    }
+    socket.on(SOCKET_EVENT.ROOM_LIST, handleRoomList);
+    set({ roomListListener: handleRoomList });
+  },
+  unsubscribeRoomList: () => {
+    const socket = get().socket;
+    const { roomListListener } = get();
+    if (!socket || !roomListListener) return;
+    socket.off(SOCKET_EVENT.ROOM_LIST, roomListListener);
+    set({ roomListListener: null });
+  },
+  requestRoomList: () => {
+    const socket = get().connect();
+    socket.emit(SOCKET_EVENT.ROOM_LIST_REQUEST);
   },
 }));

--- a/packages/constants/socket-event.ts
+++ b/packages/constants/socket-event.ts
@@ -20,6 +20,7 @@ export const SOCKET_EVENT = {
   JOIN_ROOM: 'join-room', // 방 입장 (Player/Spectator)
   LEAVE_ROOM: 'leave-room', // 방 나가기
   SEND_CHAT: 'send-chat', // 관전자 채팅 전송
+  ROOM_LIST_REQUEST: 'room-list-request', // 방 목록 요청
 
   // --- Server -> Client (응답/알림) ---
   ROOM_AVAILABILITY: 'room-availability', // 방 인원 확인 결과
@@ -28,6 +29,7 @@ export const SOCKET_EVENT = {
   ROOM_USER_JOINED: 'room-joined', // 새 유저 입장 알림
   ROOM_USER_LEFT: 'room-left', // 유저 퇴장 알림
   RECEIVE_CHAT: 'receive-chat', // 관전자 채팅 수신(일반/시스템)
+  ROOM_LIST: 'room-list', // 방 목록 응답/브로드캐스트
 
   // === Matching ===
   MATCH_SUCCESS: 'match-success', // 매칭 성공 알림


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 매칭으로 생성된 방을 Redis에서 읽어 실시간으로 브로드캐스트하고, 메인 페이지가 소켓으로 방 목록을 구독·표시할 수 있게 구현했습니다
- 방 목록 응답에서 socketId를 제거해 클라이언트에 노출하지 않도록 안전하게 가공합니다

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #86 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- `SOCKET_EVENT`에 `ROOM_LIST_REQUEST/ROOM_LIST` 추가
- `RoomGateway`: `ROOM_LIST_REQUEST` 처리 → `Redis`의 방 목록 조회 후 `ROOM_LIST` 응답
- `RoomService`: `listRooms`로 `Redis` 전체 방 조회, `toPublicRooms`로 `socketId` 제거
- `MatchingGateway`: `broadcastRoomList` 추가, 매칭 성공 시 최신 방 목록을 전체에 push
- `MatchingService`: 방 생성 직후 `broadcastRoomList` 호출
- `battleSocketStore`: rooms 상태 및 `subscribeRoomList/unsubscribeRoomList/requestRoomList` 추가
- `MainPage`: 마운트 시 방 목록 구독 및 초기 요청으로 소켓 기반 목록 수신 준비

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### 실시간 방 목록 확인 (socketId 제거)

<img width="1498" height="817" alt="image" src="https://github.com/user-attachments/assets/b4c79b55-8957-49f3-985c-b48559f3ee84" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 매칭으로 생성되는 방을 실시간으로 노출해 관전자가 최신 배틀을 바로 찾을 수 있도록 하고, 초기 진입/재연결 시에도 소켓으로 최신 방 목록 스냅샷을 확보하기 위함
- 방 목록에서 `socketId`를 제거해 내부 식별자 노출을 막고 안전하게 목록을 제공

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 커밋에 sub-message 자세하게 정리해뒀습니다
- 방 목록 응답에 `socketId`가 노출될 수 있어 `toPublicRooms`에서 제거하도록 했습니다. 혹시 더 제거해야 할 필드가 있는지, 또는 필요한 메타데이터(상태/인원 등)가 있다면 피드백 부탁드립니다.
