### PR TITLE
[FEAT] 메인페이지 UI 및 배틀 입장 이후 로직 수정 (87,88)

### DIFF
--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -6,6 +6,8 @@ import { MatchingUser } from '@packages/types/matching';
 import { Room } from '@packages/types/room';
 import { Server, Socket } from 'socket.io';
 
+import { RoomService } from '@/room/room.service';
+
 import { MatchingService } from './matching.service';
 
 @WebSocketGateway({ namespace: SOCKET_NAMESPACE.GAME })
@@ -16,6 +18,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
   constructor(
     @Inject(forwardRef(() => MatchingService))
     private readonly matchingService: MatchingService,
+    private readonly roomService: RoomService,
   ) {}
 
   async handleDisconnect(client: Socket) {
@@ -104,5 +107,11 @@ export class MatchingGateway implements OnGatewayDisconnect {
     this.server.to(socketId).emit(SOCKET_EVENT.OPPONENT_DISCONNECTED, {
       message: '상대방의 연결이 끊겨 매칭이 취소되었습니다.',
     });
+  }
+
+  // Redis I/O 후 방 목록을 모든 클라이언트에게 브로드캐스트
+  async broadcastRoomList(): Promise<void> {
+    const rooms = await this.roomService.listRooms();
+    this.server.emit(SOCKET_EVENT.ROOM_LIST, rooms);
   }
 }

--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -112,6 +112,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
   // Redis I/O 후 방 목록을 모든 클라이언트에게 브로드캐스트
   async broadcastRoomList(): Promise<void> {
     const rooms = await this.roomService.listRooms();
-    this.server.emit(SOCKET_EVENT.ROOM_LIST, rooms);
+    const publicRooms = this.roomService.toPublicRooms(rooms);
+    this.server.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 }

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -287,7 +287,9 @@ export class MatchingService {
 
   // 매칭 성공 시 Room & Battle 생성
   private async createMatch(user1: MatchingUser, user2: MatchingUser) {
-    return await this.roomService.createMatchedRoom(user1, user2);
+    const result = await this.roomService.createMatchedRoom(user1, user2);
+    await this.matchingGateway.broadcastRoomList();
+    return result;
   }
 
   // 매칭 지연 유저 알림

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -104,11 +104,8 @@ export class MatchingService {
         });
       }
 
