### PR TITLE
[FEAT] 배틀 문제 선정 및 클라이언트 전송 구현 (#103)

### DIFF
--- a/apps/api/src/battle/battle.module.ts
+++ b/apps/api/src/battle/battle.module.ts
@@ -3,8 +3,10 @@ import { Module } from '@nestjs/common';
 import { BattleGateway } from '@/battle/battle.gateway';
 import { BattleService } from '@/battle/battle.service';
 import { BattleRedisService } from '@/battle/battle-redis.service';
+import { ProblemModule } from '@/problem/problem.module';
 
 @Module({
+  imports: [ProblemModule],
   providers: [BattleService, BattleRedisService, BattleGateway],
   exports: [BattleService],
 })

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -4,14 +4,24 @@ import { Battle, BattleUser, CreateBattleDTO, UpdateUserCodeDTO } from '@package
 import { RoomUser } from '@packages/types/user';
 
 import { BattleRedisService } from '@/battle/battle-redis.service';
+import { ProblemService } from '@/problem/problem.service';
 
 @Injectable()
 export class BattleService {
-  constructor(private readonly battleRedisService: BattleRedisService) {}
+  constructor(
+    private readonly battleRedisService: BattleRedisService,
+    private readonly problemService: ProblemService,
+  ) {}
 
   async createBattle(dto: CreateBattleDTO): Promise<Battle> {
     // TODO: 배틀 ID 생성 로직 추가
     const battleId = `battle-${Date.now()}`;
+
+    // 임시 문제 선택
+    const problem = await this.problemService.findFirst();
+    if (!problem) {
+      throw new Error('No problems available.');
+    }
 
     const users: BattleUser[] = dto.users.map((userId) => ({
       userId,
@@ -20,7 +30,7 @@ export class BattleService {
       language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
       progress: {
         passedCount: 0,
-        totalCount: 0,
+        totalCount: Array.isArray(problem.testcases) ? (problem.testcases as any[]).length : 0,
       },
       isConnected: true,
       isFinished: false,
@@ -29,6 +39,7 @@ export class BattleService {
     const battle: Battle = {
       battleId,
       roomId: dto.roomId,
+      problemId: problem.id,
       status: 'running',
       config: {
         duration: dto.config.duration || BATTLE_CONFIG.DURATION,
@@ -97,6 +108,12 @@ export class BattleService {
 
   async getBattle(battleId: string): Promise<Battle | null> {
     // TODO: 권한 체크 추가 (사용자가 해당 배틀에 접근 가능한지 또는 비밀번호 존재 등)
+    return this.battleRedisService.getBattle(battleId);
+  }
+
+  async getBattleByRoomId(roomId: string): Promise<Battle | null> {
+    const battleId = await this.battleRedisService.getBattleIdByRoomId(roomId);
+    if (!battleId) return null;
     return this.battleRedisService.getBattle(battleId);
   }
 

--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -48,7 +48,13 @@ export class MatchingGateway implements OnGatewayDisconnect {
   }
 
   // 매칭 성공 이벤트를 두 유저에게 전송
-  emitMatchSuccess(user1: MatchingUser, user2: MatchingUser, room: Room, battle: Battle): void {
+  emitMatchSuccess(
+    user1: MatchingUser,
+    user2: MatchingUser,
+    room: Room,
+    battle: Battle,
+    problemInfo: { id: string; title: string },
+  ): void {
     // user1에게 전송
     this.server.to(user1.socketId).emit(SOCKET_EVENT.MATCH_SUCCESS, {
       roomId: room.roomId,
@@ -62,6 +68,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
         tier: user2.tier,
         rate: user2.myRate,
       },
+      problem: problemInfo,
     });
 
     // user2에게 전송
@@ -77,6 +84,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
         tier: user1.tier,
         rate: user1.myRate,
       },
+      problem: problemInfo,
     });
   }
 

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -158,7 +158,7 @@ export class MatchingService {
 
       try {
         // Room & Battle 생성
-        const { room, battle } = await this.createMatch(user1, user2);
+        const { room, battle, problem } = await this.createMatch(user1, user2);
 
         // 대기 시간 계산 및 저장
         const now = Date.now();
@@ -190,7 +190,11 @@ export class MatchingService {
           .exec();
 
         // 소켓 이벤트: 매칭 성공 알림
-        this.matchingGateway.emitMatchSuccess(user1, user2, room, battle);
+        const problemInfo = {
+          id: problem.id,
+          title: problem.title,
+        };
+        this.matchingGateway.emitMatchSuccess(user1, user2, room, battle, problemInfo);
 
         matchedUsers.push(user1, user2);
 

--- a/apps/api/src/problem/problem.service.ts
+++ b/apps/api/src/problem/problem.service.ts
@@ -27,7 +27,7 @@ export class ProblemService implements OnModuleInit {
 
   async importProblemsFromJson() {
     try {
-      const filePath = path.join(process.cwd(), 'data/problem_sample.json');
+      const filePath = path.join(__dirname, '../data/problem_sample.json');
       if (!fs.existsSync(filePath)) {
         this.logger.error(`File not found: ${filePath}`);
         return;
@@ -58,8 +58,8 @@ export class ProblemService implements OnModuleInit {
 
         problem.url = data.url;
         problem.title = data.title;
-        problem.timeLimit = data.time_limit;
-        problem.memoryLimit = data.memory_limit;
+        problem.timeLimit = data.timeLimit;
+        problem.memoryLimit = data.memoryLimit;
         problem.statement = data.statement;
         problem.input = data.input;
         problem.output = data.output;
@@ -79,5 +79,16 @@ export class ProblemService implements OnModuleInit {
 
   async findAll(): Promise<Problem[]> {
     return this.problemRepository.find();
+  }
+
+  async findFirst(): Promise<Problem | null> {
+    return this.problemRepository.findOne({
+      where: { difficulty: 'EASY' },
+      order: { id: 'ASC' },
+    });
+  }
+
+  async findOne(id: string): Promise<Problem | null> {
+    return this.problemRepository.findOne({ where: { id } });
   }
 }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -6,10 +6,12 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
+import { ProblemDataPayload } from '@packages/types/problem';
 import Redis from 'ioredis';
 import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
+import { ProblemService } from '@/problem/problem.service';
 
 import { CHAT_TYPE } from '../../../../packages/constants/chat';
 import {
@@ -33,6 +35,7 @@ export class RoomGateway {
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly roomService: RoomService,
     private readonly battleService: BattleService,
+    private readonly problemService: ProblemService,
   ) {}
 
   @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
@@ -168,6 +171,29 @@ export class RoomGateway {
       playerCount: room.currentPlayers.length,
       spectatorCount: room.currentSpectators.length,
     });
+
+    // 문제 정보 전송
+    const battle = await this.battleService.getBattleByRoomId(roomId);
+    if (battle) {
+      const problemEntity = await this.problemService.findOne(battle.problemId);
+      if (problemEntity) {
+        client.emit(SOCKET_EVENT.PROBLEM_INFO, {
+          id: problemEntity.id,
+          source: problemEntity.source,
+          difficulty: problemEntity.difficulty,
+          tags: problemEntity.tags,
+          url: problemEntity.url,
+          title: problemEntity.title,
+          timeLimit: problemEntity.timeLimit,
+          memoryLimit: problemEntity.memoryLimit,
+          statement: problemEntity.statement,
+          input: problemEntity.input,
+          output: problemEntity.output,
+          note: problemEntity.note,
+          examples: problemEntity.examples,
+        } as ProblemDataPayload);
+      }
+    }
 
     // 최신 인원 정보를 브로드캐스트
     const availability = await this.roomService.getRoomAvailability(roomId);

--- a/apps/api/src/room/room.module.ts
+++ b/apps/api/src/room/room.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { BattleModule } from '@/battle/battle.module';
+import { ProblemModule } from '@/problem/problem.module';
 
 import { RoomController } from './room.controller';
 import { RoomGateway } from './room.gateway';
 import { RoomService } from './room.service';
 
 @Module({
-  imports: [BattleModule],
+  imports: [BattleModule, ProblemModule],
   providers: [RoomService, RoomGateway],
   controllers: [RoomController],
   exports: [RoomService], // MatchingModule에서 사용할 수 있도록 export

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -2,8 +2,11 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { BATTLE_CONFIG } from '@packages/constants/battle';
 import { Battle } from '@packages/types/battle';
 import { MatchingUser } from '@packages/types/matching';
+import { ProblemDataPayload } from '@packages/types/problem';
 import { RoomUser } from '@packages/types/user';
 import Redis from 'ioredis';
+
+import { ProblemService } from '@/problem/problem.service';
 
 import { ROOM_CONFIG } from '../../../../packages/constants/socket-event';
 import { Room, RoomAvailabilityResponseDTO, RoomSettings } from '../../../../packages/types/room';
@@ -23,6 +26,7 @@ export class RoomService {
   constructor(
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly BattleService: BattleService,
+    private readonly problemService: ProblemService,
   ) {}
 
   // 기본 방 생성
@@ -57,7 +61,7 @@ export class RoomService {
   async createMatchedRoom(
     user1: MatchingUser,
     user2: MatchingUser,
-  ): Promise<{ room: Room; battle: Battle }> {
+  ): Promise<{ room: Room; battle: Battle; problem: ProblemDataPayload }> {
     try {
       // 방 생성: 유저 정보와 즉시 시작 상태 주입
       const now = new Date();
@@ -98,10 +102,31 @@ export class RoomService {
         users: room.currentPlayers.map((player) => player.userId),
       });
 
+      const problemEntity = await this.problemService.findOne(battle.problemId);
+      if (!problemEntity) {
+        throw new Error('Problem not found for the battle.');
+      }
+
+      const problem: ProblemDataPayload = {
+        id: problemEntity.id,
+        source: problemEntity.source,
+        difficulty: problemEntity.difficulty,
+        tags: problemEntity.tags,
+        url: problemEntity.url,
+        title: problemEntity.title,
+        timeLimit: problemEntity.timeLimit,
+        memoryLimit: problemEntity.memoryLimit,
+        statement: problemEntity.statement,
+        input: problemEntity.input,
+        output: problemEntity.output,
+        note: problemEntity.note,
+        examples: problemEntity.examples,
+      };
+
       this.logger.log(
         `Created matched room ${room.roomId} for users ${user1.userId} and ${user2.userId}`,
       );
-      return { room, battle };
+      return { room, battle, problem };
     } catch (error: unknown) {
       if (error instanceof Error)
         this.logger.error(`Failed to create matched room: ${error.message}`);

--- a/packages/constants/socket-event.ts
+++ b/packages/constants/socket-event.ts
@@ -30,6 +30,7 @@ export const SOCKET_EVENT = {
   ROOM_USER_LEFT: 'room-left', // 유저 퇴장 알림
   RECEIVE_CHAT: 'receive-chat', // 관전자 채팅 수신(일반/시스템)
   ROOM_LIST: 'room-list', // 방 목록 응답/브로드캐스트
+  PROBLEM_INFO: 'problem-info', // 배틀과 문제에 대한 정보
 
   // === Matching ===
   MATCH_SUCCESS: 'match-success', // 매칭 성공 알림

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -5,6 +5,7 @@ export type BattleResult = 'win' | 'lose' | 'draw';
 export interface Battle {
   battleId: string;
   roomId: string;
+  problemId: string;
   status: BattleStatus;
 
   config: {

--- a/packages/types/problem.ts
+++ b/packages/types/problem.ts
@@ -5,8 +5,8 @@ export interface ProblemData {
   tags: string | string[];
   url: string;
   title: string;
-  time_limit: number;
-  memory_limit: number;
+  timeLimit: number;
+  memoryLimit: number;
   statement: string;
   input: string;
   output: string;
@@ -14,3 +14,5 @@ export interface ProblemData {
   examples: { input: string; output: string }[];
   testcases: { input: string; output: string }[];
 }
+
+export interface ProblemDataPayload extends Omit<ProblemData, 'testcases'> {}


### PR DESCRIPTION
## 🔍 PR 요약

- Problem Entity, Service, Controller, Module 생성
- Battle 생성 시 EASY 난이도 문제 자동 선택
- Room join 시 클라이언트에 문제 정보 전송

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #103 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- `JOIN_ROOM` 요청 시 `PROBLEM_INFO` 이벤트를 통해 문제 데이터 전송
- apps/api/src/battle/battle.service.ts : 배틀 생성 시 문제도 선택
  - 현재는 난이도 EASY 문제 임시 선
- apps/api/src/matching/matching.gateway.ts : 매칭 성공 시 성공 이벤트와 함께 문제 전송
  - `MATCH_SUCCESS` : problemInfo 데이터 추가(id, title)
- 문제 JSON 데이터 경로를 수정
  - `process.cwd()` 보다는 `__dirname`이 더 안전

## 📸 스크린샷 (선택)

- 참가자와 관전자 모두 데이터 전송 확인했습니다.

<img width="795" height="219" alt="image" src="https://github.com/user-attachments/assets/57ff0ca9-6f4f-4b57-8345-58a2a4b1d82f" />

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 배틀 페이지 입장 시 문제 정보 전송

## 💬 리뷰 요구사항(선택)

- 문제 데이터를 전송하긴 하지만 프론트에서 이를 처리하는 부분은 아직 없어서 추가해야 할 것 같습니다!!