### PR TITLE
[FEAT] 채점 서버 채점 로직 구현 (#127)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ node_modules
 .env.production
 .env.test
 .env.dev
+
+# Judge data
+judge-data/
+
+# Test files
+apps/judge/test-runner.ts

--- a/apps/judge/src/app.module.ts
+++ b/apps/judge/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { JudgeModule } from './judge/judge.module';
 import { PubSubModule } from './pubsub/pubsub.module';
 import { RedisModule } from './redis/redis.module';
 
@@ -32,6 +33,7 @@ import { RedisModule } from './redis/redis.module';
 
     RedisModule,
     PubSubModule,
+    JudgeModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/judge/src/judge/judge.checker.ts
+++ b/apps/judge/src/judge/judge.checker.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JudgeChecker {
+  compare(actual: string, expected: string): boolean {
+    return this.normalize(actual) === this.normalize(expected);
+  }
+
+  // 문자열 정규화
+  private normalize(str: string): string {
+    return str
+      .trim()
+      .replace(/\r\n/g, '\n') // Windows 개행 → Unix 개행
+      .replace(/\r/g, '\n'); // Old Mac 개행 → Unix 개행
+  }
+}

--- a/apps/judge/src/judge/judge.context.ts
+++ b/apps/judge/src/judge/judge.context.ts
@@ -31,15 +31,13 @@ export class JudgeContext {
     for (let i = this.lastProcessedIndex + 1; i < this.testcases.length; i++) {
       if (!this.reader.hasOutputFile(this.submissionId, i)) break;
 
-      const actualOutput = this.reader.readOutputFile(this.submissionId, i);
+      const outputResult = this.reader.readOutputFile(this.submissionId, i);
       const testcase = this.testcases[i];
 
-      const isCorrect = this.checker.compare(actualOutput, testcase.output);
+      const isCorrect = this.checker.compare(outputResult.output, testcase.output);
       const tcStatus: TestcaseStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';
 
-      // TODO: 각 테스트케이스 시간/메모리 데이터 읽기
-      const time = 0;
-      const memory = 0;
+      const { time, memory } = outputResult;
 
       await this.publishUpdate(i, tcStatus, time, memory);
       this.updateStatistics(tcStatus, time, memory);

--- a/apps/judge/src/judge/judge.context.ts
+++ b/apps/judge/src/judge/judge.context.ts
@@ -33,11 +33,14 @@ export class JudgeContext {
 
       const outputResult = this.reader.readOutputFile(this.submissionId, i);
       const testcase = this.testcases[i];
+      const { time, memory, status: runnerStatus } = outputResult;
 
-      const isCorrect = this.checker.compare(outputResult.output, testcase.output);
-      const tcStatus: TestcaseStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';
-
-      const { time, memory } = outputResult;
+      // ACCEPTED인 경우에만 output 비교하여 WRONG_ANSWER 판정
+      let tcStatus: TestcaseStatus = runnerStatus;
+      if (runnerStatus === 'ACCEPTED') {
+        const isCorrect = this.checker.compare(outputResult.output, testcase.output);
+        tcStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';
+      }
 
       await this.publishUpdate(i, tcStatus, time, memory);
       this.updateStatistics(tcStatus, time, memory);
@@ -85,12 +88,12 @@ export class JudgeContext {
   }
 
   private updateStatistics(status: TestcaseStatus, time: number, memory: number) {
-    this.maxTime = Math.max(this.maxTime, time);
-    this.maxMemory = Math.max(this.maxMemory, memory);
     if (status === 'ACCEPTED') {
       this.passed++;
+      this.maxTime = Math.max(this.maxTime, time);
+      this.maxMemory = Math.max(this.maxMemory, memory);
     } else {
-      this.finalStatus = status; // 하나라도 틀리면 최종 상태 업데이트
+      this.finalStatus = 'WRONG_ANSWER';
     }
   }
 }

--- a/apps/judge/src/judge/judge.context.ts
+++ b/apps/judge/src/judge/judge.context.ts
@@ -1,0 +1,98 @@
+import { TestcaseStatus } from '@packages/types/pubsub';
+
+import { PubsubService } from '../pubsub/pubsub.service';
+import { JudgeChecker } from './judge.checker';
+import { JudgeReader } from './judge.reader';
+import { Testcase } from './judge.types';
+
+export class JudgeContext {
+  private lastProcessedIndex = -1;
+  private passed = 0;
+  private maxTime = 0;
+  private maxMemory = 0;
+  private finalStatus: TestcaseStatus = 'ACCEPTED';
+
+  constructor(
+    public readonly submissionId: number,
+    private readonly testcases: any[],
+    private readonly reader: JudgeReader,
+    private readonly checker: JudgeChecker,
+    private readonly pubsub: PubsubService,
+  ) {}
+
+  hasNewOutput(): boolean {
+    const nextIndex = this.lastProcessedIndex + 1;
+    return (
+      nextIndex < this.testcases.length && this.reader.hasOutputFile(this.submissionId, nextIndex)
+    );
+  }
+
+  async process(): Promise<void> {
+    for (let i = this.lastProcessedIndex + 1; i < this.testcases.length; i++) {
+      if (!this.reader.hasOutputFile(this.submissionId, i)) break;
+
+      const actualOutput = this.reader.readOutputFile(this.submissionId, i);
+      const testcase = this.testcases[i] as Testcase;
+
+      const isCorrect = this.checker.compare(actualOutput, testcase.output);
+      const tcStatus: TestcaseStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';
+
+      // TODO: 각 테스트케이스 시간/메모리 데이터 읽기
+      const time = 0;
+      const memory = 0;
+
+      await this.publishUpdate(i, tcStatus, time, memory);
+      this.updateStatistics(tcStatus, time, memory);
+
+      this.lastProcessedIndex = i;
+    }
+  }
+
+  isAllCompleted(): boolean {
+    return this.lastProcessedIndex === this.testcases.length - 1;
+  }
+
+  async reportFinalResult(): Promise<void> {
+    await this.pubsub.publishFinalResult({
+      type: 'FINAL_RESULT',
+      submissionId: this.submissionId,
+      status: this.finalStatus,
+      result: {
+        passed: this.passed,
+        total: this.testcases.length,
+        time: this.maxTime,
+        memory: this.maxMemory,
+      },
+    });
+  }
+
+  getSummary() {
+    return {
+      passed: this.passed,
+      total: this.testcases.length,
+    };
+  }
+
+  private async publishUpdate(index: number, status: TestcaseStatus, time: number, memory: number) {
+    await this.pubsub.publishTestcaseUpdate({
+      type: 'TESTCASE_UPDATE',
+      submissionId: this.submissionId,
+      testcase: { index: index + 1, status, time, memory },
+      progress: {
+        completed: index + 1,
+        passed: status === 'ACCEPTED' ? this.passed + 1 : this.passed,
+        total: this.testcases.length,
+      },
+    });
+  }
+
+  private updateStatistics(status: TestcaseStatus, time: number, memory: number) {
+    this.maxTime = Math.max(this.maxTime, time);
+    this.maxMemory = Math.max(this.maxMemory, memory);
+    if (status === 'ACCEPTED') {
+      this.passed++;
+    } else {
+      this.finalStatus = status; // 하나라도 틀리면 최종 상태 업데이트
+    }
+  }
+}

--- a/apps/judge/src/judge/judge.context.ts
+++ b/apps/judge/src/judge/judge.context.ts
@@ -14,7 +14,7 @@ export class JudgeContext {
 
   constructor(
     public readonly submissionId: number,
-    private readonly testcases: any[],
+    private readonly testcases: Testcase[],
     private readonly reader: JudgeReader,
     private readonly checker: JudgeChecker,
     private readonly pubsub: PubsubService,
@@ -32,7 +32,7 @@ export class JudgeContext {
       if (!this.reader.hasOutputFile(this.submissionId, i)) break;
 
       const actualOutput = this.reader.readOutputFile(this.submissionId, i);
-      const testcase = this.testcases[i] as Testcase;
+      const testcase = this.testcases[i];
 
       const isCorrect = this.checker.compare(actualOutput, testcase.output);
       const tcStatus: TestcaseStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';

--- a/apps/judge/src/judge/judge.module.ts
+++ b/apps/judge/src/judge/judge.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { PubSubModule } from '../pubsub/pubsub.module';
+import { JudgeChecker } from './judge.checker';
+import { JudgePoller } from './judge.poller';
+import { JudgeReader } from './judge.reader';
 import { JudgeService } from './judge.service';
 
 @Module({
   imports: [PubSubModule],
-  providers: [JudgeService],
+  providers: [JudgeService, JudgeReader, JudgeChecker, JudgePoller],
   exports: [JudgeService],
 })
 export class JudgeModule {}

--- a/apps/judge/src/judge/judge.module.ts
+++ b/apps/judge/src/judge/judge.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { PubSubModule } from '../pubsub/pubsub.module';
+import { JudgeService } from './judge.service';
+
+@Module({
+  imports: [PubSubModule],
+  providers: [JudgeService],
+  exports: [JudgeService],
+})
+export class JudgeModule {}

--- a/apps/judge/src/judge/judge.poller.ts
+++ b/apps/judge/src/judge/judge.poller.ts
@@ -3,13 +3,21 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class JudgePoller {
   private readonly POLL_INTERVAL = 300;
+  private readonly MAX_POLL_TIME = 60000;
 
   async poll(
     checkFn: () => Promise<boolean> | boolean,
     processFn: () => Promise<void> | void,
     isCompleteFn: () => Promise<boolean> | boolean,
   ): Promise<void> {
+    const startTime = Date.now();
+
     while (true) {
+      // 타임아웃 체크
+      if (Date.now() - startTime > this.MAX_POLL_TIME) {
+        throw new Error('Polling timed out');
+      }
+
       // 새 데이터 체크
       if (await checkFn()) {
         await processFn();

--- a/apps/judge/src/judge/judge.poller.ts
+++ b/apps/judge/src/judge/judge.poller.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JudgePoller {
+  private readonly POLL_INTERVAL = 300;
+
+  async poll(
+    checkFn: () => Promise<boolean> | boolean,
+    processFn: () => Promise<void> | void,
+    isCompleteFn: () => Promise<boolean> | boolean,
+  ): Promise<void> {
+    while (true) {
+      // 새 데이터 체크
+      if (await checkFn()) {
+        await processFn();
+      }
+
+      // 완료 확인
+      if (await isCompleteFn()) break;
+
+      // 대기
+      await this.sleep(this.POLL_INTERVAL);
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/apps/judge/src/judge/judge.reader.ts
+++ b/apps/judge/src/judge/judge.reader.ts
@@ -2,42 +2,49 @@ import { Injectable } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { Metadata, Testcase } from './judge.types';
+import type { Metadata, SubmissionJobType, Testcase } from './judge.types';
 
 @Injectable()
 export class JudgeReader {
   private readonly DATA_DIR = '/judge-data';
 
-  // metadata.json 읽기
   readMetadata(submissionId: number): Metadata {
-    const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+    const submissionDir = this.getSubmissionDir(submissionId);
     const metadataPath = path.join(submissionDir, 'metadata.json');
+
+    if (!fs.existsSync(metadataPath)) {
+      throw new Error(`Metadata file not found for submission ${submissionId}`);
+    }
+
     return JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Metadata;
   }
 
-  // 테스트케이스 로드 (test.json 또는 submission.json)
-  loadTestcases(problemId: number, type: 'TEST' | 'SUBMISSION'): Testcase[] {
+  loadTestcases(problemId: number, type: SubmissionJobType): Testcase[] {
     const problemDir = path.join(this.DATA_DIR, 'problems', problemId.toString());
     const filename = type === 'TEST' ? 'test.json' : 'submission.json';
     const testcasePath = path.join(problemDir, filename);
 
-    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as
-      | { testcases: Testcase[] }
-      | Testcase[];
+    if (!fs.existsSync(testcasePath)) {
+      throw new Error(`Testcase file not found for problem ${problemId}`);
+    }
+
+    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as { testcases: Testcase[] };
     return Array.isArray(data) ? data : data.testcases;
   }
 
-  // output 파일 존재 여부 확인
   hasOutputFile(submissionId: number, index: number): boolean {
-    const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+    const submissionDir = this.getSubmissionDir(submissionId);
     const outputPath = path.join(submissionDir, `output_${index}.txt`);
     return fs.existsSync(outputPath);
   }
 
-  // output 파일 읽기
   readOutputFile(submissionId: number, index: number): string {
-    const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+    const submissionDir = this.getSubmissionDir(submissionId);
     const outputPath = path.join(submissionDir, `output_${index}.txt`);
     return fs.readFileSync(outputPath, 'utf8');
+  }
+
+  private getSubmissionDir(submissionId: number): string {
+    return path.join(this.DATA_DIR, 'submissions', submissionId.toString());
   }
 }

--- a/apps/judge/src/judge/judge.reader.ts
+++ b/apps/judge/src/judge/judge.reader.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { Metadata, Testcase } from './judge.types';
+
+@Injectable()
+export class JudgeReader {
+  private readonly DATA_DIR = '/judge-data';
+
+  // metadata.json 읽기
+  readMetadata(submissionId: number): Metadata {
+    const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+    const metadataPath = path.join(submissionDir, 'metadata.json');
+    return JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Metadata;
+  }
+
+  // 테스트케이스 로드 (test.json 또는 submission.json)
+  loadTestcases(problemId: number, type: 'TEST' | 'SUBMISSION'): Testcase[] {
+    const problemDir = path.join(this.DATA_DIR, 'problems', problemId.toString());
+    const filename = type === 'TEST' ? 'test.json' : 'submission.json';
+    const testcasePath = path.join(problemDir, filename);
+
+    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as
+      | { testcases: Testcase[] }
+      | Testcase[];
+    return Array.isArray(data) ? data : data.testcases;
+  }
+
+  // output 파일 존재 여부 확인
+  hasOutputFile(submissionId: number, index: number): boolean {
+    const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+    const outputPath = path.join(submissionDir, `output_${index}.txt`);
+    return fs.existsSync(outputPath);
+  }
+
+  // output 파일 읽기
+  readOutputFile(submissionId: number, index: number): string {
+    const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+    const outputPath = path.join(submissionDir, `output_${index}.txt`);
+    return fs.readFileSync(outputPath, 'utf8');
+  }
+}

--- a/apps/judge/src/judge/judge.reader.ts
+++ b/apps/judge/src/judge/judge.reader.ts
@@ -6,7 +6,7 @@ import type { Metadata, SubmissionJobType, Testcase } from './judge.types';
 
 @Injectable()
 export class JudgeReader {
-  private readonly DATA_DIR = '/judge-data';
+  private readonly DATA_DIR = process.env.JUDGE_VOLUME || '/judge-data';
 
   readMetadata(submissionId: number): Metadata {
     const submissionDir = this.getSubmissionDir(submissionId);

--- a/apps/judge/src/judge/judge.reader.ts
+++ b/apps/judge/src/judge/judge.reader.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { Metadata, SubmissionJobType, Testcase } from './judge.types';
+import type { Metadata, OutputResult, SubmissionJobType, Testcase } from './judge.types';
 
 @Injectable()
 export class JudgeReader {
@@ -34,14 +34,14 @@ export class JudgeReader {
 
   hasOutputFile(submissionId: number, index: number): boolean {
     const submissionDir = this.getSubmissionDir(submissionId);
-    const outputPath = path.join(submissionDir, `output_${index}.txt`);
+    const outputPath = path.join(submissionDir, `output_${index}.json`);
     return fs.existsSync(outputPath);
   }
 
-  readOutputFile(submissionId: number, index: number): string {
+  readOutputFile(submissionId: number, index: number): OutputResult {
     const submissionDir = this.getSubmissionDir(submissionId);
-    const outputPath = path.join(submissionDir, `output_${index}.txt`);
-    return fs.readFileSync(outputPath, 'utf8');
+    const outputPath = path.join(submissionDir, `output_${index}.json`);
+    return JSON.parse(fs.readFileSync(outputPath, 'utf8')) as OutputResult;
   }
 
   private getSubmissionDir(submissionId: number): string {

--- a/apps/judge/src/judge/judge.service.ts
+++ b/apps/judge/src/judge/judge.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { TestcaseStatus } from '../../../../packages/types/pubsub';
+import { PubsubService } from '../pubsub/pubsub.service';
+
+interface Metadata {
+  problemId: number;
+  timeLimit: number;
+  memoryLimit: number;
+  type: 'TEST' | 'SUBMISSION';
+}
+
+interface Testcase {
+  id: number;
+  input: string;
+  output: string;
+}
+
+@Injectable()
+export class JudgeService {
+  private readonly logger = new Logger(JudgeService.name);
+  private readonly DATA_DIR = '/judge-data';
+  private readonly POLL_INTERVAL = 300; // 0.3초
+
+  constructor(private readonly pubsubService: PubsubService) {}
+
+  // 폴링 방식 채점 (0.3초마다 output 파일 체크)
+  async judgeSubmission(submissionId: number) {
+    try {
+      const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+
+      // 1. metadata.json 읽기
+      const metadata = this.readMetadata(submissionDir);
+
+      // 2. 테스트케이스 로드
+      const testcases = this.loadTestcases(metadata.problemId, metadata.type);
+
+      // 3. 폴링 시작
+      let lastProcessedIndex = -1;
+      let passed = 0;
+      let finalStatus: TestcaseStatus = 'ACCEPTED';
+      let maxTime = 0;
+      let maxMemory = 0;
+
+      this.logger.log(`Starting to poll output files for submission ${submissionId}`);
+
+      while (true) {
+        // 새로운 output 파일 체크
+        for (let i = lastProcessedIndex + 1; i < testcases.length; i++) {
+          const outputPath = path.join(submissionDir, `output_${i}.txt`);
+
+          // output 파일이 생성되었는지 확인
+          if (!fs.existsSync(outputPath)) {
+            // 아직 생성 안 됨 - 다음 폴링까지 대기
+            break;
+          }
+
+          const testcase = testcases[i];
+          const actualOutput = fs.readFileSync(outputPath, 'utf8');
+
+          // 출력 비교
+          const isCorrect = this.compareOutput(actualOutput, testcase.output);
+          const tcStatus: TestcaseStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';
+
+          // TODO: time, memory는 추후 Docker 컨테이너에서 측정
+          const time = 0;
+          const memory = 0;
+
+          // 진행 상황 발행 (각 테스트케이스마다)
+          await this.pubsubService.publishTestcaseUpdate({
+            type: 'TESTCASE_UPDATE',
+            submissionId,
+            testcase: {
+              index: i + 1,
+              status: tcStatus,
+              time,
+              memory,
+            },
+            progress: {
+              completed: i + 1,
+              passed: isCorrect ? passed + 1 : passed,
+              total: testcases.length,
+            },
+          });
+
+          // 통계 계산
+          maxTime = Math.max(maxTime, time);
+          maxMemory = Math.max(maxMemory, memory);
+
+          if (tcStatus === 'ACCEPTED') {
+            passed++;
+          } else {
+            finalStatus = tcStatus;
+            // WA 나와도 계속 채점 (프론트에 보여주기 위해)
+          }
+
+          lastProcessedIndex = i;
+        }
+
+        // 모든 테스트케이스 완료?
+        if (lastProcessedIndex === testcases.length - 1) {
+          this.logger.log(`All testcases completed for submission ${submissionId}`);
+          break;
+        }
+
+        // 컨테이너 종료 확인 (done.txt 같은 signal 파일)
+        if (this.isContainerFinished(submissionDir)) {
+          this.logger.log(`Container finished for submission ${submissionId}`);
+          break;
+        }
+
+        // 0.3초 대기
+        await this.sleep(this.POLL_INTERVAL);
+      }
+
+      // 4. 최종 결과 발행
+      await this.pubsubService.publishFinalResult({
+        type: 'FINAL_RESULT',
+        submissionId,
+        status: finalStatus,
+        result: {
+          passed,
+          total: testcases.length,
+          time: maxTime,
+          memory: maxMemory,
+        },
+      });
+
+      this.logger.log(
+        `Judging completed for submission ${submissionId}: ${finalStatus} (${passed}/${testcases.length})`,
+      );
+    } catch (error) {
+      this.logger.error(`Failed to judge submission ${submissionId}`, error);
+      throw error;
+    }
+  }
+
+  private readMetadata(submissionDir: string): Metadata {
+    const metadataPath = path.join(submissionDir, 'metadata.json');
+    return JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Metadata;
+  }
+
+  private loadTestcases(problemId: number, type: 'TEST' | 'SUBMISSION'): Testcase[] {
+    const problemDir = path.join(this.DATA_DIR, 'problems', problemId.toString());
+    const filename = type === 'TEST' ? 'test.json' : 'submission.json';
+    const testcasePath = path.join(problemDir, filename);
+
+    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as
+      | { testcases: Testcase[] }
+      | Testcase[];
+    return Array.isArray(data) ? data : data.testcases;
+  }
+
+  // 컨테이너 종료 확인
+  private isContainerFinished(submissionDir: string): boolean {
+    const donePath = path.join(submissionDir, 'done.txt');
+    return fs.existsSync(donePath);
+  }
+
+  // 출력 비교
+  private compareOutput(actual: string, expected: string): boolean {
+    const normalize = (str: string) =>
+      str
+        .trim()
+        .replace(/\r\n/g, '\n') // Windows 개행 → Unix 개행
+        .replace(/\r/g, '\n'); // Old Mac 개행 → Unix 개행
+
+    return normalize(actual) === normalize(expected);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/apps/judge/src/judge/judge.service.ts
+++ b/apps/judge/src/judge/judge.service.ts
@@ -1,176 +1,49 @@
 import { Injectable, Logger } from '@nestjs/common';
-import * as fs from 'fs';
-import * as path from 'path';
 
-import type { TestcaseStatus } from '../../../../packages/types/pubsub';
 import { PubsubService } from '../pubsub/pubsub.service';
-
-interface Metadata {
-  problemId: number;
-  timeLimit: number;
-  memoryLimit: number;
-  type: 'TEST' | 'SUBMISSION';
-}
-
-interface Testcase {
-  id: number;
-  input: string;
-  output: string;
-}
+import { JudgeChecker } from './judge.checker';
+import { JudgeContext } from './judge.context';
+import { JudgePoller } from './judge.poller';
+import { JudgeReader } from './judge.reader';
 
 @Injectable()
 export class JudgeService {
   private readonly logger = new Logger(JudgeService.name);
-  private readonly DATA_DIR = '/judge-data';
-  private readonly POLL_INTERVAL = 300; // 0.3초
 
-  constructor(private readonly pubsubService: PubsubService) {}
+  constructor(
+    private readonly reader: JudgeReader,
+    private readonly checker: JudgeChecker,
+    private readonly poller: JudgePoller,
+    private readonly pubsub: PubsubService,
+  ) {}
 
-  // 폴링 방식 채점 (0.3초마다 output 파일 체크)
-  async judgeSubmission(submissionId: number) {
+  // 전체 채점 흐름 관리
+  async judgeSubmission(submissionId: number): Promise<void> {
     try {
-      const submissionDir = path.join(this.DATA_DIR, 'submissions', submissionId.toString());
+      const metadata = this.reader.readMetadata(submissionId);
+      const testcases = this.reader.loadTestcases(metadata.problemId, metadata.type);
 
-      // 1. metadata.json 읽기
-      const metadata = this.readMetadata(submissionDir);
-
-      // 2. 테스트케이스 로드
-      const testcases = this.loadTestcases(metadata.problemId, metadata.type);
-
-      // 3. 폴링 시작
-      let lastProcessedIndex = -1;
-      let passed = 0;
-      let finalStatus: TestcaseStatus = 'ACCEPTED';
-      let maxTime = 0;
-      let maxMemory = 0;
-
-      this.logger.log(`Starting to poll output files for submission ${submissionId}`);
-
-      while (true) {
-        // 새로운 output 파일 체크
-        for (let i = lastProcessedIndex + 1; i < testcases.length; i++) {
-          const outputPath = path.join(submissionDir, `output_${i}.txt`);
-
-          // output 파일이 생성되었는지 확인
-          if (!fs.existsSync(outputPath)) {
-            // 아직 생성 안 됨 - 다음 폴링까지 대기
-            break;
-          }
-
-          const testcase = testcases[i];
-          const actualOutput = fs.readFileSync(outputPath, 'utf8');
-
-          // 출력 비교
-          const isCorrect = this.compareOutput(actualOutput, testcase.output);
-          const tcStatus: TestcaseStatus = isCorrect ? 'ACCEPTED' : 'WRONG_ANSWER';
-
-          // TODO: time, memory는 추후 Docker 컨테이너에서 측정
-          const time = 0;
-          const memory = 0;
-
-          // 진행 상황 발행 (각 테스트케이스마다)
-          await this.pubsubService.publishTestcaseUpdate({
-            type: 'TESTCASE_UPDATE',
-            submissionId,
-            testcase: {
-              index: i + 1,
-              status: tcStatus,
-              time,
-              memory,
-            },
-            progress: {
-              completed: i + 1,
-              passed: isCorrect ? passed + 1 : passed,
-              total: testcases.length,
-            },
-          });
-
-          // 통계 계산
-          maxTime = Math.max(maxTime, time);
-          maxMemory = Math.max(maxMemory, memory);
-
-          if (tcStatus === 'ACCEPTED') {
-            passed++;
-          } else {
-            finalStatus = tcStatus;
-            // WA 나와도 계속 채점 (프론트에 보여주기 위해)
-          }
-
-          lastProcessedIndex = i;
-        }
-
-        // 모든 테스트케이스 완료?
-        if (lastProcessedIndex === testcases.length - 1) {
-          this.logger.log(`All testcases completed for submission ${submissionId}`);
-          break;
-        }
-
-        // 컨테이너 종료 확인 (done.txt 같은 signal 파일)
-        if (this.isContainerFinished(submissionDir)) {
-          this.logger.log(`Container finished for submission ${submissionId}`);
-          break;
-        }
-
-        // 0.3초 대기
-        await this.sleep(this.POLL_INTERVAL);
-      }
-
-      // 4. 최종 결과 발행
-      await this.pubsubService.publishFinalResult({
-        type: 'FINAL_RESULT',
+      const context = new JudgeContext(
         submissionId,
-        status: finalStatus,
-        result: {
-          passed,
-          total: testcases.length,
-          time: maxTime,
-          memory: maxMemory,
-        },
-      });
-
-      this.logger.log(
-        `Judging completed for submission ${submissionId}: ${finalStatus} (${passed}/${testcases.length})`,
+        testcases,
+        this.reader,
+        this.checker,
+        this.pubsub,
       );
+
+      await this.poller.poll(
+        () => context.hasNewOutput(),
+        () => context.process(),
+        () => context.isAllCompleted(),
+      );
+
+      await context.reportFinalResult();
+
+      const { passed, total } = context.getSummary();
+      this.logger.log(`채점 완료: Submission ${submissionId} - (${passed}/${total} TC)`);
     } catch (error) {
       this.logger.error(`Failed to judge submission ${submissionId}`, error);
       throw error;
     }
-  }
-
-  private readMetadata(submissionDir: string): Metadata {
-    const metadataPath = path.join(submissionDir, 'metadata.json');
-    return JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Metadata;
-  }
-
-  private loadTestcases(problemId: number, type: 'TEST' | 'SUBMISSION'): Testcase[] {
-    const problemDir = path.join(this.DATA_DIR, 'problems', problemId.toString());
-    const filename = type === 'TEST' ? 'test.json' : 'submission.json';
-    const testcasePath = path.join(problemDir, filename);
-
-    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as
-      | { testcases: Testcase[] }
-      | Testcase[];
-    return Array.isArray(data) ? data : data.testcases;
-  }
-
-  // 컨테이너 종료 확인
-  private isContainerFinished(submissionDir: string): boolean {
-    const donePath = path.join(submissionDir, 'done.txt');
-    return fs.existsSync(donePath);
-  }
-
-  // 출력 비교
-  private compareOutput(actual: string, expected: string): boolean {
-    const normalize = (str: string) =>
-      str
-        .trim()
-        .replace(/\r\n/g, '\n') // Windows 개행 → Unix 개행
-        .replace(/\r/g, '\n'); // Old Mac 개행 → Unix 개행
-
-    return normalize(actual) === normalize(expected);
-  }
-
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/apps/judge/src/judge/judge.types.ts
+++ b/apps/judge/src/judge/judge.types.ts
@@ -1,0 +1,12 @@
+export interface Metadata {
+  problemId: number;
+  timeLimit: number;
+  memoryLimit: number;
+  type: 'TEST' | 'SUBMISSION';
+}
+
+export interface Testcase {
+  id: number;
+  input: string;
+  output: string;
+}

--- a/apps/judge/src/judge/judge.types.ts
+++ b/apps/judge/src/judge/judge.types.ts
@@ -12,3 +12,9 @@ export interface Testcase {
   input: string;
   output: string;
 }
+
+export interface OutputResult {
+  output: string;
+  time: number;
+  memory: number;
+}

--- a/apps/judge/src/judge/judge.types.ts
+++ b/apps/judge/src/judge/judge.types.ts
@@ -1,3 +1,5 @@
+import type { TestcaseStatus } from '@packages/types/pubsub';
+
 export type SubmissionJobType = 'TEST' | 'SUBMISSION';
 
 export interface Metadata {
@@ -17,4 +19,5 @@ export interface OutputResult {
   output: string;
   time: number;
   memory: number;
+  status: TestcaseStatus;
 }

--- a/apps/judge/src/judge/judge.types.ts
+++ b/apps/judge/src/judge/judge.types.ts
@@ -1,8 +1,10 @@
+export type SubmissionJobType = 'TEST' | 'SUBMISSION';
+
 export interface Metadata {
   problemId: number;
   timeLimit: number;
   memoryLimit: number;
-  type: 'TEST' | 'SUBMISSION';
+  type: SubmissionJobType;
 }
 
 export interface Testcase {

--- a/apps/judge/test/judge/judge.service.spec.ts
+++ b/apps/judge/test/judge/judge.service.spec.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { JudgeChecker } from '../../src/judge/judge.checker';
+import { JudgePoller } from '../../src/judge/judge.poller';
+import { JudgeReader } from '../../src/judge/judge.reader';
+import { JudgeService } from '../../src/judge/judge.service';
+import { PubsubService } from '../../src/pubsub/pubsub.service';
+
+describe('JudgeService (Integration Flow)', () => {
+  let service: JudgeService;
+  let reader: JudgeReader;
+  let pubsub: PubsubService;
+
+  beforeEach(async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JudgeService,
+        JudgePoller,
+        JudgeChecker,
+        {
+          provide: JudgeReader,
+          useValue: {
+            readMetadata: jest.fn(),
+            loadTestcases: jest.fn(),
+            hasOutputFile: jest.fn(),
+            readOutputFile: jest.fn(),
+            isContainerFinished: jest.fn(),
+          },
+        },
+        {
+          provide: PubsubService,
+          useValue: {
+            publishTestcaseUpdate: jest.fn(),
+            publishFinalResult: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<JudgeService>(JudgeService);
+    reader = module.get<JudgeReader>(JudgeReader);
+    pubsub = module.get<PubsubService>(PubsubService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('모든 테스트케이스를 통과하면 ACCEPTED 결과를 발행해야 한다', async () => {
+    const submissionId = 123;
+    (reader.readMetadata as jest.Mock).mockReturnValue({ problemId: 1, type: 'SUBMISSION' });
+    (reader.loadTestcases as jest.Mock).mockReturnValue([
+      { input: '1', output: 'A' },
+      { input: '2', output: 'B' },
+    ]);
+
+    (reader.hasOutputFile as jest.Mock).mockReturnValue(true);
+    (reader.readOutputFile as jest.Mock).mockReturnValueOnce('A').mockReturnValueOnce('B');
+
+    const judgePromise = service.judgeSubmission(submissionId);
+
+    for (let i = 0; i < 10; i++) {
+      // 시간 가속
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    }
+
+    await judgePromise;
+
+    expect(pubsub.publishFinalResult).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'ACCEPTED' }),
+    );
+  });
+
+  it('테스트케이스 중 하나라도 틀리면 WRONG_ANSWER 결과를 발행해야 한다', async () => {
+    const submissionId = 456;
+    (reader.readMetadata as jest.Mock).mockReturnValue({ problemId: 1, type: 'SUBMISSION' });
+
+    (reader.loadTestcases as jest.Mock).mockReturnValue([
+      { input: '1', output: 'A' },
+      { input: '2', output: 'B' },
+    ]);
+
+    (reader.hasOutputFile as jest.Mock).mockReturnValue(true);
+
+    (reader.readOutputFile as jest.Mock).mockReturnValueOnce('A').mockReturnValueOnce('C');
+
+    const judgePromise = service.judgeSubmission(submissionId);
+
+    // 시간 가속
+    for (let i = 0; i < 10; i++) {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    }
+
+    await judgePromise;
+
+    expect(pubsub.publishFinalResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'WRONG_ANSWER',
+        result: expect.objectContaining({
+          passed: 1, // 2개 중 1개만 맞음
+          total: 2,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## 🔍 PR 요약

- 채점 서버에서 채점 로직 함수를 구현하였습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #127 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- apps/judge/src/judge/judge.checker.ts : 정답 비교 로직
- apps/judge/src/judge/judge.context.ts : 채점 로직 상태 저장
- apps/judge/src/judge/judge.poller.ts : 폴링 방식 파일 확인
  - 0.3초 폴링으로 파일 변경 확인
  - 최대 연결 1분 타임아웃 설정
- apps/judge/src/judge/judge.reader.ts : 스토리지 파일 리더 함수
  - 출력 파일(output_{i}.json}을 읽어서 처리
- apps/judge/src/judge/judge.service.ts : 채점 전체 흐름 로직


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 도커 실행 컨테이너에서 작성한 테스트 케이스 결과 내용을 읽어서 API 서버에 전송하기 위함

## ➕ 코드 추가 설명
- `judge.service.ts`의 `judgeSubmission` 함수를 SubmissionProcessor에서 호출하여 동작하지 않을까 생각합니다.
- 제가 이해한 흐름은 아래와 같습니다.
```
  - concurrency: 5면 → 5개의 process() 함수가 동시에 실행
  - 각 process()는 자기 submissionId로 독립적으로 폴링
  - judgeSubmission()의 while 루프가 끝나면 → process() 종료 → 다음 Job 처리

  동시 실행 예시:
  Thread 1: process(job 100) → judgeSubmission(100) → while 폴링 중...
  Thread 2: process(job 101) → judgeSubmission(101) → while 폴링 중...
  Thread 3: process(job 102) → judgeSubmission(102) → while 폴링 중...
  Thread 4: process(job 103) → judgeSubmission(103) → while 폴링 중...
  Thread 5: process(job 104) → judgeSubmission(104) → while 폴링 중...
```
- JudgeChecker를 분리한 이유가 현재는 단순하게 값 비교만 하지만, 추후에 정답 처리 방식을 변경할 수도 있지 않을까 해서 분리했습니다.
  - ex) 정답의 대소문자 무시...

## 💬 리뷰 요구사항(선택)
- 테스트 로직도 간단하게 작성하긴 했지만 로컬에 `judge-data` 폴더를 만들어 실제 테스트를 진행했습니다. 또한, `.gitignore`에 `judge-data`를 추가했는데 괜찮을지 궁금합니다.
- 아무래도 테스트 코드 작성할 때 제한되는 부분이 많아서 실제로 코드들을 연결해서 동작하는지 한 번 더 점검해야 할 것 같습니다.
