### PR TITLE
[FEAT] Docker 컨테이너 실행 - docker run (#115)

### DIFF
--- a/apps/judge/Dockerfile
+++ b/apps/judge/Dockerfile
@@ -1,5 +1,6 @@
 # Base
 FROM node:22-alpine AS base
+RUN apk add --no-cache docker-cli
 RUN corepack enable && corepack prepare pnpm@10.20.0 --activate
 WORKDIR /app
 
@@ -32,6 +33,7 @@ RUN pnpm run build
 
 # production
 FROM node:22-alpine AS production
+RUN apk add --no-cache docker-cli
 RUN corepack enable && corepack prepare pnpm@10.20.0 --activate
 WORKDIR /app
 

--- a/apps/judge/src/docker/docker.cleanup.service.ts
+++ b/apps/judge/src/docker/docker.cleanup.service.ts
@@ -1,0 +1,73 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { DOCKER_CONTAINER_NAME, DOCKER_SUBMISSIONS_PATH } from './docker.constants';
+
+@Injectable()
+export class DockerCleanupService {
+  private readonly logger = new Logger(DockerCleanupService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async cleanupExecution(executionId: string): Promise<void> {
+    await Promise.all([this.removeSubmissionFiles(executionId), this.removeContainer(executionId)]);
+  }
+
+  private async removeSubmissionFiles(executionId: string): Promise<void> {
+    const submissionsPath = this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH);
+    const targetPath = path.join(submissionsPath, executionId);
+
+    try {
+      await fs.rm(targetPath, { recursive: true, force: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to remove submission files (${targetPath}): ${message}`);
+    }
+  }
+
+  private removeContainer(executionId: string): Promise<void> {
+    const containerName = `${DOCKER_CONTAINER_NAME}-${executionId}`;
+    return this.spawnDocker(['rm', '-f', containerName]);
+  }
+
+  private spawnDocker(args: string[]): Promise<void> {
+    return new Promise((resolve) => {
+      const child = spawn('docker', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      let stderr = '';
+
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        if (typeof chunk === 'string') {
+          stderr += chunk;
+        } else {
+          stderr += chunk.toString();
+        }
+      });
+
+      child.on('error', (error) => {
+        this.logger.warn(`Docker cleanup command failed to start: ${error.message}`);
+        resolve();
+      });
+
+      child.on('close', (code) => {
+        const message = stderr.trim();
+        if (code && message.length > 0 && !this.isNotFoundMessage(message)) {
+          this.logger.warn(`Docker cleanup command exited with code ${code}: ${message}`);
+        }
+        resolve();
+      });
+    });
+  }
+
+  private isNotFoundMessage(message: string): boolean {
+    return message.includes('No such container');
+  }
+
+  private getString(key: string, fallback: string): string {
+    const value = this.configService.get<string>(key);
+    return value && value.trim().length > 0 ? value : fallback;
+  }
+}

--- a/apps/judge/src/docker/docker.cleanup.service.ts
+++ b/apps/judge/src/docker/docker.cleanup.service.ts
@@ -18,7 +18,9 @@ export class DockerCleanupService {
   }
 
   private async removeSubmissionFiles(executionId: string): Promise<void> {
-    const submissionsPath = this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH);
+    const submissionsPath = path.resolve(
+      this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH),
+    );
     const targetPath = path.join(submissionsPath, executionId);
 
     try {

--- a/apps/judge/src/docker/docker.constants.ts
+++ b/apps/judge/src/docker/docker.constants.ts
@@ -1,0 +1,8 @@
+export const DOCKER_RUNNER_IMAGE = 'judge-javascript';
+export const DOCKER_PROBLEMS_VOLUME = 'judge-problems';
+export const DOCKER_SUBMISSIONS_VOLUME = 'judge-submissions';
+
+export const DOCKER_CPU_LIMIT = 0.5;
+export const DOCKER_PIDS_LIMIT = 10;
+export const DOCKER_TMPFS_SIZE_MB = 32;
+export const DOCKER_DEFAULT_MEMORY_LIMIT_MB = 256;

--- a/apps/judge/src/docker/docker.constants.ts
+++ b/apps/judge/src/docker/docker.constants.ts
@@ -1,6 +1,7 @@
 export const DOCKER_RUNNER_IMAGE = 'judge-javascript';
 export const DOCKER_PROBLEMS_PATH = '/judge-data/problems';
 export const DOCKER_SUBMISSIONS_PATH = '/judge-data/submissions';
+export const DOCKER_CONTAINER_NAME = 'submission';
 
 export const DOCKER_CPU_LIMIT = 0.5;
 export const DOCKER_PIDS_LIMIT = 10;

--- a/apps/judge/src/docker/docker.constants.ts
+++ b/apps/judge/src/docker/docker.constants.ts
@@ -1,9 +1,8 @@
 export const DOCKER_RUNNER_IMAGE = 'judge-javascript';
-export const DOCKER_PROBLEMS_PATH = '/judge-data/problems';
-export const DOCKER_SUBMISSIONS_PATH = '/judge-data/submissions';
+export const DOCKER_PROBLEMS_PATH = 'judge-data';
+export const DOCKER_SUBMISSIONS_PATH = 'judge-data/submissions';
 export const DOCKER_CONTAINER_NAME = 'submission';
 
 export const DOCKER_CPU_LIMIT = 0.5;
-export const DOCKER_PIDS_LIMIT = 10;
 export const DOCKER_TMPFS_SIZE_MB = 32;
 export const DOCKER_DEFAULT_MEMORY_LIMIT_MB = 256;

--- a/apps/judge/src/docker/docker.constants.ts
+++ b/apps/judge/src/docker/docker.constants.ts
@@ -1,6 +1,6 @@
 export const DOCKER_RUNNER_IMAGE = 'judge-javascript';
-export const DOCKER_PROBLEMS_VOLUME = 'judge-problems';
-export const DOCKER_SUBMISSIONS_VOLUME = 'judge-submissions';
+export const DOCKER_PROBLEMS_PATH = '/judge-data/problems';
+export const DOCKER_SUBMISSIONS_PATH = '/judge-data/submissions';
 
 export const DOCKER_CPU_LIMIT = 0.5;
 export const DOCKER_PIDS_LIMIT = 10;

--- a/apps/judge/src/docker/docker.module.ts
+++ b/apps/judge/src/docker/docker.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { DockerCleanupService } from './docker.cleanup.service';
 import { DockerRunnerService } from './docker.service';
 
 @Module({
   imports: [ConfigModule],
-  providers: [DockerRunnerService],
-  exports: [DockerRunnerService],
+  providers: [DockerRunnerService, DockerCleanupService],
+  exports: [DockerRunnerService, DockerCleanupService],
 })
 export class DockerModule {}

--- a/apps/judge/src/docker/docker.module.ts
+++ b/apps/judge/src/docker/docker.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { DockerRunnerService } from './docker.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [DockerRunnerService],
+  exports: [DockerRunnerService],
+})
+export class DockerModule {}

--- a/apps/judge/src/docker/docker.service.ts
+++ b/apps/judge/src/docker/docker.service.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import path from 'node:path';
 
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -7,9 +8,9 @@ import {
   DOCKER_CPU_LIMIT,
   DOCKER_DEFAULT_MEMORY_LIMIT_MB,
   DOCKER_PIDS_LIMIT,
-  DOCKER_PROBLEMS_VOLUME,
+  DOCKER_PROBLEMS_PATH,
   DOCKER_RUNNER_IMAGE,
-  DOCKER_SUBMISSIONS_VOLUME,
+  DOCKER_SUBMISSIONS_PATH,
   DOCKER_TMPFS_SIZE_MB,
 } from './docker.constants';
 
@@ -38,8 +39,9 @@ export class DockerRunnerService {
 
   private buildRunArgs(options: DockerRunOptions): string[] {
     const image = this.getString('JUDGE_RUNNER_IMAGE', DOCKER_RUNNER_IMAGE);
-    const problemsVolume = this.getString('JUDGE_PROBLEMS_VOLUME', DOCKER_PROBLEMS_VOLUME);
-    const submissionsVolume = this.getString('JUDGE_SUBMISSIONS_VOLUME', DOCKER_SUBMISSIONS_VOLUME);
+    const problemsPath = this.getString('JUDGE_PROBLEMS_PATH', DOCKER_PROBLEMS_PATH);
+    const submissionsPath = this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH);
+    const submissionOutputPath = path.posix.join(submissionsPath, options.submissionId);
     const memoryLimitMb =
       options.memoryLimitMb ??
       this.getNumber('JUDGE_DEFAULT_MEMORY_LIMIT_MB', DOCKER_DEFAULT_MEMORY_LIMIT_MB);
@@ -48,9 +50,9 @@ export class DockerRunnerService {
       'run',
       '--rm',
       '-v',
-      `${problemsVolume}:/app/data:ro`,
+      `${problemsPath}:/app/data:ro`,
       '-v',
-      `${submissionsVolume}:/app/output:rw`,
+      `${submissionOutputPath}:/app/output:rw`,
       '--network',
       'none',
       '--memory',

--- a/apps/judge/src/docker/docker.service.ts
+++ b/apps/judge/src/docker/docker.service.ts
@@ -5,6 +5,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import {
+  DOCKER_CONTAINER_NAME,
   DOCKER_CPU_LIMIT,
   DOCKER_DEFAULT_MEMORY_LIMIT_MB,
   DOCKER_PIDS_LIMIT,
@@ -45,10 +46,12 @@ export class DockerRunnerService {
     const memoryLimitMb =
       options.memoryLimitMb ??
       this.getNumber('JUDGE_DEFAULT_MEMORY_LIMIT_MB', DOCKER_DEFAULT_MEMORY_LIMIT_MB);
-
+    const containerName = `${DOCKER_CONTAINER_NAME}-${options.submissionId}`;
     return [
       'run',
       '--rm',
+      '--name',
+      containerName,
       '-v',
       `${problemsPath}:/app/data:ro`,
       '-v',

--- a/apps/judge/src/docker/docker.service.ts
+++ b/apps/judge/src/docker/docker.service.ts
@@ -1,0 +1,120 @@
+import { spawn } from 'node:child_process';
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import {
+  DOCKER_CPU_LIMIT,
+  DOCKER_DEFAULT_MEMORY_LIMIT_MB,
+  DOCKER_PIDS_LIMIT,
+  DOCKER_PROBLEMS_VOLUME,
+  DOCKER_RUNNER_IMAGE,
+  DOCKER_SUBMISSIONS_VOLUME,
+  DOCKER_TMPFS_SIZE_MB,
+} from './docker.constants';
+
+export interface DockerRunOptions {
+  submissionId: string;
+  memoryLimitMb?: number;
+}
+
+export interface DockerRunResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+@Injectable()
+export class DockerRunnerService {
+  private readonly logger = new Logger(DockerRunnerService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async runSubmission(options: DockerRunOptions): Promise<DockerRunResult> {
+    const args = this.buildRunArgs(options);
+    return this.spawnDocker(args);
+  }
+
+  private buildRunArgs(options: DockerRunOptions): string[] {
+    const image = this.getString('JUDGE_RUNNER_IMAGE', DOCKER_RUNNER_IMAGE);
+    const problemsVolume = this.getString('JUDGE_PROBLEMS_VOLUME', DOCKER_PROBLEMS_VOLUME);
+    const submissionsVolume = this.getString('JUDGE_SUBMISSIONS_VOLUME', DOCKER_SUBMISSIONS_VOLUME);
+    const memoryLimitMb =
+      options.memoryLimitMb ??
+      this.getNumber('JUDGE_DEFAULT_MEMORY_LIMIT_MB', DOCKER_DEFAULT_MEMORY_LIMIT_MB);
+
+    return [
+      'run',
+      '--rm',
+      '-v',
+      `${problemsVolume}:/app/data:ro`,
+      '-v',
+      `${submissionsVolume}:/app/output:rw`,
+      '--network',
+      'none',
+      '--memory',
+      `${memoryLimitMb}m`,
+      '--cpus',
+      `${DOCKER_CPU_LIMIT}`,
+      '--pids-limit',
+      `${DOCKER_PIDS_LIMIT}`,
+      '--tmpfs',
+      `/tmp:size=${DOCKER_TMPFS_SIZE_MB}m`,
+      image,
+      'node',
+      '/runner/run.js',
+      options.submissionId,
+    ];
+  }
+
+  // 외부 명령어를 새 프로세스로 실행하는 함수
+  private spawnDocker(args: string[]): Promise<DockerRunResult> {
+    return new Promise((resolve, reject) => {
+      const child = spawn('docker', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        if (typeof chunk === 'string') {
+          stdout += chunk;
+        } else {
+          stdout += chunk.toString();
+        }
+      });
+
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        if (typeof chunk === 'string') {
+          stderr += chunk;
+        } else {
+          stderr += chunk.toString();
+        }
+      });
+
+      child.on('error', (error) => {
+        this.logger.error(`Docker execution failed to start: ${error.message}`);
+        reject(error);
+      });
+
+      child.on('close', (code, signal) => {
+        resolve({
+          exitCode: code,
+          signal,
+          stdout,
+          stderr,
+        });
+      });
+    });
+  }
+
+  private getString(key: string, fallback: string): string {
+    const value = this.configService.get<string>(key);
+    return value && value.trim().length > 0 ? value : fallback;
+  }
+
+  private getNumber(key: string, fallback: number): number {
+    const value = this.configService.get<string>(key);
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/apps/judge/src/docker/docker.service.ts
+++ b/apps/judge/src/docker/docker.service.ts
@@ -8,7 +8,6 @@ import {
   DOCKER_CONTAINER_NAME,
   DOCKER_CPU_LIMIT,
   DOCKER_DEFAULT_MEMORY_LIMIT_MB,
-  DOCKER_PIDS_LIMIT,
   DOCKER_PROBLEMS_PATH,
   DOCKER_RUNNER_IMAGE,
   DOCKER_SUBMISSIONS_PATH,
@@ -40,9 +39,11 @@ export class DockerRunnerService {
 
   private buildRunArgs(options: DockerRunOptions): string[] {
     const image = this.getString('JUDGE_RUNNER_IMAGE', DOCKER_RUNNER_IMAGE);
-    const problemsPath = this.getString('JUDGE_PROBLEMS_PATH', DOCKER_PROBLEMS_PATH);
-    const submissionsPath = this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH);
-    const submissionOutputPath = path.posix.join(submissionsPath, options.submissionId);
+    const problemsPath = path.resolve(this.getString('JUDGE_PROBLEMS_PATH', DOCKER_PROBLEMS_PATH));
+    const submissionsPath = path.resolve(
+      this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH),
+    );
+    const submissionOutputPath = path.join(submissionsPath, options.submissionId);
     const memoryLimitMb =
       options.memoryLimitMb ??
       this.getNumber('JUDGE_DEFAULT_MEMORY_LIMIT_MB', DOCKER_DEFAULT_MEMORY_LIMIT_MB);
@@ -62,8 +63,6 @@ export class DockerRunnerService {
       `${memoryLimitMb}m`,
       '--cpus',
       `${DOCKER_CPU_LIMIT}`,
-      '--pids-limit',
-      `${DOCKER_PIDS_LIMIT}`,
       '--tmpfs',
       `/tmp:size=${DOCKER_TMPFS_SIZE_MB}m`,
       image,

--- a/apps/judge/src/submission/submission.module.ts
+++ b/apps/judge/src/submission/submission.module.ts
@@ -1,11 +1,12 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 
+import { DockerModule } from '../docker/docker.module';
 import { SUBMISSION_QUEUE } from './submission.constants';
 import { SubmissionProcessor } from './submission.processor';
 
 @Module({
-  imports: [BullModule.registerQueue({ name: SUBMISSION_QUEUE })],
+  imports: [BullModule.registerQueue({ name: SUBMISSION_QUEUE }), DockerModule],
   providers: [SubmissionProcessor],
 })
 export class SubmissionModule {}

--- a/apps/judge/src/submission/submission.payload.ts
+++ b/apps/judge/src/submission/submission.payload.ts
@@ -1,7 +1,7 @@
 export type SubmissionJobType = 'SUBMISSION' | 'TEST';
 
 export interface SubmissionJobPayload {
-  submissionId: number | null;
+  submissionId: string;
   problemId: string;
   code: string;
   language: string;
@@ -18,13 +18,9 @@ export function parseSubmissionJobPayload(payload: unknown): SubmissionJobPayloa
   const data = payload as Record<string, unknown>;
   const type = parseJobType(data.type);
   const problemId = parseNonEmptyString(data.problemId, 'problemId');
+  const submissionId = parseNonEmptyString(data.submissionId, 'submissionId');
   const code = parseNonEmptyString(data.code, 'code');
   const language = parseNonEmptyString(data.language, 'language');
-  const submissionId = parseNullableNumber(data.submissionId, 'submissionId');
-
-  if (type === 'SUBMISSION' && submissionId === null) {
-    throw new Error('"submissionId" is required for SUBMISSION jobs.');
-  }
 
   return {
     submissionId,
@@ -40,18 +36,6 @@ export function parseSubmissionJobPayload(payload: unknown): SubmissionJobPayloa
 function parseJobType(value: unknown): SubmissionJobType {
   if (value !== 'SUBMISSION' && value !== 'TEST') {
     throw new Error('"type" must be either "SUBMISSION" or "TEST".');
-  }
-
-  return value;
-}
-
-function parseNullableNumber(value: unknown, field: string): number | null {
-  if (value === undefined || value === null) {
-    return null;
-  }
-
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    throw new Error(`"${field}" must be a positive number or null.`);
   }
 
   return value;

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -2,6 +2,7 @@ import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 
+import { DockerCleanupService } from '../docker/docker.cleanup.service';
 import { DockerRunnerService } from '../docker/docker.service';
 import { SUBMISSION_QUEUE, SUBMISSION_WORKER_CONCURRENCY } from './submission.constants';
 import { parseSubmissionJobPayload, SubmissionJobPayload } from './submission.payload';
@@ -10,7 +11,10 @@ import { parseSubmissionJobPayload, SubmissionJobPayload } from './submission.pa
 export class SubmissionProcessor extends WorkerHost {
   private readonly logger = new Logger(SubmissionProcessor.name);
 
-  constructor(private readonly dockerRunnerService: DockerRunnerService) {
+  constructor(
+    private readonly dockerRunnerService: DockerRunnerService,
+    private readonly dockerCleanupService: DockerCleanupService,
+  ) {
     super();
   }
 
@@ -32,11 +36,15 @@ export class SubmissionProcessor extends WorkerHost {
       `Job ${job.id ?? 'unknown'} received: type=${payload.type}, problemId=${payload.problemId}, submissionId=${payload.submissionId ?? 'null'}`,
     );
 
-    const result = await this.dockerRunnerService.runSubmission({ submissionId: executionId });
+    try {
+      const result = await this.dockerRunnerService.runSubmission({ submissionId: executionId });
 
-    this.logger.log(
-      `Docker run completed: exitCode=${result.exitCode ?? 'null'}, signal=${result.signal ?? 'null'}`,
-    );
+      this.logger.log(
+        `Docker run completed: exitCode=${result.exitCode ?? 'null'}, signal=${result.signal ?? 'null'}`,
+      );
+    } finally {
+      await this.dockerCleanupService.cleanupExecution(executionId);
+    }
   }
 
   @OnWorkerEvent('failed')

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -2,6 +2,7 @@ import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 
+import { DockerRunnerService } from '../docker/docker.service';
 import { SUBMISSION_QUEUE, SUBMISSION_WORKER_CONCURRENCY } from './submission.constants';
 import { parseSubmissionJobPayload, SubmissionJobPayload } from './submission.payload';
 
@@ -9,15 +10,33 @@ import { parseSubmissionJobPayload, SubmissionJobPayload } from './submission.pa
 export class SubmissionProcessor extends WorkerHost {
   private readonly logger = new Logger(SubmissionProcessor.name);
 
+  constructor(private readonly dockerRunnerService: DockerRunnerService) {
+    super();
+  }
+
   async process(job: Job<SubmissionJobPayload>): Promise<void> {
     const payload = parseSubmissionJobPayload(job.data);
+    // 컨테이너 실행에 사용할 실행 ID 결정
+    const executionId =
+      payload.submissionId !== null
+        ? String(payload.submissionId)
+        : job.id !== undefined && job.id !== null
+          ? String(job.id)
+          : null;
+
+    if (!executionId) {
+      throw new Error('Execution id is required to run docker container.');
+    }
 
     this.logger.log(
       `Job ${job.id ?? 'unknown'} received: type=${payload.type}, problemId=${payload.problemId}, submissionId=${payload.submissionId ?? 'null'}`,
     );
 
-    // TODO: 연결된 채점 로직(Docker 실행 등)으로 payload 전달
-    await Promise.resolve();
+    const result = await this.dockerRunnerService.runSubmission({ submissionId: executionId });
+
+    this.logger.log(
+      `Docker run completed: exitCode=${result.exitCode ?? 'null'}, signal=${result.signal ?? 'null'}`,
+    );
   }
 
   @OnWorkerEvent('failed')

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -21,16 +21,7 @@ export class SubmissionProcessor extends WorkerHost {
   async process(job: Job<SubmissionJobPayload>): Promise<void> {
     const payload = parseSubmissionJobPayload(job.data);
     // 컨테이너 실행에 사용할 실행 ID 결정
-    const executionId =
-      payload.submissionId !== null
-        ? String(payload.submissionId)
-        : job.id !== undefined && job.id !== null
-          ? String(job.id)
-          : null;
-
-    if (!executionId) {
-      throw new Error('Execution id is required to run docker container.');
-    }
+    const executionId = String(payload.submissionId);
 
     this.logger.log(
       `Job ${job.id ?? 'unknown'} received: type=${payload.type}, problemId=${payload.problemId}, submissionId=${payload.submissionId ?? 'null'}`,


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- Judge 워커에서 docker run을 생성/실행하는 서비스 추가 및 워커 연결

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #115

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

> [!NOTE]
> 이전 #114 내용도 같이 포함되어 있어서 주요 변경사항의 폴더를 참고해주세요!
> 변경 폴더:  `docker.constants.ts`, `docker.service.ts`, `docker.module.ts`, `submission.module.ts`, `submission.processor.ts`, `Dockerfile`

- DockerRunnerService 추가: docker run args 생성 + spawn 실행/로그 수집
- 도커 실행 기본값 상수 분리(이미지명, 리소스 제한 등)
- 워커에서 실행 ID 결정 후 DockerRunner 호출
- Judge 이미지에 docker-cli 설치


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 제출 코드를 격리된 컨테이너에서 실행해 호스트 자원을 보호하고, 채점 로직의 기반을 만들기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 바인드 마운트 경로(JUDGE_PROBLEMS_PATH, JUDGE_SUBMISSIONS_PATH)를 절대경로로 넣는 방식이 타당한지 확인 부탁드립니다
- 런너 컨테이너가 기대하는 경로(/app/data, /app/output)가 EPIC 3 설계와 일치하는지도 봐주세요

