### PR TITLE
[FEAT]: 채점 서버 Redis Publisher 구현 (#100)

### DIFF
--- a/apps/judge/src/app.module.ts
+++ b/apps/judge/src/app.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { PubSubModule } from './pubsub/pubsub.module';
+import { RedisModule } from './redis/redis.module';
+
 @Module({
   imports: [
     // 환경변수 설정
@@ -26,6 +29,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
       }),
       inject: [ConfigService],
     }),
+
+    RedisModule,
+    PubSubModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/judge/src/pubsub/pubsub.module.ts
+++ b/apps/judge/src/pubsub/pubsub.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { PubsubService } from './pubsub.service';
+
+@Module({
+  providers: [PubsubService],
+  exports: [PubsubService],
+})
+export class PubSubModule {}

--- a/apps/judge/src/pubsub/pubsub.service.ts
+++ b/apps/judge/src/pubsub/pubsub.service.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { PUBSUB_CHANNELS } from '@packages/constants/pubsub';
-import type { FinalResultMessage, TestcaseUpdateMessage } from '@packages/types/pubsub';
 import type Redis from 'ioredis';
 
-import { REDIS_CLIENT } from '@/redis/redis.module';
+import { PUBSUB_CHANNELS } from '../../../../packages/constants/pubsub';
+import type { FinalResultMessage, TestcaseUpdateMessage } from '../../../../packages/types/pubsub';
+import { REDIS_CLIENT } from '../redis/redis.module';
 
 @Injectable()
 export class PubsubService {

--- a/apps/judge/src/pubsub/pubsub.service.ts
+++ b/apps/judge/src/pubsub/pubsub.service.ts
@@ -1,0 +1,46 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { PUBSUB_CHANNELS } from '@packages/constants/pubsub';
+import type { FinalResultMessage, TestcaseUpdateMessage } from '@packages/types/pubsub';
+import type Redis from 'ioredis';
+
+import { REDIS_CLIENT } from '@/redis/redis.module';
+
+@Injectable()
+export class PubsubService {
+  private readonly logger = new Logger(PubsubService.name);
+  private readonly CHANNEL = PUBSUB_CHANNELS.SUBMISSION_RESULT;
+
+  constructor(@Inject(REDIS_CLIENT) private readonly redisPublisher: Redis) {}
+
+  async publishTestcaseUpdate(message: TestcaseUpdateMessage): Promise<void> {
+    try {
+      const payload = JSON.stringify(message);
+      await this.redisPublisher.publish(this.CHANNEL, payload);
+      this.logger.log(
+        `Published TESTCASE_UPDATE for submission ${message.submissionId}: TC#${message.testcase.index} ${message.testcase.status} (${message.progress.completed}/${message.progress.total})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to publish testcase update for submission ${message.submissionId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  async publishFinalResult(message: FinalResultMessage): Promise<void> {
+    try {
+      const payload = JSON.stringify(message);
+      await this.redisPublisher.publish(this.CHANNEL, payload);
+      this.logger.log(
+        `Published FINAL_RESULT for submission ${message.submissionId}: ${message.status} (${message.result.passed}/${message.result.total})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to publish final result for submission ${message.submissionId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+}

--- a/apps/judge/src/redis/redis.module.ts
+++ b/apps/judge/src/redis/redis.module.ts
@@ -1,0 +1,33 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      useFactory: (configService: ConfigService) => {
+        const redis = new Redis({
+          host: configService.get('REDIS_HOST'),
+          port: configService.get('REDIS_PORT'),
+        });
+
+        redis.on('connect', () => {
+          console.warn('Redis connected successfully');
+        });
+
+        redis.on('error', (error) => {
+          console.error('Redis connection error:', error);
+        });
+
+        return redis;
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [REDIS_CLIENT],
+})
+export class RedisModule {}

--- a/packages/constants/pubsub.ts
+++ b/packages/constants/pubsub.ts
@@ -1,0 +1,3 @@
+export const PUBSUB_CHANNELS = {
+  SUBMISSION_RESULT: 'submission-result',
+} as const;

--- a/packages/types/pubsub.ts
+++ b/packages/types/pubsub.ts
@@ -1,0 +1,40 @@
+export type TestcaseStatus =
+  | 'ACCEPTED'
+  | 'WRONG_ANSWER'
+  | 'TIME_LIMIT_EXCEEDED'
+  | 'MEMORY_LIMIT_EXCEEDED'
+  | 'RUNTIME_ERROR'
+  | 'COMPILE_ERROR';
+
+// 각 테스트케이스 결과 전송 (실시간)
+export interface TestcaseUpdateMessage {
+  type: 'TESTCASE_UPDATE';
+  submissionId: number;
+  testcase: {
+    index: number;
+    status: TestcaseStatus;
+    time: number;
+    memory: number;
+  };
+  progress: {
+    completed: number; // 지금까지 실행 완료된 개수
+    passed: number; // 지금까지 통과한 개수
+    total: number;
+  };
+}
+
+// 최종 결과
+export interface FinalResultMessage {
+  type: 'FINAL_RESULT';
+  submissionId: number;
+  status: TestcaseStatus;
+  result: {
+    passed: number;
+    total: number;
+    time: number; // 최대 시간
+    memory: number; // 최대 메모리
+  };
+}
+
+// Pub/Sub 메시지 Union Type
+export type PubSubMessage = TestcaseUpdateMessage | FinalResultMessage;


### PR DESCRIPTION
## 🔍 PR 요약

- Redis 모듈 추가 및 PubSub 서비스 구현
- 테스트케이스별 실시간 진행 상황 전송 기능
- 최종 채점 결과 전송 기능
- submission-result 채널을 통한 메시지 발행

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- #100 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- apps/judge/src/pubsub/pubsub.service.ts : Redis Publish 함수 구현
  - `publishTestcaseUpdate` : 각 테스트별 결과 전송
  - `publishFinalResult` : 최종 채점 결과 전송
- packages/types/pubsub.ts : Pub/Sub 구조에서 사용되는 payload
  - `TestcaseUpdateMessage` : 각 테스트케이스 결과 payload
  - `FinalResultMessage` : 최종 결과 payload


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 채점 결과를 Redis Pub/Sub을 통해 API 서버에게 전달하기 위함

## 💬 리뷰 요구사항(선택)

- payload 구조 확인 부탁드립니다!
- path alias를 사용하려고 하니 경로를 인식하지 못하는 문제가 발생했습니다. 그래서 일단 상대경로로 수정했는데, 다른 분들은 이 부분이 문제가 없으신지 궁금합니다.
