### PR TITLE
[FEAT] 매칭 중 상대방 연결 끊김 처리 (#92)

### DIFF
--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -35,7 +35,7 @@ export default function MatchingSuccess() {
   const { opponent, myRate } = matchResult;
 
   return (
-    <div className="flex min-h-screen w-full flex-col items-center justify-center gap-10 select-none">
+    <div className="flex gap-4 w-full flex-col items-center justify-center select-none">
       {/* 매칭 성공 메시지 */}
       <div className="text-center">
         <div className="flex justify-center">
@@ -47,7 +47,7 @@ export default function MatchingSuccess() {
         <p className="mt-2 text-lg text-base-primary">2명의 플레이어가 모였습니다</p>
       </div>
 
-      <div className="flex items-center justify-center gap-24 w-2/3 max-w-6xl mx-auto bg-base-faint rounded-3xl py-12">
+      <div className="flex items-center justify-center gap-24 w-2/3 max-w-4xl mx-auto bg-base-faint rounded-3xl py-10">
         {/* 내 정보 */}
         <div className="flex flex-col items-center gap-4">
           <div className="flex h-24 w-24 items-center justify-center rounded-full">

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -1,0 +1,54 @@
+import { AlertCircle } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+interface ToastProps {
+  message: string;
+  onClose: () => void;
+  duration?: number;
+}
+
+export default function Toast({ message, onClose, duration = 2000 }: ToastProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const onCloseRef = useRef(onClose);
+
+  // onClose 참조를 항상 최신으로 유지
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    // 마운트 직후 애니메이션 트리거
+    const animationFrame = requestAnimationFrame(() => {
+      setIsVisible(true);
+    });
+
+    // duration 후 사라지기 시작
+    const hideTimer = setTimeout(() => {
+      setIsVisible(false);
+    }, duration);
+
+    // 페이드 아웃 애니메이션 후 완전히 제거
+    const removeTimer = setTimeout(() => {
+      onCloseRef.current();
+    }, duration + 300);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      clearTimeout(hideTimer);
+      clearTimeout(removeTimer);
+    };
+  }, [duration]);
+
+  return (
+    <div
+      className={`fixed top-20 left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ease-out ${
+        isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'
+      }`}
+    >
+      <div className="flex items-center gap-3 rounded-lg border-2 border-pink-05 bg-pink-05/10 backdrop-blur-sm px-4 py-3 shadow-lg">
+        <AlertCircle className="h-5 w-5 text-pink-05" />
+        <p className="text-sm">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -42,9 +42,9 @@ function MatchingPage() {
   }
 
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Header rightContent={<MatchingCancelButton />} />
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-1 items-center justify-center">
         <MatchingWait waitTime={waitTime} />
       </div>
       {toastMessage && (
@@ -55,7 +55,7 @@ function MatchingPage() {
           }}
         />
       )}
-    </>
+    </div>
   );
 }
 

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -34,10 +34,12 @@ function MatchingPage() {
 
   if (matchResult) {
     return (
-      <>
+      <div className="flex min-h-screen flex-col">
         <Header hideUserMenu />
-        <MatchingSuccess />
-      </>
+        <div className="flex flex-1 items-center justify-center">
+          <MatchingSuccess />
+        </div>
+      </div>
     );
   }
 

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -4,11 +4,14 @@ import Header from '@/components/Header/Header';
 import { MatchingCancelButton } from '@/components/Matching/MatchingCancelButton';
 import MatchingSuccess from '@/components/Matching/MatchingSuccess';
 import MatchingWait from '@/components/Matching/MatchingWait';
+import Toast from '@/components/ui/Toast';
 import { useMatchingStore } from '@/stores/matchingStore';
 
 function MatchingPage() {
   const [waitTime, setWaitTime] = useState(0);
   const matchResult = useMatchingStore((state) => state.matchResult);
+  const toastMessage = useMatchingStore((state) => state.toastMessage);
+  const clearToast = useMatchingStore((state) => state.clearToast);
 
   // 타이머
   useEffect(() => {
@@ -44,6 +47,14 @@ function MatchingPage() {
       <div className="flex min-h-screen items-center justify-center">
         <MatchingWait waitTime={waitTime} />
       </div>
+      {toastMessage && (
+        <Toast
+          message={toastMessage}
+          onClose={() => {
+            clearToast();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/stores/matchingStore.ts
+++ b/apps/web/src/stores/matchingStore.ts
@@ -28,7 +28,7 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
   stats: null,
   timeoutMessage: null,
 
-  // MATCH_SUCCESS, STATS_UPDATE, MATCHING_TIMEOUT 이벤트 리스너 등록
+  // MATCH_SUCCESS, STATS_UPDATE, MATCHING_TIMEOUT, OPPONENT_DISCONNECTED 이벤트 리스너 등록
   registerMatchingListeners: (socket: Socket) => {
     const handleMatchSuccess = (data: MatchingSuccessResponse) => {
       set({ matchResult: data });
@@ -42,13 +42,23 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
       set({ timeoutMessage: data.message });
     };
 
+    const handleOpponentDisconnected = (data: { message: string }) => {
+      // TODO: 토스트 메시지 표시
+      alert(data.message);
+
+      // 상태 초기화
+      get().cleanup();
+    };
+
     // 기존 리스너 제거 후 새로 등록
     socket.off(SOCKET_EVENT.MATCH_SUCCESS);
     socket.off(SOCKET_EVENT.STATS_UPDATE);
     socket.off(SOCKET_EVENT.MATCHING_TIMEOUT);
+    socket.off(SOCKET_EVENT.OPPONENT_DISCONNECTED);
     socket.on(SOCKET_EVENT.MATCH_SUCCESS, handleMatchSuccess);
     socket.on(SOCKET_EVENT.STATS_UPDATE, handleStatsUpdate);
     socket.on(SOCKET_EVENT.MATCHING_TIMEOUT, handleMatchingTimeout);
+    socket.on(SOCKET_EVENT.OPPONENT_DISCONNECTED, handleOpponentDisconnected);
   },
 
   // 매칭 관련 소켓 리스너 제거
@@ -56,6 +66,7 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
     socket.off(SOCKET_EVENT.MATCH_SUCCESS);
     socket.off(SOCKET_EVENT.STATS_UPDATE);
     socket.off(SOCKET_EVENT.MATCHING_TIMEOUT);
+    socket.off(SOCKET_EVENT.OPPONENT_DISCONNECTED);
   },
 
   // 매칭 시작

--- a/apps/web/src/stores/matchingStore.ts
+++ b/apps/web/src/stores/matchingStore.ts
@@ -15,18 +15,21 @@ interface MatchingStore {
   matchResult: MatchingSuccessResponse | null;
   stats: MatchingStats | null;
   timeoutMessage: string | null;
+  toastMessage: string | null;
 
   registerMatchingListeners: (socket: Socket) => void;
   unregisterMatchingListeners: (socket: Socket) => void;
   startMatching: (userId: string, socketId: string) => Promise<void>;
   cancelMatching: (userId: string) => Promise<void>;
   cleanup: () => void;
+  clearToast: () => void;
 }
 
 export const useMatchingStore = create<MatchingStore>((set, get) => ({
   matchResult: null,
   stats: null,
   timeoutMessage: null,
+  toastMessage: null,
 
   // MATCH_SUCCESS, STATS_UPDATE, MATCHING_TIMEOUT, OPPONENT_DISCONNECTED 이벤트 리스너 등록
   registerMatchingListeners: (socket: Socket) => {
@@ -43,8 +46,7 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
     };
 
     const handleOpponentDisconnected = (data: { message: string }) => {
-      // TODO: 토스트 메시지 표시
-      alert(data.message);
+      set({ toastMessage: data.message });
 
       // 상태 초기화
       get().cleanup();
@@ -100,5 +102,10 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
   // 정리
   cleanup: () => {
     set({ matchResult: null, stats: null, timeoutMessage: null });
+  },
+
+  // 토스트 메시지 제거
+  clearToast: () => {
+    set({ toastMessage: null });
   },
 }));


### PR DESCRIPTION
## 🔍 PR 요약

매칭 중 상대방 연결 끊김 시 토스트 알림을 표시 및 매칭 대기 화면으로 이동

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #92 

## 🛠️ 주요 변경 사항

- Toast 컴포넌트 구현 (슬라이드 다운 애니메이션, 2초 자동 제거)
- matchingStore에 토스트 메시지 상태 및 OPPONENT_DISCONNECTED 리스너 추가
- MatchingPage에서 토스트 알림 표시

## 📸 스크린샷

https://github.com/user-attachments/assets/cbdae9a6-768f-45ee-8917-a7ec8498d565

## 🧠 의도 및 배경

매칭 완료 후 카운트다운 중 상대방의 연결이 끊기면 사용자에게 알림을 제공하기 위함

## 💬 리뷰 요구사항

- 토스트 메시지를 2초간 표시하는 것
- 토스트 메시지 문구 검토
  - 현재: "상대방의 연결이 끊겨 매칭이 취소되었습니다."
  - 상대방 연결 끊김 시 표시되는 토스트 문구를 사용자가 다시 매칭 대기 상태로 이동하는 흐름을 반영해 “상대방의 연결이 끊어졌습니다. 다시 매칭 중입니다.” 등의 형태로 수정하는 것이 더 좋을지 의견 부탁드립니다.
