### PR TITLE
[FEAT] Message Queue에서 Job 가져오기 (#114)

### DIFF
--- a/apps/judge/package.json
+++ b/apps/judge/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/bullmq": "^11.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -28,6 +29,7 @@
     "@nestjs/schedule": "^6.1.0",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.1.9",
+    "bullmq": "^5.13.0",
     "cron": "^4.4.0",
     "ioredis": "^5.8.2",
     "mysql2": "^3.15.3",

--- a/apps/judge/src/app.module.ts
+++ b/apps/judge/src/app.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { RedisModule } from './redis/redis.module';
+import { SubmissionModule } from './submission/submission.module';
+
 @Module({
   imports: [
     // 환경변수 설정
@@ -26,6 +29,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
       }),
       inject: [ConfigService],
     }),
+    // Redis 연결 설정
+    RedisModule,
+    SubmissionModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/judge/src/redis/redis.module.ts
+++ b/apps/judge/src/redis/redis.module.ts
@@ -1,0 +1,51 @@
+import { BullModule } from '@nestjs/bullmq';
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+const DEFAULT_REDIS_PORT = 6379;
+
+@Global()
+@Module({
+  imports: [
+    BullModule.forRootAsync({
+      useFactory: (configService: ConfigService) => ({
+        connection: createRedisOptions(configService),
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      useFactory: (configService: ConfigService) => {
+        const redis = new Redis(createRedisOptions(configService));
+
+        redis.on('connect', () => {
+          console.warn('Redis connected successfully');
+        });
+
+        redis.on('error', (error) => {
+          console.error('Redis connection error:', error);
+        });
+
+        return redis;
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [REDIS_CLIENT],
+})
+export class RedisModule {}
+
+function createRedisOptions(configService: ConfigService): { host?: string; port: number } {
+  const host = configService.get<string>('REDIS_HOST');
+  const portValue = configService.get<string>('REDIS_PORT');
+  const port = typeof portValue === 'number' ? portValue : Number(portValue ?? DEFAULT_REDIS_PORT);
+
+  return {
+    host,
+    port: Number.isFinite(port) ? port : DEFAULT_REDIS_PORT,
+  };
+}

--- a/apps/judge/src/submission/submission.constants.ts
+++ b/apps/judge/src/submission/submission.constants.ts
@@ -1,0 +1,3 @@
+export const SUBMISSION_QUEUE = 'submission-queue';
+// 큐 작업자 동시 처리 수
+export const SUBMISSION_WORKER_CONCURRENCY = 5;

--- a/apps/judge/src/submission/submission.module.ts
+++ b/apps/judge/src/submission/submission.module.ts
@@ -1,0 +1,11 @@
+import { BullModule } from '@nestjs/bullmq';
+import { Module } from '@nestjs/common';
+
+import { SUBMISSION_QUEUE } from './submission.constants';
+import { SubmissionProcessor } from './submission.processor';
+
+@Module({
+  imports: [BullModule.registerQueue({ name: SUBMISSION_QUEUE })],
+  providers: [SubmissionProcessor],
+})
+export class SubmissionModule {}

--- a/apps/judge/src/submission/submission.payload.ts
+++ b/apps/judge/src/submission/submission.payload.ts
@@ -1,0 +1,86 @@
+export type SubmissionJobType = 'SUBMISSION' | 'TEST';
+
+export interface SubmissionJobPayload {
+  submissionId: number | null;
+  problemId: number;
+  code: string;
+  language: string;
+  type: SubmissionJobType;
+  userId?: string;
+  socketId?: string;
+}
+
+export function parseSubmissionJobPayload(payload: unknown): SubmissionJobPayload {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Job payload must be an object.');
+  }
+
+  const data = payload as Record<string, unknown>;
+  const type = parseJobType(data.type);
+  const problemId = parsePositiveNumber(data.problemId, 'problemId');
+  const code = parseNonEmptyString(data.code, 'code');
+  const language = parseNonEmptyString(data.language, 'language');
+  const submissionId = parseNullableNumber(data.submissionId, 'submissionId');
+
+  if (type === 'SUBMISSION' && submissionId === null) {
+    throw new Error('"submissionId" is required for SUBMISSION jobs.');
+  }
+
+  return {
+    submissionId,
+    problemId,
+    code,
+    language,
+    type,
+    userId: parseOptionalString(data.userId, 'userId'),
+    socketId: parseOptionalString(data.socketId, 'socketId'),
+  };
+}
+
+function parseJobType(value: unknown): SubmissionJobType {
+  if (value !== 'SUBMISSION' && value !== 'TEST') {
+    throw new Error('"type" must be either "SUBMISSION" or "TEST".');
+  }
+
+  return value;
+}
+
+function parsePositiveNumber(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`"${field}" must be a positive number.`);
+  }
+
+  return value;
+}
+
+function parseNullableNumber(value: unknown, field: string): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`"${field}" must be a positive number or null.`);
+  }
+
+  return value;
+}
+
+function parseNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`"${field}" must be a non-empty string.`);
+  }
+
+  return value;
+}
+
+function parseOptionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`"${field}" must be a non-empty string if provided.`);
+  }
+
+  return value;
+}