-      // 생성된 방 및 배틀 삭제
-      if (userdata.roomId) {
-        await this.roomService.deleteRoom(userdata.roomId);
-        await this.battleService.deleteBattle(userdata.roomId);
-      }
+      // 이미 배틀이 시작된 상태라면 방/배틀은 유지하고 상대 재입장(혹은 재매칭)만 처리합니다.
+      // 추후 명확한 종료 정책이 생기면 여기서 방/배틀 정리 로직을 추가!
     }
 
     await pipeline

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -56,6 +56,12 @@ export class MatchingService {
     const userdata = await this.redis.hgetall(RedisKeys.matchingUser(userId));
     if (!userdata) return;
 
+    // 이미 매칭 완료/배틀 진행 중인 상태라면 방/배틀 유지 및 알림 스킵 (재접속용)
+    if (userdata.status === 'MATCHED') {
+      this.logger.log(`User ${userId} disconnected after match start - keeping room/battle.`);
+      return;
+    }
+
     const pipeline = this.redis.pipeline();
 
     // 만약 이미 매칭된 상태에서 취소(연결 끊김)된 경우라면 상대방 처리

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -33,7 +33,8 @@ export class RoomGateway {
   @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
   async handleRoomListRequest(@ConnectedSocket() client: Socket) {
     const rooms = await this.roomService.listRooms();
-    client.emit(SOCKET_EVENT.ROOM_LIST, rooms);
+    const publicRooms = this.roomService.toPublicRooms(rooms);
+    client.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 
   @SubscribeMessage(SOCKET_EVENT.CHECK_ROOM_AVAILABILITY)

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -30,6 +30,12 @@ export class RoomGateway {
     private readonly battleService: BattleService,
   ) {}
 
+  @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
+  async handleRoomListRequest(@ConnectedSocket() client: Socket) {
+    const rooms = await this.roomService.listRooms();
+    client.emit(SOCKET_EVENT.ROOM_LIST, rooms);
+  }
+
   @SubscribeMessage(SOCKET_EVENT.CHECK_ROOM_AVAILABILITY)
   async handleCheckRoomAvailability(
     @ConnectedSocket() client: Socket,

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -75,16 +75,6 @@ export class RoomGateway {
       return;
     }
 
-    const currentPlayerCount = room.currentPlayers.length;
-
-    if (requestedRole === 'player' && currentPlayerCount >= 2) {
-      client.emit(SOCKET_EVENT.ERROR, {
-        code: SOCKET_ERROR.ROOM_FULL,
-        message: '방이 가득 찼습니다.',
-      });
-      return;
-    }
-
     const resolvedUserId = userId ?? client.id;
     const resolvedUsername = username ?? `User-${resolvedUserId.slice(-4)}`;
     const resolvedAvatar = avatarUrl;
@@ -92,6 +82,16 @@ export class RoomGateway {
     // 기존 유저 재접속 처리: 동일 userId가 있으면 socketId만 교체
     const existingPlayer = room.currentPlayers.find((u) => u.userId === resolvedUserId);
     const existingSpectator = room.currentSpectators.find((u) => u.userId === resolvedUserId);
+    const currentPlayerCount = room.currentPlayers.length;
+
+    // 새 플레이어가 추가되는 경우에만 정원 체크
+    if (requestedRole === 'player' && !existingPlayer && currentPlayerCount >= 2) {
+      client.emit(SOCKET_EVENT.ERROR, {
+        code: SOCKET_ERROR.ROOM_FULL,
+        message: '방이 가득 찼습니다.',
+      });
+      return;
+    }
 
     let newUser: RoomUser | null = null;
 

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -11,6 +11,11 @@ import { BattleService } from '../battle/battle.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { RedisKeys } from '../redis/redis-key.constant';
 
+type PublicRoom = Omit<Room, 'currentPlayers' | 'currentSpectators'> & {
+  currentPlayers: Array<Omit<RoomUser, 'socketId'>>;
+  currentSpectators: Array<Omit<RoomUser, 'socketId'>>;
+};
+
 @Injectable()
 export class RoomService {
   private readonly logger = new Logger(RoomService.name);
@@ -178,7 +183,8 @@ export class RoomService {
   }
 
   // 클라이언트에 노출할 때 socketId 등 민감 정보를 제거한 방 데이터
-  toPublicRooms(rooms: Room[]): Room[] {
+
+  toPublicRooms(rooms: Room[]): PublicRoom[] {
     return rooms.map((room) => ({
       ...room,
       currentPlayers: room.currentPlayers.map(({ socketId: _socketId, ...rest }) => rest),

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -152,4 +152,28 @@ export class RoomService {
     await this.redis.del(key);
     this.logger.log(`Deleted room ${roomId}`);
   }
+
+  async listRooms(): Promise<Room[]> {
+    // 방 정보를 담고 있는 모든 키 조회
+    const keys = await this.redis.keys(RedisKeys.room('*'));
+    if (!keys.length) return [];
+
+    // 파이프라인으로 한 번에 조회 후 파싱
+    const pipeline = this.redis.pipeline();
+    keys.forEach((key) => pipeline.get(key));
+    const results = (await pipeline.exec()) as [Error | null, string | null][];
+
+    const rooms: Room[] = [];
+    results.forEach(([err, value]) => {
+      if (err || !value) return;
+      try {
+        const parsed = JSON.parse(value) as Room;
+        rooms.push(parsed);
+      } catch (e) {
+        this.logger.warn(`Failed to parse room data: ${e}`);
+      }
+    });
+
+    return rooms;
+  }
 }

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -176,4 +176,13 @@ export class RoomService {
 
     return rooms;
   }
+
+  // 클라이언트에 노출할 때 socketId 등 민감 정보를 제거한 방 데이터
+  toPublicRooms(rooms: Room[]): Room[] {
+    return rooms.map((room) => ({
+      ...room,
+      currentPlayers: room.currentPlayers.map(({ socketId: _socketId, ...rest }) => rest),
+      currentSpectators: room.currentSpectators.map(({ socketId: _socketId, ...rest }) => rest),
+    }));
+  }
 }

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -53,10 +53,11 @@ function CodeEditor() {
   const handleChange = (value: string) => {
     setCode(value);
     if (!socket?.connected) return;
+    if (!me?.userId) return; // 입장 정보 없으면 전송하지 않음
 
     socket.emit(BATTLE_EVENTS.CODE_CHANGE, {
       roomId,
-      userId: me?.userId ?? socket.id,
+      userId: me.userId,
       code: value,
       language: 'javascript',
     });

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -88,7 +88,7 @@ function ChatSpectator() {
 
   return (
     <>
-      <section className="relative flex h-full min-h-0 max-h-[70vh] sm:max-h-[80vh] xl:max-h-none flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
+      <section className="relative flex h-full min-h-[60vh] max-h-[70vh] sm:max-h-[60vh] xl:max-h-none flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
         <div className="flex items-center justify-between border-b border-border-soft bg-[var(--bg-layer-2)] px-4 py-3">
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 items-center justify-center rounded-full">

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { logout } from '@/apis/auth';
+import LogoImage from '@/assets/logo.png';
 import { UserProfile } from '@/components/Profile/UserProfile';
 import { useTheme } from '@/hooks/useTheme';
 import { useUserStore } from '@/stores/userStore';
@@ -43,12 +44,9 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
 
   return (
     <header className="border-b border-border-soft bg-bg-layer-2 shadow-sm">
-      <div className="mx-auto flex max-w-5xl items-center justify-between px-10 py-2">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-8 py-2">
         <div className="flex items-center gap-3">
-          <div className="grid h-12 w-12 rounded-2xl bg-brand shadow-lg"></div>
-          <div className="flex flex-col">
-            <span className="text-lg font-extrabold tracking-tight logo-gradient">CODE RENA</span>
-          </div>
+          <img src={LogoImage} alt="TADAK 로고" className="h-12 w-auto" />
         </div>
         <div className="flex items-center gap-4">
           {rightContent ? (

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -16,7 +16,7 @@ function RoomCardList({ rooms, onSpectate }: Props) {
         return (
           <div
             key={room.roomId}
-            className="rounded-2xl bg-white px-5 py-4 shadow-sm transition hover:shadow-md"
+            className="rounded-2xl bg-bg-layer-2 border border-border-soft px-5 py-4 shadow-sm transition hover:shadow-md"
           >
             <div className="mb-4 flex items-center justify-between text-xs text-base-secondary">
               <div className="flex items-center gap-2">
@@ -60,7 +60,7 @@ function RoomCardList({ rooms, onSpectate }: Props) {
                       className="h-full rounded-full"
                       style={{
                         width: `${idx === 0 ? 75 : 60}%`,
-                        backgroundColor: idx === 0 ? 'bg-green-05' : 'bg-red-01',
+                        backgroundColor: idx === 0 ? '#00e074' : '#ff6584',
                       }}
                     />
                   </div>
@@ -71,7 +71,7 @@ function RoomCardList({ rooms, onSpectate }: Props) {
             <button
               type="button"
               onClick={onSpectate ? () => onSpectate(room.roomId) : undefined}
-              className="mt-6 flex w-full items-center justify-center rounded-lg bg-base-muted px-4 py-3 text-sm font-semibold text-base-primary transition hover:brightness-105 disabled:opacity-50"
+              className="mt-6 flex w-full items-center justify-center rounded-lg bg-base-muted px-4 py-3 text-sm font-semibold transition hover:bg-base-primary/50 disabled:opacity-50"
               disabled={!onSpectate}
             >
               관전하기

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -1,0 +1,86 @@
+import type { Room } from '@shared/types/room';
+import { Eye } from 'lucide-react';
+
+type Props = {
+  rooms: Room[];
+  onSpectate?: (roomId: string) => void;
+};
+
+const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
+
+function RoomCardList({ rooms, onSpectate }: Props) {
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      {rooms.map((room) => {
+        const players = room.currentPlayers?.slice(0, 2) ?? [];
+        return (
+          <div
+            key={room.roomId}
+            className="rounded-2xl bg-white px-5 py-4 shadow-sm transition hover:shadow-md"
+          >
+            <div className="mb-4 flex items-center justify-between text-xs text-base-secondary">
+              <div className="flex items-center gap-2">
+                <span className="flex items-center font-semibold text-red-01">● LIVE</span>
+                <span className="text-blue-03">12:34</span>
+              </div>
+              <div className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium">
+                <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} />
+                {room.currentSpectators?.length ?? 0}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <h3 className="text-xl font-bold text-base-primary">{room.title}</h3>
+              <span className="rounded-full bg-green-01 px-2 py-1 text-[10px] font-bold text-green-06">
+                Gold
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-4">
+              {players.map((p, idx) => (
+                <div key={p.userId} className="space-y-1">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-full bg-base-muted text-sm font-bold text-base-primary">
+                      {p.avatarUrl ? (
+                        <img
+                          src={p.avatarUrl}
+                          alt={p.username}
+                          className="h-full w-full rounded-full object-cover"
+                        />
+                      ) : (
+                        getInitial(p.username)
+                      )}
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-semibold text-base-primary">{p.username}</span>
+                      <span className="text-xs text-base-secondary">🏆 Gold III</span>
+                    </div>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${idx === 0 ? 75 : 60}%`,
+                        backgroundColor: idx === 0 ? 'bg-green-05' : 'bg-red-01',
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={onSpectate ? () => onSpectate(room.roomId) : undefined}
+              className="mt-6 flex w-full items-center justify-center rounded-lg bg-base-muted px-4 py-3 text-sm font-semibold text-base-primary transition hover:brightness-105 disabled:opacity-50"
+              disabled={!onSpectate}
+            >
+              관전하기
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default RoomCardList;

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -4,11 +4,12 @@ import { Eye } from 'lucide-react';
 type Props = {
   rooms: Room[];
   onSpectate?: (roomId: string) => void;
+  joiningRoomId?: string | null;
 };
 
 const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
 
-function RoomCardList({ rooms, onSpectate }: Props) {
+function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {rooms.map((room) => {
@@ -72,9 +73,9 @@ function RoomCardList({ rooms, onSpectate }: Props) {
               type="button"
               onClick={onSpectate ? () => onSpectate(room.roomId) : undefined}
               className="mt-6 flex w-full items-center justify-center rounded-lg bg-base-muted px-4 py-3 text-sm font-semibold transition hover:bg-base-primary/50 disabled:opacity-50"
-              disabled={!onSpectate}
+              disabled={!onSpectate || joiningRoomId === room.roomId}
             >
-              관전하기
+              {joiningRoomId === room.roomId ? '입장 중...' : '관전하기'}
             </button>
           </div>
         );

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -14,6 +14,7 @@ function BattlePage() {
   const isSpectator = searchParams.get('mode') === 'spectator';
   const { theme, toggleTheme } = useTheme();
   const resumeSession = useBattleSocketStore((state) => state.resumeSession);
+  const connect = useBattleSocketStore((state) => state.connect);
   const me = useRoomStore((state) => state.me);
 
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? '1';
@@ -24,6 +25,18 @@ function BattlePage() {
       // 복구 실패 시 무시하고 사용자가 다시 입장하게 둡니다.
     });
   }, [me, resumeSession, roomId, isSpectator]);
+
+  useEffect(() => {
+    const socket = connect();
+    const handleReconnect = () => {
+      // 소켓이 재연결될 때 저장된 세션 기준으로 다시 JOIN_ROOM 시도
+      resumeSession({ roleHint: isSpectator ? 'spectator' : 'player' }).catch(() => {});
+    };
+    socket.on('connect', handleReconnect);
+    return () => {
+      socket.off('connect', handleReconnect);
+    };
+  }, [connect, resumeSession, isSpectator]);
 
   return (
     <div className="min-h-svh overflow-auto xl:h-screen xl:overflow-hidden">

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -7,6 +7,7 @@ import BattleSpectator from '@/components/Battle/Spectator/BattleSpectator';
 import { useTheme } from '@/hooks/useTheme';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
+import { useUserStore } from '@/stores/userStore';
 
 function BattlePage() {
   const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
@@ -15,28 +16,63 @@ function BattlePage() {
   const { theme, toggleTheme } = useTheme();
   const resumeSession = useBattleSocketStore((state) => state.resumeSession);
   const connect = useBattleSocketStore((state) => state.connect);
+  const joinRoom = useBattleSocketStore((state) => state.joinRoom);
+  const user = useUserStore((state) => state.user);
   const me = useRoomStore((state) => state.me);
 
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? '1';
 
   useEffect(() => {
     if (me) return;
-    resumeSession({ roomId, roleHint: isSpectator ? 'spectator' : 'player' }).catch(() => {
-      // 복구 실패 시 무시하고 사용자가 다시 입장하게 둡니다.
-    });
-  }, [me, resumeSession, roomId, isSpectator]);
+    const desiredRole = isSpectator ? 'spectator' : 'player';
+    const attempt = async () => {
+      await resumeSession({ roomId, roleHint: desiredRole }).catch(() => {});
+      if (!useRoomStore.getState().me) {
+        await joinRoom({
+          roomId,
+          requestedRole: desiredRole,
+          userId: user?.id,
+          username: user?.username,
+          avatarUrl: user?.avatarUrl,
+        }).catch(() => {});
+      }
+    };
+    attempt();
+  }, [me, resumeSession, joinRoom, roomId, isSpectator, user?.avatarUrl, user?.id, user?.username]);
 
   useEffect(() => {
     const socket = connect();
     const handleReconnect = () => {
-      // 소켓이 재연결될 때 저장된 세션 기준으로 다시 JOIN_ROOM 시도
-      resumeSession({ roleHint: isSpectator ? 'spectator' : 'player' }).catch(() => {});
+      // 소켓 재연결 시 저장된 세션 기준으로 다시 JOIN_ROOM 시도
+      const desiredRole = isSpectator ? 'spectator' : 'player';
+      resumeSession({ roleHint: desiredRole })
+        .catch(() => {})
+        .then(() => {
+          if (!useRoomStore.getState().me) {
+            joinRoom({
+              roomId,
+              requestedRole: desiredRole,
+              userId: user?.id,
+              username: user?.username,
+              avatarUrl: user?.avatarUrl,
+            }).catch(() => {});
+          }
+        });
     };
     socket.on('connect', handleReconnect);
     return () => {
       socket.off('connect', handleReconnect);
     };
-  }, [connect, resumeSession, isSpectator]);
+  }, [
+    connect,
+    resumeSession,
+    joinRoom,
+    roomId,
+    isSpectator,
+    user?.avatarUrl,
+    user?.id,
+    user?.username,
+  ]);
 
   return (
     <div className="min-h-svh overflow-auto xl:h-screen xl:overflow-hidden">

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,5 +1,5 @@
 import type { Room } from '@shared/types/room';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Header from '@/components/Header/Header';
@@ -29,11 +29,12 @@ function MainPage() {
   const unsubscribeRoomList = useBattleSocketStore((state) => state.unsubscribeRoomList);
   const requestRoomList = useBattleSocketStore((state) => state.requestRoomList);
   const rooms = useBattleSocketStore((state) => state.rooms);
+  const joinRoom = useBattleSocketStore((state) => state.joinRoom);
 
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
 
-  //const [joiningRoomId] = useState<string | null>(null);
+  const [joiningRoomId, setJoiningRoomId] = useState<string | null>(null);
 
   useEffect(() => {
     const socket = connect();
@@ -111,7 +112,27 @@ function MainPage() {
     }
   };
 
-  // 관전하기 입장 로직은 추후 백엔드 연동 시 추가 예정
+  const handleJoinSpectator = async (roomId: string) => {
+    setJoiningRoomId(roomId);
+    try {
+      const socket = connect();
+      if (!socket.connected) {
+        await new Promise<void>((resolve) => socket.once('connect', () => resolve()));
+      }
+      await joinRoom({
+        roomId,
+        requestedRole: 'spectator',
+        userId: user?.id,
+        username: user?.username,
+        avatarUrl: user?.avatarUrl,
+      });
+      navigate(`/room/${roomId}?mode=spectator`);
+    } catch (error) {
+      console.error('관전 입장 실패:', error);
+    } finally {
+      setJoiningRoomId(null);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-bg-layer-1">
@@ -170,7 +191,11 @@ function MainPage() {
         </div>
 
         {/* 방 카드 리스트 */}
-        <RoomCardList rooms={roomCards} onSpectate={undefined} />
+        <RoomCardList
+          rooms={roomCards}
+          onSpectate={handleJoinSpectator}
+          joiningRoomId={joiningRoomId}
+        />
       </main>
     </div>
   );

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -143,7 +143,7 @@ function MainPage() {
               key={tier.label}
               type="button"
               className={`rounded-full px-4 py-2 text-xs font-semibold text-base-primary shadow-sm ${
-                idx === 0 ? 'bg-green-01 text-green-06' : 'bg-white text-base-secondary'
+                idx === 0 ? 'bg-green-01 text-green-06' : 'bg-base-faint text-base-secondary'
               }`}
             >
               <span className={`mr-2 inline-block h-2 w-2 rounded-full ${tier.color}`} />

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,4 +1,3 @@
-import type { Room } from '@shared/types/room';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -56,40 +55,6 @@ function MainPage() {
     const totalPlayers = rooms.reduce((sum, room) => sum + (room.currentPlayers?.length ?? 0), 0);
     return { totalBattles, totalSpectators, totalPlayers };
   }, [rooms]);
-
-  const sampleFallback: Room[] = [
-    {
-      roomId: 'sample-1',
-      title: '두 수의 합',
-      hostId: 'system',
-      status: 'in-battle',
-      createdAt: new Date(),
-      settings: { maxPlayers: 2 },
-      currentPlayers: [
-        {
-          roomId: 'sample-1',
-          role: 'player',
-          userId: 'p1',
-          username: 'CodeMaster',
-          avatarUrl: undefined,
-          socketId: '',
-          joinedAt: new Date(),
-        },
-        {
-          roomId: 'sample-1',
-          role: 'player',
-          userId: 'p2',
-          username: 'AlgoKing',
-          avatarUrl: undefined,
-          socketId: '',
-          joinedAt: new Date(),
-        },
-      ],
-      currentSpectators: [],
-    },
-  ];
-
-  const roomCards = rooms.length > 0 ? rooms : sampleFallback;
 
   const handleStartBattle = async () => {
     if (!user?.id) {
@@ -191,11 +156,17 @@ function MainPage() {
         </div>
 
         {/* 방 카드 리스트 */}
-        <RoomCardList
-          rooms={roomCards}
-          onSpectate={handleJoinSpectator}
-          joiningRoomId={joiningRoomId}
-        />
+        {rooms.length === 0 ? (
+          <div className="rounded-2xl bg-bg-layer-2 border border-border-soft px-6 py-8 text-center text-base-secondary shadow-sm">
+            현재 진행 중인 배틀이 없습니다.
+          </div>
+        ) : (
+          <RoomCardList
+            rooms={rooms}
+            onSpectate={handleJoinSpectator}
+            joiningRoomId={joiningRoomId}
+          />
+        )}
       </main>
     </div>
   );

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,4 +1,6 @@
-import { useEffect } from 'react';
+import type { Room } from '@shared/types/room';
+import { Eye } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Header from '@/components/Header/Header';
@@ -6,18 +8,34 @@ import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useMatchingStore } from '@/stores/matchingStore';
 import { useUserStore } from '@/stores/userStore';
 
+// 색상 값은 임시 값 입니다 (추후에 index.css에 정의 후 사용 예정)
+const tierFilters = [
+  { label: '전체', color: 'bg-green-05' },
+  { label: '브론즈', color: 'bg-[#d78b4c]' },
+  { label: '실버', color: 'bg-[#a7b3c2]' },
+  { label: '골드', color: 'bg-[#f2c94c]' },
+  { label: '플래티넘', color: 'bg-[#27ae60]' },
+  { label: '다이아몬드', color: 'bg-[#56ccf2]' },
+  { label: '루비', color: 'bg-[#ff6584]' },
+  { label: '마스터', color: 'bg-[#9b51e0]' },
+];
+
 function MainPage() {
   const navigate = useNavigate();
   const user = useUserStore((state) => state.user);
+
   const connect = useBattleSocketStore((state) => state.connect);
   const subscribeRoomList = useBattleSocketStore((state) => state.subscribeRoomList);
   const unsubscribeRoomList = useBattleSocketStore((state) => state.unsubscribeRoomList);
   const requestRoomList = useBattleSocketStore((state) => state.requestRoomList);
+  const rooms = useBattleSocketStore((state) => state.rooms);
+
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
 
+  const [joiningRoomId] = useState<string | null>(null);
+
   useEffect(() => {
-    // 소켓 연결 후 방 목록 수신 구독 + 초기 요청
     const socket = connect();
     if (!socket.connected) socket.connect();
     subscribeRoomList();
@@ -28,6 +46,50 @@ function MainPage() {
     };
   }, [connect, subscribeRoomList, unsubscribeRoomList, requestRoomList]);
 
+  const stats = useMemo(() => {
+    const totalBattles = rooms.length;
+    const totalSpectators = rooms.reduce(
+      (sum, room) => sum + (room.currentSpectators?.length ?? 0),
+      0,
+    );
+    const totalPlayers = rooms.reduce((sum, room) => sum + (room.currentPlayers?.length ?? 0), 0);
+    return { totalBattles, totalSpectators, totalPlayers };
+  }, [rooms]);
+
+  const sampleFallback: Room[] = [
+    {
+      roomId: 'sample-1',
+      title: '두 수의 합',
+      hostId: 'system',
+      status: 'in-battle',
+      createdAt: new Date(),
+      settings: { maxPlayers: 2 },
+      currentPlayers: [
+        {
+          roomId: 'sample-1',
+          role: 'player',
+          userId: 'p1',
+          username: 'CodeMaster',
+          avatarUrl: undefined,
+          socketId: '',
+          joinedAt: new Date(),
+        },
+        {
+          roomId: 'sample-1',
+          role: 'player',
+          userId: 'p2',
+          username: 'AlgoKing',
+          avatarUrl: undefined,
+          socketId: '',
+          joinedAt: new Date(),
+        },
+      ],
+      currentSpectators: [],
+    },
+  ];
+
+  const roomCards = rooms.length > 0 ? rooms : sampleFallback;
+
   const handleStartBattle = async () => {
     if (!user?.id) {
       console.error('로그인이 필요합니다.');
@@ -36,48 +98,151 @@ function MainPage() {
 
     try {
       const socket = connect();
-
-      // Socket이 연결될 때까지 대기
       if (!socket.connected) {
-        await new Promise<void>((resolve) => {
-          socket.once('connect', () => resolve());
-        });
+        await new Promise<void>((resolve) => socket.once('connect', () => resolve()));
       }
-
-      if (!socket.id) {
-        throw new Error('Socket ID를 받지 못했습니다.');
-      }
+      if (!socket.id) throw new Error('Socket ID를 받지 못했습니다.');
 
       registerMatchingListeners(socket);
-
       await startMatching(user.id, socket.id);
-
       navigate('/matching');
     } catch (error) {
       console.error('매칭 시작 중 오류:', error);
     }
   };
 
+  // 관전하기 입장 로직은 추후 백엔드 연동 시 추가 예정
+  const handleJoinSpectator = () => {};
+
+  const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
+
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-bg-layer-1">
       <Header />
-      <main className="mx-auto flex max-w-5xl flex-col gap-10 pt-10 px-10 pb-16">
+      <main className="mx-auto flex max-w-6xl flex-col gap-8 px-4 pb-16 pt-10 lg:px-8">
+        {/* 상단 헤더 */}
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <div className="h-2 w-2 rounded-full bg-red-01" />
             <h1 className="text-3xl font-bold">LIVE</h1>
-            <h1 className="text-3xl font-bold text-brand">BATTLE</h1>
+            <h1 className="text-3xl font-bold text-brand">BATTLES</h1>
             <button
               type="button"
               onClick={handleStartBattle}
-              className="ml-auto rounded-24 bg-brand px-8 py-4 text-lg font-semibold shadow-md transition hover:scale-[1.02]"
+              className="ml-auto rounded-3xl bg-brand px-6 py-3 text-lg font-semibold shadow-md transition hover:scale-[1.02]"
             >
-              자동 매칭
+              게임 시작하기
             </button>
           </div>
           <p className="text-sm text-base-primary">
             현재 진행 중인 배틀을 관전하고 고수들의 코딩을 배워보세요
           </p>
+        </div>
+
+        {/* 티어 필터 (동작 없음, UI만) */}
+        <div className="flex flex-wrap gap-2">
+          {tierFilters.map((tier, idx) => (
+            <button
+              key={tier.label}
+              type="button"
+              className={`rounded-full px-4 py-2 text-xs font-semibold text-base-primary shadow-sm ${
+                idx === 0 ? 'bg-green-01 text-green-06' : 'bg-white text-base-secondary'
+              }`}
+            >
+              <span className={`mr-2 inline-block h-2 w-2 rounded-full ${tier.color}`} />
+              {tier.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 통계 카드 */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="rounded-2xl bg-white px-6 py-4 shadow-sm">
+            <p className="text-sm font-semibold text-green-05">진행 중인 배틀</p>
+            <p className="mt-2 text-3xl font-bold text-green-05">{stats.totalBattles}</p>
+          </div>
+          <div className="rounded-2xl bg-white px-6 py-4 shadow-sm">
+            <p className="text-sm font-semibold text-green-05">총 관전자</p>
+            <p className="mt-2 text-3xl font-bold text-green-05">{stats.totalSpectators}</p>
+          </div>
+          <div className="rounded-2xl bg-white px-6 py-4 shadow-sm">
+            <p className="text-sm font-semibold text-green-05">참가 중인 플레이어</p>
+            <p className="mt-2 text-3xl font-bold text-green-05">{stats.totalPlayers}</p>
+          </div>
+        </div>
+
+        {/* 방 카드 리스트 */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          {roomCards.map((room) => {
+            const players = room.currentPlayers?.slice(0, 2) ?? [];
+            return (
+              <div
+                key={room.roomId}
+                className="rounded-2xl bg-white px-5 py-4 shadow-sm transition hover:shadow-md"
+              >
+                <div className="mb-4 flex items-center justify-between text-xs text-base-secondary">
+                  <div className="flex items-center gap-2">
+                    <span className="flex items-center font-semibold text-red-01">● LIVE</span>
+                    <span className="text-blue-03">12:34</span>
+                  </div>
+                  <div className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium">
+                    <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} />
+                    {room.currentSpectators?.length ?? 0}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <h3 className="text-xl font-bold text-base-primary">{room.title}</h3>
+                  <span className="rounded-full bg-green-01 px-2 py-1 text-[10px] font-bold text-green-06">
+                    Gold
+                  </span>
+                </div>
+
+                <div className="mt-4 space-y-4">
+                  {players.map((p, idx) => (
+                    <div key={p.userId} className="space-y-1">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-base-muted text-sm font-bold text-base-primary">
+                          {p.avatarUrl ? (
+                            <img
+                              src={p.avatarUrl}
+                              alt={p.username}
+                              className="h-full w-full rounded-full object-cover"
+                            />
+                          ) : (
+                            getInitial(p.username)
+                          )}
+                        </div>
+                        <div className="flex flex-col">
+                          <span className="text-sm font-semibold text-base-primary">
+                            {p.username}
+                          </span>
+                          <span className="text-xs text-base-secondary">🏆 Gold III</span>
+                        </div>
+                      </div>
+                      <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
+                        <div
+                          className="h-full rounded-full"
+                          style={{
+                            width: `${idx === 0 ? 75 : 60}%`,
+                            backgroundColor: idx === 0 ? 'bg-green-05' : 'bg-red-01',
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => handleJoinSpectator()}
+                  className="mt-6 flex w-full items-center justify-center rounded-lg bg-base-muted px-4 py-3 text-sm font-semibold text-base-primary transition hover:brightness-105 disabled:opacity-50"
+                  disabled={joiningRoomId === room.roomId}
+                >
+                  관전하기
+                </button>
+              </div>
+            );
+          })}
         </div>
       </main>
     </div>

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,9 +1,9 @@
 import type { Room } from '@shared/types/room';
-import { Eye } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Header from '@/components/Header/Header';
+import RoomCardList from '@/components/Main/RoomCardList';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useMatchingStore } from '@/stores/matchingStore';
 import { useUserStore } from '@/stores/userStore';
@@ -33,7 +33,7 @@ function MainPage() {
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
 
-  const [joiningRoomId] = useState<string | null>(null);
+  //const [joiningRoomId] = useState<string | null>(null);
 
   useEffect(() => {
     const socket = connect();
@@ -112,9 +112,6 @@ function MainPage() {
   };
 
   // 관전하기 입장 로직은 추후 백엔드 연동 시 추가 예정
-  const handleJoinSpectator = () => {};
-
-  const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
 
   return (
     <div className="min-h-screen bg-bg-layer-1">
@@ -157,93 +154,23 @@ function MainPage() {
 
         {/* 통계 카드 */}
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <div className="rounded-2xl bg-white px-6 py-4 shadow-sm">
-            <p className="text-sm font-semibold text-green-05">진행 중인 배틀</p>
-            <p className="mt-2 text-3xl font-bold text-green-05">{stats.totalBattles}</p>
-          </div>
-          <div className="rounded-2xl bg-white px-6 py-4 shadow-sm">
-            <p className="text-sm font-semibold text-green-05">총 관전자</p>
-            <p className="mt-2 text-3xl font-bold text-green-05">{stats.totalSpectators}</p>
-          </div>
-          <div className="rounded-2xl bg-white px-6 py-4 shadow-sm">
-            <p className="text-sm font-semibold text-green-05">참가 중인 플레이어</p>
-            <p className="mt-2 text-3xl font-bold text-green-05">{stats.totalPlayers}</p>
-          </div>
+          {[
+            { label: '진행 중인 배틀', value: stats.totalBattles },
+            { label: '총 관전자', value: stats.totalSpectators },
+            { label: '참가 중인 플레이어', value: stats.totalPlayers },
+          ].map((item) => (
+            <div
+              key={item.label}
+              className="rounded-2xl bg-bg-layer-2 border border-border-soft px-6 py-4 shadow-sm"
+            >
+              <p className="text-3xl font-bold text-green-05">{item.value}</p>
+              <p className="mt-1 text-sm text-base-secondary">{item.label}</p>
+            </div>
+          ))}
         </div>
 
         {/* 방 카드 리스트 */}
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          {roomCards.map((room) => {
-            const players = room.currentPlayers?.slice(0, 2) ?? [];
-            return (
-              <div
-                key={room.roomId}
-                className="rounded-2xl bg-white px-5 py-4 shadow-sm transition hover:shadow-md"
-              >
-                <div className="mb-4 flex items-center justify-between text-xs text-base-secondary">
-                  <div className="flex items-center gap-2">
-                    <span className="flex items-center font-semibold text-red-01">● LIVE</span>
-                    <span className="text-blue-03">12:34</span>
-                  </div>
-                  <div className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium">
-                    <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} />
-                    {room.currentSpectators?.length ?? 0}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <h3 className="text-xl font-bold text-base-primary">{room.title}</h3>
-                  <span className="rounded-full bg-green-01 px-2 py-1 text-[10px] font-bold text-green-06">
-                    Gold
-                  </span>
-                </div>
-
-                <div className="mt-4 space-y-4">
-                  {players.map((p, idx) => (
-                    <div key={p.userId} className="space-y-1">
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-base-muted text-sm font-bold text-base-primary">
-                          {p.avatarUrl ? (
-                            <img
-                              src={p.avatarUrl}
-                              alt={p.username}
-                              className="h-full w-full rounded-full object-cover"
-                            />
-                          ) : (
-                            getInitial(p.username)
-                          )}
-                        </div>
-                        <div className="flex flex-col">
-                          <span className="text-sm font-semibold text-base-primary">
-                            {p.username}
-                          </span>
-                          <span className="text-xs text-base-secondary">🏆 Gold III</span>
-                        </div>
-                      </div>
-                      <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
-                        <div
-                          className="h-full rounded-full"
-                          style={{
-                            width: `${idx === 0 ? 75 : 60}%`,
-                            backgroundColor: idx === 0 ? 'bg-green-05' : 'bg-red-01',
-                          }}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-
-                <button
-                  type="button"
-                  onClick={() => handleJoinSpectator()}
-                  className="mt-6 flex w-full items-center justify-center rounded-lg bg-base-muted px-4 py-3 text-sm font-semibold text-base-primary transition hover:brightness-105 disabled:opacity-50"
-                  disabled={joiningRoomId === room.roomId}
-                >
-                  관전하기
-                </button>
-              </div>
-            );
-          })}
-        </div>
+        <RoomCardList rooms={roomCards} onSpectate={undefined} />
       </main>
     </div>
   );

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Header from '@/components/Header/Header';
@@ -9,8 +10,23 @@ function MainPage() {
   const navigate = useNavigate();
   const user = useUserStore((state) => state.user);
   const connect = useBattleSocketStore((state) => state.connect);
+  const subscribeRoomList = useBattleSocketStore((state) => state.subscribeRoomList);
+  const unsubscribeRoomList = useBattleSocketStore((state) => state.unsubscribeRoomList);
+  const requestRoomList = useBattleSocketStore((state) => state.requestRoomList);
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
+
+  useEffect(() => {
+    // 소켓 연결 후 방 목록 수신 구독 + 초기 요청
+    const socket = connect();
+    if (!socket.connected) socket.connect();
+    subscribeRoomList();
+    requestRoomList();
+
+    return () => {
+      unsubscribeRoomList();
+    };
+  }, [connect, subscribeRoomList, unsubscribeRoomList, requestRoomList]);
 
   const handleStartBattle = async () => {
     if (!user?.id) {

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -7,6 +7,7 @@ import type {
   RoomPlayerPayload,
   RoomStateSyncPayload,
 } from '@shared/types/room';
+import type { Room } from '@shared/types/room';
 import type { Socket } from 'socket.io-client';
 import { create } from 'zustand';
 
@@ -46,7 +47,9 @@ interface BattleSocketState {
   isConnected: boolean;
   roomAvailability: RoomAvailabilityResponseDTO | null;
   spectatorCount: number;
+  rooms: Room[];
   availabilityListener: ((payload: RoomAvailabilityResponseDTO) => void) | null;
+  roomListListener: ((rooms: Room[]) => void) | null;
   joinedListener: ((payload: { playerCount: number }) => void) | null;
   leftListener: ((payload: { playerCount: number }) => void) | null;
   connect: () => Socket;
@@ -59,6 +62,9 @@ interface BattleSocketState {
   subscribeRoomAvailability: (roomId: string) => void;
   unsubscribeRoomAvailability: () => void;
   resumeSession: (options?: { roomId?: string; roleHint?: string }) => Promise<void>;
+  subscribeRoomList: () => void;
+  unsubscribeRoomList: () => void;
+  requestRoomList: () => void;
 }
 
 export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
@@ -66,7 +72,9 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
   isConnected: false,
   roomAvailability: null,
   spectatorCount: 0,
+  rooms: [],
   availabilityListener: null,
+  roomListListener: null,
   joinedListener: null,
   leftListener: null,
   // 단일 소켓 인스턴스를 유지하고 기본 연결 상태를 관리합니다.
@@ -292,5 +300,28 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
       username: session.username,
       avatarUrl: session.avatarUrl,
     });
+  },
+  subscribeRoomList: () => {
+    const socket = get().connect();
+    const handleRoomList = (rooms: Room[]) => set({ rooms });
+
+    // 기존 리스너 제거 후 등록
+    const { roomListListener } = get();
+    if (roomListListener) {
+      socket.off(SOCKET_EVENT.ROOM_LIST, roomListListener);
+    }
+    socket.on(SOCKET_EVENT.ROOM_LIST, handleRoomList);
+    set({ roomListListener: handleRoomList });
+  },
+  unsubscribeRoomList: () => {
+    const socket = get().socket;
+    const { roomListListener } = get();
+    if (!socket || !roomListListener) return;
+    socket.off(SOCKET_EVENT.ROOM_LIST, roomListListener);
+    set({ roomListListener: null });
+  },
+  requestRoomList: () => {
+    const socket = get().connect();
+    socket.emit(SOCKET_EVENT.ROOM_LIST_REQUEST);
   },
 }));

--- a/packages/constants/socket-event.ts
+++ b/packages/constants/socket-event.ts
@@ -20,6 +20,7 @@ export const SOCKET_EVENT = {
   JOIN_ROOM: 'join-room', // 방 입장 (Player/Spectator)
   LEAVE_ROOM: 'leave-room', // 방 나가기
   SEND_CHAT: 'send-chat', // 관전자 채팅 전송
+  ROOM_LIST_REQUEST: 'room-list-request', // 방 목록 요청
 
   // --- Server -> Client (응답/알림) ---
   ROOM_AVAILABILITY: 'room-availability', // 방 인원 확인 결과
@@ -28,6 +29,7 @@ export const SOCKET_EVENT = {
   ROOM_USER_JOINED: 'room-joined', // 새 유저 입장 알림
   ROOM_USER_LEFT: 'room-left', // 유저 퇴장 알림
   RECEIVE_CHAT: 'receive-chat', // 관전자 채팅 수신(일반/시스템)
+  ROOM_LIST: 'room-list', // 방 목록 응답/브로드캐스트
 
   // === Matching ===
   MATCH_SUCCESS: 'match-success', // 매칭 성공 알림


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 메인 페이지에 실시간 배틀 목록 UI를 추가하고 소켓으로 방 리스트를 구독하도록 구성
- 배틀 재접속/관전 로직을 보완해 방 삭제 없이 재입장이 가능하도록 하고, `CODE_CHANGE` 브로드캐스트가 유지되게 수정
- 관전하기 버튼을 통해 실제 방에 `spectator`로 `JOIN_ROOM`을 호출하도록 연결

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #87
- close #88

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 메인 페이지: 방 목록 소켓 구독, 통계 카드/필터/배틀 카드 UI 추가, 관전하기 버튼 활성화.
- `RoomCardList` 컴포넌트 분리 및 관전 버튼 상태 관리(`joiningRoomId`).
- `BattlePage`: 소켓 재연결 시 `resumeSession→joinRoom` 재시도로 방 재입장 보장.
- `CodeEditor`: `me.userId` 없으면 `CODE_CHANGE` 전송 차단, 항상 방에 등록된 `userId` 사용.
- `RoomGateway`: 정원 체크를 “새 플레이어 추가”에만 적용, 기존 플레이어 재접속은 허용.
- `MatchingService`: 매칭 완료 후 한쪽이 끊겨도 방/배틀을 삭제하지 않고 유지해 재접속 가능하도록 변경.

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### MainPage UI

<img width="1506" height="813" alt="image" src="https://github.com/user-attachments/assets/00487baa-ed8a-425e-b03f-a2d3777d2ad0" />

### 배틀 중인 방이 없을 때

<img width="1501" height="814" alt="image" src="https://github.com/user-attachments/assets/00402d7a-a51a-485f-800b-897e1cc83c25" />

### 재접속 로그


https://github.com/user-attachments/assets/879f1104-d228-45f2-8d7c-3ac7229f25cd



## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 메인에서 실시간 배틀을 한눈에 보고 바로 관전/입장할 수 있도록 목록 UI와 소켓 흐름을 수정
- 배틀 중 재접속 시 방이 사라지거나 `ROOM_FULL/ROOM_NOT_FOUND`로 막히는 문제를 해소해 `CODE_CHANGE` 브로드캐스트가 끊기지 않게 함


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 커밋에 sub-message 자세하게 정리해뒀습니다
- 매칭 로직에서 매칭이 끊긴다면 방을 즉시 삭제하는 로직이 있는데 이 부분이 현재 배틀이 생성되고 이후에도 플레이어 접속이 끊긴다면 바로 방이 삭제되고 있습니다. 현재는 `cancelMatching`에서 `status === 'MATCHED'` 추가했습니다
- 재접속 시 더 안전하게 복구할 수 있는 방법(예: 서버가 배틀 상태를 재전송) 제안 있으면 공유해주세요
- 현재는 재접속 때 발생하는 소켓 이벤트가 너무 많이 있습니다, 추후에 리팩토링에 수정을 해야할 것 같아요

## 추가한 내용
- 