--- a/apps/judge/src/submission/submission.payload.ts
+++ b/apps/judge/src/submission/submission.payload.ts
@@ -2,7 +2,7 @@ export type SubmissionJobType = 'SUBMISSION' | 'TEST';
 
 export interface SubmissionJobPayload {
   submissionId: number | null;
-  problemId: number;
+  problemId: string;
   code: string;
   language: string;
   type: SubmissionJobType;
@@ -17,7 +17,7 @@ export function parseSubmissionJobPayload(payload: unknown): SubmissionJobPayloa
 
   const data = payload as Record<string, unknown>;
   const type = parseJobType(data.type);
-  const problemId = parsePositiveNumber(data.problemId, 'problemId');
+  const problemId = parseNonEmptyString(data.problemId, 'problemId');
   const code = parseNonEmptyString(data.code, 'code');
   const language = parseNonEmptyString(data.language, 'language');
   const submissionId = parseNullableNumber(data.submissionId, 'submissionId');
@@ -40,14 +40,6 @@ export function parseSubmissionJobPayload(payload: unknown): SubmissionJobPayloa
 function parseJobType(value: unknown): SubmissionJobType {
   if (value !== 'SUBMISSION' && value !== 'TEST') {
     throw new Error('"type" must be either "SUBMISSION" or "TEST".');
-  }
-
-  return value;
-}
-
-function parsePositiveNumber(value: unknown, field: string): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    throw new Error(`"${field}" must be a positive number.`);
   }
 
   return value;

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -1,0 +1,28 @@
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+
+import { SUBMISSION_QUEUE, SUBMISSION_WORKER_CONCURRENCY } from './submission.constants';
+import { parseSubmissionJobPayload, SubmissionJobPayload } from './submission.payload';
+
+@Processor(SUBMISSION_QUEUE, { concurrency: SUBMISSION_WORKER_CONCURRENCY })
+export class SubmissionProcessor extends WorkerHost {
+  private readonly logger = new Logger(SubmissionProcessor.name);
+
+  async process(job: Job<SubmissionJobPayload>): Promise<void> {
+    const payload = parseSubmissionJobPayload(job.data);
+
+    this.logger.log(
+      `Job ${job.id ?? 'unknown'} received: type=${payload.type}, problemId=${payload.problemId}, submissionId=${payload.submissionId ?? 'null'}`,
+    );
+
+    // TODO: 연결된 채점 로직(Docker 실행 등)으로 payload 전달
+    await Promise.resolve();
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<SubmissionJobPayload> | undefined, error: Error): void {
+    const jobId = job?.id ?? 'unknown';
+    this.logger.error(`Job ${jobId} failed: ${error.message}`, error.stack);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
 
   apps/judge:
     dependencies:
+      '@nestjs/bullmq':
+        specifier: ^11.0.0
+        version: 11.0.4(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(bullmq@5.66.5)
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -198,6 +201,9 @@ importers:
       '@nestjs/websockets':
         specifier: ^11.1.9
         version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(@nestjs/platform-socket.io@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      bullmq:
+        specifier: ^5.13.0
+        version: 5.66.5
       cron:
         specifier: ^4.4.0
         version: 4.4.0
@@ -1052,6 +1058,9 @@ packages:
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
 
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -1183,8 +1192,51 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@nestjs/bull-shared@11.0.4':
+    resolution: {integrity: sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
+  '@nestjs/bullmq@11.0.4':
+    resolution: {integrity: sha512-wBzK9raAVG0/6NTMdvLGM4/FQ1lsB35/pYS8L6a0SDgkTiLpd7mAjQ8R692oMx5s7IjvgntaZOuTUrKYLNfIkA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      bullmq: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@nestjs/cli@11.0.14':
     resolution: {integrity: sha512-YwP03zb5VETTwelXU+AIzMVbEZKk/uxJL+z9pw0mdG9ogAtqZ6/mpmIM4nEq/NU8D0a7CBRLcMYUmWW/55pfqw==}
@@ -2208,6 +2260,9 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bullmq@5.66.5:
+    resolution: {integrity: sha512-DC1E7P03L+TfNHv+2SGxwNYvtb0oJPODWSKkWdfis0heU5zFW16vjM7fCjwlxMdGWw2w28EI3mTRfYLEHeQQSw==}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2447,6 +2502,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
 
   cron@4.3.5:
     resolution: {integrity: sha512-hKPP7fq1+OfyCqoePkKfVq7tNAdFwiQORr4lZUHwrf0tebC65fYEeWgOrXOL6prn1/fegGOdTfrM6e34PJfksg==}
@@ -3095,6 +3154,10 @@ packages:
     resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
     engines: {node: '>=12.22.0'}
 
+  ioredis@5.9.1:
+    resolution: {integrity: sha512-BXNqFQ66oOsR82g9ajFFsR8ZKrjVvYCLyeML9IvSMAsP56XH2VXBdZjmI11p65nXXJxTEt1hie3J2QeFJVgrtQ==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3707,6 +3770,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+
   multer@2.0.2:
     resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
@@ -3756,6 +3826,10 @@ packages:
 
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5590,6 +5664,8 @@ snapshots:
 
   '@ioredis/commands@1.4.0': {}
 
+  '@ioredis/commands@1.5.0': {}
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -5827,12 +5903,44 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nestjs/bull-shared@11.0.4(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)':
+    dependencies:
+      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(@nestjs/websockets@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      tslib: 2.8.1
+
+  '@nestjs/bullmq@11.0.4(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(bullmq@5.66.5)':
+    dependencies:
+      '@nestjs/bull-shared': 11.0.4(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)
+      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(@nestjs/websockets@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      bullmq: 5.66.5
+      tslib: 2.8.1
 
   '@nestjs/cli@11.0.14(@types/node@22.19.2)':
     dependencies:
@@ -6894,6 +7002,18 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bullmq@5.66.5:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.9.1
+      msgpackr: 1.11.5
+      node-abort-controller: 3.1.1
+      semver: 7.7.3
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -7106,6 +7226,10 @@ snapshots:
       typescript: 5.9.3
 
   create-require@1.1.1: {}
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
 
   cron@4.3.5:
     dependencies:
@@ -7807,6 +7931,20 @@ snapshots:
   ioredis@5.8.2:
     dependencies:
       '@ioredis/commands': 1.4.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ioredis@5.9.1:
+    dependencies:
+      '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
       debug: 4.4.3
       denque: 2.1.0
@@ -8572,6 +8710,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   multer@2.0.2:
     dependencies:
       append-field: 1.0.0
@@ -8619,6 +8773,11 @@ snapshots:
   node-emoji@1.11.0:
     dependencies:
       lodash: 4.17.21
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-int64@0.4.0: {}
 


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- Judge 서버에 BullMQ 워커를 연결해 submission-queue에서 Job을 수신/검증하고 로그로 확인 가능하도록 구현

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #114 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- RedisModule에서 BullMQ Redis 연결과 Redis 클라이언트를 함께 초기화하도록 구성
- SubmissionModule에서 submission-queue 등록 및 워커(provider) 등록
- SubmissionProcessor에서 Job 수신/검증/실패 로그 처리 및 concurrency 설정
- SubmissionJobPayload 검증 로직 추가
- BullMQ 관련 의존성 추가 (@nestjs/bullmq, bullmq)

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### 로그 테스트

<img width="801" height="97" alt="image" src="https://github.com/user-attachments/assets/c84cfddb-9773-4847-ab03-8047b3471450" />

<img width="1166" height="246" alt="image" src="https://github.com/user-attachments/assets/84414815-688b-4467-b953-8aeeb08c8224" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- API 서버가 Redis 큐에 넣은 제출 Job을 Judge 서버가 비동기로 받아 처리하기 위한 기반(Consumer/Processor)을 마련하기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- Job payload 검증 규칙(필수/선택 필드, 타입 제약)이 현재 요구사항에 맞는지 확인 부탁드립니다
