### PR TITLE
[FEAT] Docker 컨테이너 코드 실행 환경 구축 (#104, #105, #106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 .env.production
 .env.test
 .env.dev
+/judge-data

--- a/apps/api/src/battle/battle.module.ts
+++ b/apps/api/src/battle/battle.module.ts
@@ -3,8 +3,10 @@ import { Module } from '@nestjs/common';
 import { BattleGateway } from '@/battle/battle.gateway';
 import { BattleService } from '@/battle/battle.service';
 import { BattleRedisService } from '@/battle/battle-redis.service';
+import { ProblemModule } from '@/problem/problem.module';
 
 @Module({
+  imports: [ProblemModule],
   providers: [BattleService, BattleRedisService, BattleGateway],
   exports: [BattleService],
 })

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -4,14 +4,24 @@ import { Battle, BattleUser, CreateBattleDTO, UpdateUserCodeDTO } from '@package
 import { RoomUser } from '@packages/types/user';
 
 import { BattleRedisService } from '@/battle/battle-redis.service';
+import { ProblemService } from '@/problem/problem.service';
 
 @Injectable()
 export class BattleService {
-  constructor(private readonly battleRedisService: BattleRedisService) {}
+  constructor(
+    private readonly battleRedisService: BattleRedisService,
+    private readonly problemService: ProblemService,
+  ) {}
 
   async createBattle(dto: CreateBattleDTO): Promise<Battle> {
     // TODO: 배틀 ID 생성 로직 추가
     const battleId = `battle-${Date.now()}`;
+
+    // 임시 문제 선택
+    const problem = await this.problemService.findFirst();
+    if (!problem) {
+      throw new Error('No problems available.');
+    }
 
     const users: BattleUser[] = dto.users.map((userId) => ({
       userId,
@@ -20,7 +30,7 @@ export class BattleService {
       language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
       progress: {
         passedCount: 0,
-        totalCount: 0,
+        totalCount: Array.isArray(problem.testcases) ? (problem.testcases as any[]).length : 0,
       },
       isConnected: true,
       isFinished: false,
@@ -29,6 +39,7 @@ export class BattleService {
     const battle: Battle = {
       battleId,
       roomId: dto.roomId,
+      problemId: problem.id,
       status: 'running',
       config: {
         duration: dto.config.duration || BATTLE_CONFIG.DURATION,
@@ -97,6 +108,12 @@ export class BattleService {
 
   async getBattle(battleId: string): Promise<Battle | null> {
     // TODO: 권한 체크 추가 (사용자가 해당 배틀에 접근 가능한지 또는 비밀번호 존재 등)
+    return this.battleRedisService.getBattle(battleId);
+  }
+
+  async getBattleByRoomId(roomId: string): Promise<Battle | null> {
+    const battleId = await this.battleRedisService.getBattleIdByRoomId(roomId);
+    if (!battleId) return null;
     return this.battleRedisService.getBattle(battleId);
   }
 

--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -48,7 +48,13 @@ export class MatchingGateway implements OnGatewayDisconnect {
   }
 
   // 매칭 성공 이벤트를 두 유저에게 전송
-  emitMatchSuccess(user1: MatchingUser, user2: MatchingUser, room: Room, battle: Battle): void {
+  emitMatchSuccess(
+    user1: MatchingUser,
+    user2: MatchingUser,
+    room: Room,
+    battle: Battle,
+    problemInfo: { id: string; title: string },
+  ): void {
     // user1에게 전송
     this.server.to(user1.socketId).emit(SOCKET_EVENT.MATCH_SUCCESS, {
       roomId: room.roomId,
@@ -62,6 +68,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
         tier: user2.tier,
         rate: user2.myRate,
       },
+      problem: problemInfo,
     });
 
     // user2에게 전송
@@ -77,6 +84,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
         tier: user1.tier,
         rate: user1.myRate,
       },
+      problem: problemInfo,
     });
   }
 

--- a/apps/api/src/matching/matching.service.ts
+++ b/apps/api/src/matching/matching.service.ts
@@ -158,7 +158,7 @@ export class MatchingService {
 
       try {
         // Room & Battle 생성
-        const { room, battle } = await this.createMatch(user1, user2);
+        const { room, battle, problem } = await this.createMatch(user1, user2);
 
         // 대기 시간 계산 및 저장
         const now = Date.now();
@@ -190,7 +190,11 @@ export class MatchingService {
           .exec();
 
         // 소켓 이벤트: 매칭 성공 알림
-        this.matchingGateway.emitMatchSuccess(user1, user2, room, battle);
+        const problemInfo = {
+          id: problem.id,
+          title: problem.title,
+        };
+        this.matchingGateway.emitMatchSuccess(user1, user2, room, battle, problemInfo);
 
         matchedUsers.push(user1, user2);
 

--- a/apps/api/src/problem/problem.service.ts
+++ b/apps/api/src/problem/problem.service.ts
@@ -27,7 +27,7 @@ export class ProblemService implements OnModuleInit {
 
   async importProblemsFromJson() {
     try {
-      const filePath = path.join(process.cwd(), 'data/problem_sample.json');
+      const filePath = path.join(__dirname, '../data/problem_sample.json');
       if (!fs.existsSync(filePath)) {
         this.logger.error(`File not found: ${filePath}`);
         return;
@@ -58,8 +58,8 @@ export class ProblemService implements OnModuleInit {
 
         problem.url = data.url;
         problem.title = data.title;
-        problem.timeLimit = data.time_limit;
-        problem.memoryLimit = data.memory_limit;
+        problem.timeLimit = data.timeLimit;
+        problem.memoryLimit = data.memoryLimit;
         problem.statement = data.statement;
         problem.input = data.input;
         problem.output = data.output;
@@ -79,5 +79,16 @@ export class ProblemService implements OnModuleInit {
 
   async findAll(): Promise<Problem[]> {
     return this.problemRepository.find();
+  }
+
+  async findFirst(): Promise<Problem | null> {
+    return this.problemRepository.findOne({
+      where: { difficulty: 'EASY' },
+      order: { id: 'ASC' },
+    });
+  }
+
+  async findOne(id: string): Promise<Problem | null> {
+    return this.problemRepository.findOne({ where: { id } });
   }
 }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -6,10 +6,12 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
+import { ProblemDataPayload } from '@packages/types/problem';
 import Redis from 'ioredis';
 import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
+import { ProblemService } from '@/problem/problem.service';
 
 import { CHAT_TYPE } from '../../../../packages/constants/chat';
 import {
@@ -33,6 +35,7 @@ export class RoomGateway {
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly roomService: RoomService,
     private readonly battleService: BattleService,
+    private readonly problemService: ProblemService,
   ) {}
 
   @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
@@ -168,6 +171,29 @@ export class RoomGateway {
       playerCount: room.currentPlayers.length,
       spectatorCount: room.currentSpectators.length,
     });
+
+    // 문제 정보 전송
+    const battle = await this.battleService.getBattleByRoomId(roomId);
+    if (battle) {
+      const problemEntity = await this.problemService.findOne(battle.problemId);
+      if (problemEntity) {
+        client.emit(SOCKET_EVENT.PROBLEM_INFO, {
+          id: problemEntity.id,
+          source: problemEntity.source,
+          difficulty: problemEntity.difficulty,
+          tags: problemEntity.tags,
+          url: problemEntity.url,
+          title: problemEntity.title,
+          timeLimit: problemEntity.timeLimit,
+          memoryLimit: problemEntity.memoryLimit,
+          statement: problemEntity.statement,
+          input: problemEntity.input,
+          output: problemEntity.output,
+          note: problemEntity.note,
+          examples: problemEntity.examples,
+        } as ProblemDataPayload);
+      }
+    }
 
     // 최신 인원 정보를 브로드캐스트
     const availability = await this.roomService.getRoomAvailability(roomId);

--- a/apps/api/src/room/room.module.ts
+++ b/apps/api/src/room/room.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { BattleModule } from '@/battle/battle.module';
+import { ProblemModule } from '@/problem/problem.module';
 
 import { RoomController } from './room.controller';
 import { RoomGateway } from './room.gateway';
 import { RoomService } from './room.service';
 
 @Module({
-  imports: [BattleModule],
+  imports: [BattleModule, ProblemModule],
   providers: [RoomService, RoomGateway],
   controllers: [RoomController],
   exports: [RoomService], // MatchingModule에서 사용할 수 있도록 export

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -2,8 +2,11 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { BATTLE_CONFIG } from '@packages/constants/battle';
 import { Battle } from '@packages/types/battle';
 import { MatchingUser } from '@packages/types/matching';
+import { ProblemDataPayload } from '@packages/types/problem';
 import { RoomUser } from '@packages/types/user';
 import Redis from 'ioredis';
+
+import { ProblemService } from '@/problem/problem.service';
 
 import { ROOM_CONFIG } from '../../../../packages/constants/socket-event';
 import { Room, RoomAvailabilityResponseDTO, RoomSettings } from '../../../../packages/types/room';
@@ -23,6 +26,7 @@ export class RoomService {
   constructor(
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
     private readonly BattleService: BattleService,
+    private readonly problemService: ProblemService,
   ) {}
 
   // 기본 방 생성
@@ -57,7 +61,7 @@ export class RoomService {
   async createMatchedRoom(
     user1: MatchingUser,
     user2: MatchingUser,
-  ): Promise<{ room: Room; battle: Battle }> {
+  ): Promise<{ room: Room; battle: Battle; problem: ProblemDataPayload }> {
     try {
       // 방 생성: 유저 정보와 즉시 시작 상태 주입
       const now = new Date();
@@ -98,10 +102,31 @@ export class RoomService {
         users: room.currentPlayers.map((player) => player.userId),
       });
 
+      const problemEntity = await this.problemService.findOne(battle.problemId);
+      if (!problemEntity) {
+        throw new Error('Problem not found for the battle.');
+      }
+
+      const problem: ProblemDataPayload = {
+        id: problemEntity.id,
+        source: problemEntity.source,
+        difficulty: problemEntity.difficulty,
+        tags: problemEntity.tags,
+        url: problemEntity.url,
+        title: problemEntity.title,
+        timeLimit: problemEntity.timeLimit,
+        memoryLimit: problemEntity.memoryLimit,
+        statement: problemEntity.statement,
+        input: problemEntity.input,
+        output: problemEntity.output,
+        note: problemEntity.note,
+        examples: problemEntity.examples,
+      };
+
       this.logger.log(
         `Created matched room ${room.roomId} for users ${user1.userId} and ${user2.userId}`,
       );
-      return { room, battle };
+      return { room, battle, problem };
     } catch (error: unknown) {
       if (error instanceof Error)
         this.logger.error(`Failed to create matched room: ${error.message}`);

--- a/apps/judge/.gitignore
+++ b/apps/judge/.gitignore
@@ -1,0 +1,56 @@
+# compiled output
+/dist
+/node_modules
+/build
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# temp directory
+.temp
+.tmp
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/apps/judge/Dockerfile
+++ b/apps/judge/Dockerfile
@@ -1,0 +1,52 @@
+# Base
+FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.20.0 --activate
+WORKDIR /app
+
+# deps
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/judge/package.json ./apps/judge/
+COPY packages ./packages
+RUN pnpm install --frozen-lockfile
+
+# development
+FROM base AS development
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/judge/node_modules ./apps/judge/node_modules
+COPY package.json pnpm-workspace.yaml ./
+COPY apps/judge/package.json apps/judge/nest-cli.json apps/judge/tsconfig*.json ./apps/judge/
+WORKDIR /app/apps/judge
+EXPOSE 4000
+CMD ["pnpm", "run", "start:dev"]
+
+# build
+FROM base AS builder
+WORKDIR /app
+COPY . .
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/judge/node_modules ./apps/judge/node_modules
+WORKDIR /app/apps/judge
+RUN pnpm run build
+
+# production
+FROM node:22-alpine AS production
+RUN corepack enable && corepack prepare pnpm@10.20.0 --activate
+WORKDIR /app
+
+# Docker에서는 Husky CI 필요없음
+ENV HUSKY=0
+
+# 프로덕션 의존성만 설치
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/judge/package.json ./apps/judge/
+COPY packages ./packages
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
+
+# 빌드된 파일 복사
+COPY --from=builder /app/apps/judge/dist ./apps/judge/dist
+
+WORKDIR /app/apps/judge
+EXPOSE 4000
+CMD ["node", "dist/apps/judge/src/main.js"]

--- a/apps/judge/README.md
+++ b/apps/judge/README.md
@@ -8,4 +8,4 @@
 pnpm run start:dev
 ```
 
-서버는 `http://localhost:3001`에서 실행됩니다.
+서버는 `http://localhost:4000`에서 실행됩니다.

--- a/apps/judge/README.md
+++ b/apps/judge/README.md
@@ -1,0 +1,11 @@
+# Judge Server
+
+코드 실행 및 채점을 담당하는 Judge 서버입니다.
+
+## 실행 방법
+
+```bash
+pnpm run start:dev
+```
+
+서버는 `http://localhost:3001`에서 실행됩니다.

--- a/apps/judge/eslint.config.mjs
+++ b/apps/judge/eslint.config.mjs
@@ -1,0 +1,3 @@
+import apiConfig from '@web30/eslint-config/api';
+
+export default apiConfig;

--- a/apps/judge/eslint.config.mjs
+++ b/apps/judge/eslint.config.mjs
@@ -1,3 +1,8 @@
 import apiConfig from '@web30/eslint-config/api';
 
-export default apiConfig;
+export default [
+  ...apiConfig,
+  {
+    ignores: ['runner/**'],
+  },
+];

--- a/apps/judge/nest-cli.json
+++ b/apps/judge/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/apps/judge/package.json
+++ b/apps/judge/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "judge",
+  "version": "0.0.1",
+  "description": "Code execution judge server",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "ts-node-dev --respawn --transpile-only --poll src/main.ts",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.2",
+    "@nestjs/core": "^11.0.1",
+    "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-socket.io": "^11.1.9",
+    "@nestjs/schedule": "^6.1.0",
+    "@nestjs/typeorm": "^11.0.0",
+    "@nestjs/websockets": "^11.1.9",
+    "cron": "^4.4.0",
+    "ioredis": "^5.8.2",
+    "mysql2": "^3.15.3",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "socket.io": "^4.8.1",
+    "tsconfig-paths": "^4.2.0",
+    "typeorm": "^0.3.28"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^11.0.0",
+    "@nestjs/schematics": "^11.0.0",
+    "@nestjs/testing": "^11.0.1",
+    "@types/express": "^5.0.0",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.10.7",
+    "@types/socket.io": "^3.0.2",
+    "@types/supertest": "^6.0.2",
+    "@web30/eslint-config": "workspace:*",
+    "eslint": "^9.18.0",
+    "ioredis-mock": "^8.13.1",
+    "jest": "^30.0.0",
+    "prettier": "^3.4.2",
+    "source-map-support": "^0.5.21",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.5",
+    "ts-loader": "^9.5.2",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.7.3"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": ".",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@packages/(.*)$": "<rootDir>/../../packages/$1"
+    }
+  }
+}

--- a/apps/judge/runner/Dockerfile
+++ b/apps/judge/runner/Dockerfile
@@ -1,0 +1,25 @@
+# Base Image
+FROM node:20-alpine
+
+# 2. 일반 사용자 'coder' 계정 생성
+RUN addgroup -S coder && adduser -S coder -G coder
+
+# 3. 불필요한 도구 삭제 (보안 강화)
+RUN rm -rf /usr/local/bin/npm /usr/local/bin/npx /usr/local/lib/node_modules \
+    && rm -rf /opt/yarn* /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
+# 4. 네트워크 도구 삭제
+RUN rm -f /usr/bin/curl /usr/bin/wget
+
+# 5. 작업 디렉토리 설정 및 파일 복사
+WORKDIR /runner
+
+COPY run.js .
+
+# 6. 소유권 변경 및 사용자 전환
+RUN chown -R coder:coder /runner
+
+USER coder
+
+# 7. 기본 실행 명령어
+CMD ["node", "run.js"]

--- a/apps/judge/runner/Dockerfile
+++ b/apps/judge/runner/Dockerfile
@@ -14,7 +14,7 @@ RUN rm -f /usr/bin/curl /usr/bin/wget
 # 5. 작업 디렉토리 설정 및 파일 복사
 WORKDIR /runner
 
-COPY run.js .
+COPY run.js wrapper.js ./
 
 # 6. 소유권 변경 및 사용자 전환
 RUN chown -R coder:coder /runner

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -95,8 +95,21 @@ async function main() {
     const result = await runTestCase(solutionFile, testCase.input, timeLimit, memoryLimit);
 
     // 4. 실행 결과 파일 저장 (Save Results)
-    // 표준 출력(stdout) 저장 -> output_{i}.txt
-    fs.writeFileSync(path.join(OUTPUT_DIR, `output_${i}.txt`), result.stdout);
+    // stdout에서 메트릭 정보 분리
+    const parts = result.stdout.split('\n---METRIC---\n');
+    const rawOutput = parts[0];
+    const usedMemory = parts[1] ? parseInt(parts[1], 10) : 0;
+
+    const caseResult = {
+      output: rawOutput,
+      time: result.time,
+      memory: Math.round((usedMemory / 1024 / 1024) * 100) / 100, // Byte -> MB 변환 (소수점 2자리)
+    };
+
+    fs.writeFileSync(
+      path.join(OUTPUT_DIR, `output_${i}.json`),
+      JSON.stringify(caseResult, null, 2),
+    );
 
     // 표준 에러(stderr)가 있다면 저장 -> error_{i}.txt
     if (result.stderr) {
@@ -133,7 +146,7 @@ function runTestCase(solutionFile, input, timeLimit, memoryLimit) {
         solutionFile,
       ],
       {
-        stdio: ['pipe', 'pipe', 'pipe'], // stdin, stdout, stderr를 부모와 연결
+        stdio: ['pipe', 'pipe', 'pipe'], // 다시 pipe로 복구
       },
     );
 
@@ -159,9 +172,11 @@ function runTestCase(solutionFile, input, timeLimit, memoryLimit) {
     });
 
     // stderr(표준 에러) 수집
-    child.stderr.on('data', (data) => {
-      stderrBuffer += data.toString();
-    });
+    if (child.stderr) {
+      child.stderr.on('data', (data) => {
+        stderrBuffer += data.toString();
+      });
+    }
 
     // stdin(표준 입력)에 테스트 케이스 주입
     child.stdin.write(input);

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -1,6 +1,205 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+// --- 환경 설정 (Configuration) ---
+// 배포 환경(Docker)에서는 볼륨 마운트된 경로를 사용합니다.
+// 로컬 개발 환경에서는 프로젝트 루트의 'judge-data' 폴더를 바라봅니다.
+const IS_DOCKER = process.env.IS_DOCKER === 'true';
+
+// Docker 환경:
+// /app/data -> 호스트의 judge-data (읽기 전용, 문제 정보)
+// /app/output -> 호스트의 judge-data/submissions/{id} (읽기/쓰기, 제출물 및 결과)
+const BASE_DIR = IS_DOCKER ? '/app' : path.resolve(__dirname, '../../../judge-data');
+
+// 로컬 개발 시 Docker 마운트 동작을 흉내내기 위한 경로 조정
+const submissionId = process.argv[2];
+if (!IS_DOCKER && !submissionId) {
+  console.error('Usage: node run.js <submissionId>');
+  process.exit(1);
+}
+
+// DATA_DIR: 문제 정보("problems")가 위치한 경로
+// Docker: /app/data
+// Local: judge-data
+const DATA_DIR = IS_DOCKER ? path.join(BASE_DIR, 'data') : BASE_DIR;
+
+// OUTPUT_DIR: 유저 코드("solution.js")가 있고 실행 결과를 저장할 경로
+// Docker: /app/output (이미 특정 제출물 폴더로 마운트됨)
+// Local: judge-data/submissions/{id} (직접 경로를 찾아가야 함)
+const OUTPUT_DIR = IS_DOCKER
+  ? path.join(BASE_DIR, 'output')
+  : path.join(BASE_DIR, 'submissions', submissionId);
+
 /**
- * Placeholder for code execution script.
- * Actual implementation will be done in Story 3-2.
+ * 메인 실행 함수
  */
-console.log('Runner started as user:', process.env.USER || 'unknown');
-console.log('Current working directory:', process.cwd());
+async function main() {
+  console.log(`[Runner] Starting... (ID: ${submissionId || 'Mounted Volume'})`);
+  console.log(`[Runner] Environment: ${IS_DOCKER ? 'Docker' : 'Local Host'}`);
+
+  // 1. 메타 데이터 로드 (Load Metadata)
+  // problemId(문제번호), timeLimit(시간제한), memoryLimit(메모리제한), type(제출타입)
+  const metaPath = path.join(OUTPUT_DIR, 'meta.json');
+
+  if (!fs.existsSync(metaPath)) {
+    console.error(`[Error] Meta file not found: ${metaPath}`);
+    console.error(`[Debug] Looked in: ${OUTPUT_DIR}`);
+    process.exit(1);
+  }
+
+  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+  const problemId = meta.problemId;
+  const timeLimit = meta.timeLimit || 2000; // 기본값 2초
+  const memoryLimit = meta.memoryLimit || 256; // 기본값 256MB
+  const type = meta.type || 'SUBMISSION'; // 'TEST'(테스트실행) 또는 'SUBMISSION'(정답제출)
+
+  console.log(
+    `[Runner] Problem: ${problemId}, Type: ${type}, TimeLimit: ${timeLimit}ms, memoryLimit: ${memoryLimit}MB `,
+  );
+
+  // 2. 테스트 케이스 로드 (Load Test Cases)
+  // Docker: /app/data/problems/{id}/[test|submission].json
+  const problemPath = path.join(DATA_DIR, 'problems', String(problemId));
+  // 타입에 따라 예제용('test.json') 또는 채점용('submission.json') 선택
+  const casesFileName = type === 'TEST' ? 'test.json' : 'submission.json';
+  const casesPath = path.join(problemPath, casesFileName);
+
+  if (!fs.existsSync(casesPath)) {
+    console.error(`[Error] Cases file not found: ${casesPath}`);
+    process.exit(1);
+  }
+
+  console.log(`[Runner] Loading cases from: ${casesFileName}`);
+
+  const testCases = JSON.parse(fs.readFileSync(casesPath, 'utf8'));
+  const solutionFile = path.join(OUTPUT_DIR, 'solution.js');
+
+  if (!fs.existsSync(solutionFile)) {
+    console.error(`[Error] Solution file not found: ${solutionFile}`);
+    process.exit(1);
+  }
+
+  // 3. 테스트 케이스별 실행 (Execute User Code)
+  for (let i = 0; i < testCases.length; i++) {
+    const testCase = testCases[i];
+    console.log(`[Runner] Running Case #${i + 1} (ID: ${testCase.id})...`);
+
+    // 개별 케이스 실행
+    const result = await runTestCase(solutionFile, testCase.input, timeLimit, memoryLimit);
+
+    // 4. 실행 결과 파일 저장 (Save Results)
+    // 표준 출력(stdout) 저장 -> output_{i}.txt
+    fs.writeFileSync(path.join(OUTPUT_DIR, `output_${i}.txt`), result.stdout);
+
+    // 표준 에러(stderr)가 있다면 저장 -> error_{i}.txt
+    if (result.stderr) {
+      fs.writeFileSync(path.join(OUTPUT_DIR, `error_${i}.txt`), result.stderr);
+    }
+
+    // 진행 상황 로깅
+    console.log(`  -> Status: ${result.status}, Time: ${result.time}ms`);
+  }
+
+  console.log('[Runner] All cases completed.');
+}
+
+/**
+ * 유저 코드를 자식 프로세스로 실행하는 함수
+ * @param {string} solutionFile - 실행할 파일 경로
+ * @param {string} input - 테스트 케이스 입력값
+ * @param {number} timeLimit - 시간 제한 (ms)
+ * @param {number} memoryLimit - 메모리 제한 (MB)
+ */
+function runTestCase(solutionFile, input, timeLimit, memoryLimit) {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    let status = 'PENDING';
+
+    // 자식 프로세스 생성 (spawn)
+    // node --max-old-space-size={Limit} wrapper.js solution.js
+    const wrapperPath = IS_DOCKER ? '/runner/wrapper.js' : path.join(__dirname, 'wrapper.js');
+    const child = spawn(
+      'node',
+      [
+        `--max-old-space-size=${memoryLimit}`, // V8 메모리 제한 옵션
+        wrapperPath,
+        solutionFile,
+      ],
+      {
+        stdio: ['pipe', 'pipe', 'pipe'], // stdin, stdout, stderr를 부모와 연결
+      },
+    );
+
+    let stdoutBuffer = '';
+    let stderrBuffer = '';
+
+    // 시간 초과(Time Limit Exceeded) 감시 타이머
+    const timer = setTimeout(() => {
+      if (child.exitCode === null) {
+        child.kill('SIGKILL'); // 강제 종료
+        status = 'TIME_LIMIT_EXCEEDED';
+      }
+    }, timeLimit);
+
+    // stdout(표준 출력) 수집
+    child.stdout.on('data', (data) => {
+      stdoutBuffer += data.toString();
+      // 출력 제한(Output Limit Exceeded) 안전 장치: 1MB 초과 시 종료
+      if (stdoutBuffer.length > 1024 * 1024) {
+        child.kill('SIGKILL');
+        status = 'OUTPUT_LIMIT_EXCEEDED';
+      }
+    });
+
+    // stderr(표준 에러) 수집
+    child.stderr.on('data', (data) => {
+      stderrBuffer += data.toString();
+    });
+
+    // stdin(표준 입력)에 테스트 케이스 주입
+    child.stdin.write(input);
+    child.stdin.end(); // 입력 끝 알림
+
+    // 프로세스 종료 처리
+    child.on('close', (code) => {
+      clearTimeout(timer); // 타이머 해제
+      const endTime = Date.now();
+      const time = endTime - startTime;
+
+      // 다른 상태(TLE, OLE 등)가 아니고 정상 종료된 경우
+      if (status === 'PENDING') {
+        if (code === 0) {
+          status = 'ACCEPTED';
+        } else {
+          status = 'RUNTIME_ERROR';
+        }
+      }
+
+      resolve({
+        status,
+        time,
+        stdout: stdoutBuffer,
+        stderr: stderrBuffer,
+        exitCode: code,
+      });
+    });
+
+    // 실행 실패 처리 (예: node 명령어를 못 찾음)
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        status: 'INTERNAL_ERROR',
+        time: 0,
+        stdout: '',
+        stderr: err.message,
+        exitCode: -1,
+      });
+    });
+  });
+}
+
+main().catch((err) => {
+  console.error('[Runner] Fatal Error:', err);
+  process.exit(1);
+});

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -51,7 +51,7 @@ async function main() {
   if (!fs.existsSync(metaPath)) {
     console.error(`[Error] Meta file not found: ${metaPath}`);
     console.error(`[Debug] Looked in: ${OUTPUT_DIR}`);
-    process.exit(1);
+    process.exit(1); // meta.json 파일 없을 시 즉시 종료
   }
 
   const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
@@ -73,7 +73,7 @@ async function main() {
 
   if (!fs.existsSync(casesPath)) {
     console.error(`[Error] Cases file not found: ${casesPath}`);
-    process.exit(1);
+    process.exit(1); // 테스트 파일 없을 시 즉시 종료
   }
 
   console.log(`[Runner] Loading cases from: ${casesFileName}`);
@@ -83,7 +83,7 @@ async function main() {
 
   if (!fs.existsSync(solutionFile)) {
     console.error(`[Error] Solution file not found: ${solutionFile}`);
-    process.exit(1);
+    process.exit(1); // solution.js 파일 없을 시 즉시 종료
   }
 
   // 3. 테스트 케이스별 실행 (Execute User Code)
@@ -155,12 +155,13 @@ function runTestCase(solutionFile, input, timeLimit, memoryLimit) {
     let stderrBuffer = '';
 
     // 시간 초과(Time Limit Exceeded) 감시 타이머
+    // 실제 timeLimit보다 약간의 여유(1초)를 주어 시스템 오버헤드를 허용합니다.
     const timer = setTimeout(() => {
       if (child.exitCode === null) {
         child.kill('SIGKILL'); // 강제 종료
         status = 'TIME_LIMIT_EXCEEDED';
       }
-    }, timeLimit);
+    }, timeLimit + 1000);
 
     // stdout(표준 출력) 수집
     child.stdout.on('data', (data) => {

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -1,0 +1,6 @@
+/**
+ * Placeholder for code execution script.
+ * Actual implementation will be done in Story 3-2.
+ */
+console.log('Runner started as user:', process.env.USER || 'unknown');
+console.log('Current working directory:', process.cwd());

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -101,6 +101,7 @@ async function main() {
     const usedMemory = parts[1] ? parseInt(parts[1], 10) : 0;
 
     const caseResult = {
+      status: result.status, // 추가: 개별 케이스의 상태 (ACCEPTED, OUTPUT_LIMIT_EXCEEDED 등)
       output: rawOutput,
       time: result.time,
       memory: Math.round((usedMemory / 1024 / 1024) * 100) / 100, // Byte -> MB 변환 (소수점 2자리)

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -31,6 +31,12 @@ const OUTPUT_DIR = IS_DOCKER
   ? path.join(BASE_DIR, 'output')
   : path.join(BASE_DIR, 'submissions', submissionId);
 
+// --- 폴더 자동 생성 (Directory Preparation) ---
+// 실행 결과를 저장할 폴더가 없으면 자동으로 생성합니다.
+if (!fs.existsSync(OUTPUT_DIR)) {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+}
+
 /**
  * 메인 실행 함수
  */

--- a/apps/judge/runner/wrapper.js
+++ b/apps/judge/runner/wrapper.js
@@ -1,0 +1,66 @@
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+/**
+ * wrapper.js
+ * 유저가 작성한 solution.js를 불러와서 'solution' 함수를 찾아 실행합니다.
+ * 더 이상 유저가 module.exports를 작성할 필요가 없도록 개선된 버전입니다.
+ */
+function main() {
+  const solutionPath = process.argv[2];
+
+  if (!solutionPath) {
+    process.exit(1);
+  }
+
+  // 1. 유저 코드 읽기
+  let userCode;
+  try {
+    userCode = fs.readFileSync(solutionPath, 'utf8');
+  } catch (err) {
+    process.stderr.write(`[Wrapper] Failed to read solution file: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  // 2. VM(가상 머신) 환경 설정
+  // 유저 코드가 실행될 격리된 컨텍스트를 만듭니다.
+  const context = {
+    console, // 디버깅용 로그 허용
+    process, // 기본적인 프로세스 객체 허용
+    Buffer,
+    setTimeout,
+    clearTimeout,
+    // 필요 시 여기에 더 많은 전역 객체를 주입할 수 있습니다.
+  };
+  vm.createContext(context);
+
+  try {
+    // 유저 코드를 실행합니다. 이때 전역 범위에 solution 함수가 선언됩니다.
+    vm.runInContext(userCode, context);
+
+    // 실행 후 컨텍스트에서 'solution'이라는 이름의 함수를 찾습니다.
+    const solution = context.solution;
+
+    if (typeof solution !== 'function') {
+      process.stderr.write('[Wrapper] function solution(input) { ... } 이 정의되지 않았습니다.\n');
+      process.exit(1);
+    }
+
+    // 3. 입력 읽기 (stdin)
+    const input = fs.readFileSync(0, 'utf8');
+
+    // 4. 함수 실행 및 결과 출력
+    const result = solution(input);
+
+    // 결과가 있으면 표준 출력(stdout)으로 내보냄
+    if (result !== undefined) {
+      process.stdout.write(String(result));
+    }
+  } catch (err) {
+    // 실행 중 발생한 에러 처리 (Runtime Error)
+    process.stderr.write(`[Wrapper] Runtime Error: ${err.stack || err.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/apps/judge/runner/wrapper.js
+++ b/apps/judge/runner/wrapper.js
@@ -2,63 +2,46 @@ const fs = require('node:fs');
 const vm = require('node:vm');
 
 /**
- * wrapper.js
- * 유저가 작성한 solution.js를 불러와서 'solution' 함수를 찾아 실행합니다.
- * 더 이상 유저가 module.exports를 작성할 필요가 없도록 개선된 버전입니다.
+ * wrapper.js (Memory Measurement Version)
  */
 function main() {
   const solutionPath = process.argv[2];
+  const userCode = fs.readFileSync(solutionPath, 'utf8');
 
-  if (!solutionPath) {
-    process.exit(1);
-  }
-
-  // 1. 유저 코드 읽기
-  let userCode;
-  try {
-    userCode = fs.readFileSync(solutionPath, 'utf8');
-  } catch (err) {
-    process.stderr.write(`[Wrapper] Failed to read solution file: ${err.message}\n`);
-    process.exit(1);
-  }
-
-  // 2. VM(가상 머신) 환경 설정
-  // 유저 코드가 실행될 격리된 컨텍스트를 만듭니다.
   const context = {
-    console, // 디버깅용 로그 허용
-    process, // 기본적인 프로세스 객체 허용
+    console,
+    process,
     Buffer,
     setTimeout,
     clearTimeout,
-    // 필요 시 여기에 더 많은 전역 객체를 주입할 수 있습니다.
   };
   vm.createContext(context);
 
   try {
-    // 유저 코드를 실행합니다. 이때 전역 범위에 solution 함수가 선언됩니다.
     vm.runInContext(userCode, context);
-
-    // 실행 후 컨텍스트에서 'solution'이라는 이름의 함수를 찾습니다.
     const solution = context.solution;
 
     if (typeof solution !== 'function') {
-      process.stderr.write('[Wrapper] function solution(input) { ... } 이 정의되지 않았습니다.\n');
+      process.stderr.write('Error: solution function missing\n');
       process.exit(1);
     }
 
-    // 3. 입력 읽기 (stdin)
     const input = fs.readFileSync(0, 'utf8');
 
-    // 4. 함수 실행 및 결과 출력
+    // 실행 전 메모리 측정은 큰 의미가 없으므로
+    // 실행 완료 직후의 heapUsed를 측정합니다.
     const result = solution(input);
+    const memoryUsage = process.memoryUsage().heapUsed;
 
-    // 결과가 있으면 표준 출력(stdout)으로 내보냄
+    // 표준 출력으로 결과 전송
     if (result !== undefined) {
       process.stdout.write(String(result));
     }
+
+    // 메모리 정보 구분자를 붙여서 마지막에 전송
+    process.stdout.write(`\n---METRIC---\n${memoryUsage}`);
   } catch (err) {
-    // 실행 중 발생한 에러 처리 (Runtime Error)
-    process.stderr.write(`[Wrapper] Runtime Error: ${err.stack || err.message}\n`);
+    process.stderr.write(err.stack || err.message);
     process.exit(1);
   }
 }

--- a/apps/judge/src/app.module.ts
+++ b/apps/judge/src/app.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { PubSubModule } from './pubsub/pubsub.module';
+import { RedisModule } from './redis/redis.module';
+
 @Module({
   imports: [
     // 환경변수 설정
@@ -26,6 +29,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
       }),
       inject: [ConfigService],
     }),
+
+    RedisModule,
+    PubSubModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/judge/src/app.module.ts
+++ b/apps/judge/src/app.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [
+    // 환경변수 설정
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: '.env',
+    }),
+
+    // MySQL (TypeORM) 연결 설정
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        type: 'mysql',
+        host: configService.get('DB_HOST'),
+        port: configService.get('DB_PORT'),
+        username: configService.get('DB_USERNAME'),
+        password: configService.get('DB_PASSWORD'),
+        database: configService.get('DB_DATABASE'),
+        entities: [],
+        synchronize: true,
+        logging: ['error'],
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/apps/judge/src/main.ts
+++ b/apps/judge/src/main.ts
@@ -1,0 +1,13 @@
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = 4000;
+
+  await app.listen(port);
+  console.warn(`Judge server is running on: http://localhost:${port}`);
+}
+
+void bootstrap();

--- a/apps/judge/src/pubsub/pubsub.module.ts
+++ b/apps/judge/src/pubsub/pubsub.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { PubsubService } from './pubsub.service';
+
+@Module({
+  providers: [PubsubService],
+  exports: [PubsubService],
+})
+export class PubSubModule {}

--- a/apps/judge/src/pubsub/pubsub.service.ts
+++ b/apps/judge/src/pubsub/pubsub.service.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { PUBSUB_CHANNELS } from '@packages/constants/pubsub';
-import type { FinalResultMessage, TestcaseUpdateMessage } from '@packages/types/pubsub';
 import type Redis from 'ioredis';
 
-import { REDIS_CLIENT } from '@/redis/redis.module';
+import { PUBSUB_CHANNELS } from '../../../../packages/constants/pubsub';
+import type { FinalResultMessage, TestcaseUpdateMessage } from '../../../../packages/types/pubsub';
+import { REDIS_CLIENT } from '../redis/redis.module';
 
 @Injectable()
 export class PubsubService {

--- a/apps/judge/src/pubsub/pubsub.service.ts
+++ b/apps/judge/src/pubsub/pubsub.service.ts
@@ -1,0 +1,46 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { PUBSUB_CHANNELS } from '@packages/constants/pubsub';
+import type { FinalResultMessage, TestcaseUpdateMessage } from '@packages/types/pubsub';
+import type Redis from 'ioredis';
+
+import { REDIS_CLIENT } from '@/redis/redis.module';
+
+@Injectable()
+export class PubsubService {
+  private readonly logger = new Logger(PubsubService.name);
+  private readonly CHANNEL = PUBSUB_CHANNELS.SUBMISSION_RESULT;
+
+  constructor(@Inject(REDIS_CLIENT) private readonly redisPublisher: Redis) {}
+
+  async publishTestcaseUpdate(message: TestcaseUpdateMessage): Promise<void> {
+    try {
+      const payload = JSON.stringify(message);
+      await this.redisPublisher.publish(this.CHANNEL, payload);
+      this.logger.log(
+        `Published TESTCASE_UPDATE for submission ${message.submissionId}: TC#${message.testcase.index} ${message.testcase.status} (${message.progress.completed}/${message.progress.total})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to publish testcase update for submission ${message.submissionId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  async publishFinalResult(message: FinalResultMessage): Promise<void> {
+    try {
+      const payload = JSON.stringify(message);
+      await this.redisPublisher.publish(this.CHANNEL, payload);
+      this.logger.log(
+        `Published FINAL_RESULT for submission ${message.submissionId}: ${message.status} (${message.result.passed}/${message.result.total})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to publish final result for submission ${message.submissionId}`,
+        error,
+      );
+      throw error;
+    }
+  }
+}

--- a/apps/judge/src/redis/redis.module.ts
+++ b/apps/judge/src/redis/redis.module.ts
@@ -1,0 +1,33 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      useFactory: (configService: ConfigService) => {
+        const redis = new Redis({
+          host: configService.get('REDIS_HOST'),
+          port: configService.get('REDIS_PORT'),
+        });
+
+        redis.on('connect', () => {
+          console.warn('Redis connected successfully');
+        });
+
+        redis.on('error', (error) => {
+          console.error('Redis connection error:', error);
+        });
+
+        return redis;
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [REDIS_CLIENT],
+})
+export class RedisModule {}

--- a/apps/judge/test/jest-e2e.json
+++ b/apps/judge/test/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1",
+    "^@/(.*)$": "<rootDir>/src/$1",
+    "^@packages/(.*)$": "<rootDir>/../../packages/$1"
+  }
+}

--- a/apps/judge/tsconfig.build.json
+++ b/apps/judge/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/apps/judge/tsconfig.json
+++ b/apps/judge/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolvePackageJsonExports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2023",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "paths": {
+      "@packages/*": ["../../packages/*"],
+      "@/*": ["src/*"]
+    },
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,6 +70,31 @@ services:
       - /app/apps/web/node_modules
       - /app/node_modules
 
+  judge:
+    build:
+      context: .
+      dockerfile: apps/judge/Dockerfile
+      target: development
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    env_file:
+      - .env.dev
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - WATCHPACK_POLLING=true
+    ports:
+      - "4000:4000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # 도커 소켓 마운트 (코드 실행용 컨테이너 생성을 위해 필수)
+      - ./apps/judge:/app/apps/judge
+      - ./packages:/app/packages
+      - /app/apps/judge/node_modules
+      - /app/node_modules
+
 volumes:
   mysql_data:
   redis_data:

--- a/packages/constants/pubsub.ts
+++ b/packages/constants/pubsub.ts
@@ -1,0 +1,3 @@
+export const PUBSUB_CHANNELS = {
+  SUBMISSION_RESULT: 'submission-result',
+} as const;

--- a/packages/constants/socket-event.ts
+++ b/packages/constants/socket-event.ts
@@ -30,6 +30,7 @@ export const SOCKET_EVENT = {
   ROOM_USER_LEFT: 'room-left', // 유저 퇴장 알림
   RECEIVE_CHAT: 'receive-chat', // 관전자 채팅 수신(일반/시스템)
   ROOM_LIST: 'room-list', // 방 목록 응답/브로드캐스트
+  PROBLEM_INFO: 'problem-info', // 배틀과 문제에 대한 정보
 
   // === Matching ===
   MATCH_SUCCESS: 'match-success', // 매칭 성공 알림

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -5,6 +5,7 @@ export type BattleResult = 'win' | 'lose' | 'draw';
 export interface Battle {
   battleId: string;
   roomId: string;
+  problemId: string;
   status: BattleStatus;
 
   config: {

--- a/packages/types/problem.ts
+++ b/packages/types/problem.ts
@@ -5,8 +5,8 @@ export interface ProblemData {
   tags: string | string[];
   url: string;
   title: string;
-  time_limit: number;
-  memory_limit: number;
+  timeLimit: number;
+  memoryLimit: number;
   statement: string;
   input: string;
   output: string;
@@ -14,3 +14,5 @@ export interface ProblemData {
   examples: { input: string; output: string }[];
   testcases: { input: string; output: string }[];
 }
+
+export interface ProblemDataPayload extends Omit<ProblemData, 'testcases'> {}

--- a/packages/types/pubsub.ts
+++ b/packages/types/pubsub.ts
@@ -1,0 +1,40 @@
+export type TestcaseStatus =
+  | 'ACCEPTED'
+  | 'WRONG_ANSWER'
+  | 'TIME_LIMIT_EXCEEDED'
+  | 'MEMORY_LIMIT_EXCEEDED'
+  | 'RUNTIME_ERROR'
+  | 'COMPILE_ERROR';
+
+// 각 테스트케이스 결과 전송 (실시간)
+export interface TestcaseUpdateMessage {
+  type: 'TESTCASE_UPDATE';
+  submissionId: number;
+  testcase: {
+    index: number;
+    status: TestcaseStatus;
+    time: number;
+    memory: number;
+  };
+  progress: {
+    completed: number; // 지금까지 실행 완료된 개수
+    passed: number; // 지금까지 통과한 개수
+    total: number;
+  };
+}
+
+// 최종 결과
+export interface FinalResultMessage {
+  type: 'FINAL_RESULT';
+  submissionId: number;
+  status: TestcaseStatus;
+  result: {
+    passed: number;
+    total: number;
+    time: number; // 최대 시간
+    memory: number; // 최대 메모리
+  };
+}
+
+// Pub/Sub 메시지 Union Type
+export type PubSubMessage = TestcaseUpdateMessage | FinalResultMessage;

--- a/packages/types/pubsub.ts
+++ b/packages/types/pubsub.ts
@@ -3,8 +3,10 @@ export type TestcaseStatus =
   | 'WRONG_ANSWER'
   | 'TIME_LIMIT_EXCEEDED'
   | 'MEMORY_LIMIT_EXCEEDED'
+  | 'OUTPUT_LIMIT_EXCEEDED'
   | 'RUNTIME_ERROR'
-  | 'COMPILE_ERROR';
+  | 'COMPILE_ERROR'
+  | 'INTERNAL_ERROR';
 
 // 각 테스트케이스 결과 전송 (실시간)
 export interface TestcaseUpdateMessage {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,118 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  apps/judge:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.0.1
+        version: 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.2
+        version: 4.0.2(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.1
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(@nestjs/websockets@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-express':
+        specifier: ^11.0.1
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)
+      '@nestjs/platform-socket.io':
+        specifier: ^11.1.9
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.9)(rxjs@7.8.2)
+      '@nestjs/schedule':
+        specifier: ^6.1.0
+        version: 6.1.0(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)
+      '@nestjs/typeorm':
+        specifier: ^11.0.0
+        version: 11.0.0(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.8.2)(mysql2@3.15.3)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3)))
+      '@nestjs/websockets':
+        specifier: ^11.1.9
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(@nestjs/platform-socket.io@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron:
+        specifier: ^4.4.0
+        version: 4.4.0
+      ioredis:
+        specifier: ^5.8.2
+        version: 5.8.2
+      mysql2:
+        specifier: ^3.15.3
+        version: 3.15.3
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+      socket.io:
+        specifier: ^4.8.1
+        version: 4.8.1
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
+      typeorm:
+        specifier: ^0.3.28
+        version: 0.3.28(ioredis@5.8.2)(mysql2@3.15.3)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^11.0.0
+        version: 11.0.14(@types/node@22.19.2)
+      '@nestjs/schematics':
+        specifier: ^11.0.0
+        version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
+      '@nestjs/testing':
+        specifier: ^11.0.1
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(@nestjs/platform-express@11.1.9)
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.2
+      '@types/socket.io':
+        specifier: ^3.0.2
+        version: 3.0.2
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
+      '@web30/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.1(jiti@2.6.1)
+      ioredis-mock:
+        specifier: ^8.13.1
+        version: 8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.8.2))(ioredis@5.8.2)
+      jest:
+        specifier: ^30.0.0
+        version: 30.2.0(@types/node@22.19.2)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
+      prettier:
+        specifier: ^3.4.2
+        version: 3.7.4
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+      supertest:
+        specifier: ^7.0.0
+        version: 7.1.4
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.2)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-loader:
+        specifier: ^9.5.2
+        version: 9.5.4(typescript@5.9.3)(webpack@5.103.0)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.19.2)(typescript@5.9.3)
+      ts-node-dev:
+        specifier: ^2.0.0
+        version: 2.0.0(@types/node@22.19.2)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   apps/web:
     dependencies:
       axios:
@@ -5506,7 +5618,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -5520,14 +5632,14 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.3.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.19.2)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@24.10.3)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -5590,7 +5702,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.2.0':
@@ -5601,7 +5713,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -5678,7 +5790,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6095,11 +6207,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
 
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
@@ -6129,7 +6241,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -6239,12 +6351,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
 
   '@types/socket.io@3.0.2':
     dependencies:
@@ -6264,7 +6376,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':
@@ -7883,6 +7995,39 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.2.0(@types/node@24.10.3)(ts-node@10.9.2(@types/node@22.19.2)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.10.3
+      ts-node: 10.9.2(@types/node@22.19.2)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@30.2.0:
     dependencies:
       '@jest/diff-sequences': 30.0.1
@@ -7915,7 +8060,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7954,7 +8099,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       jest-util: 30.2.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
@@ -7988,7 +8133,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -8017,7 +8162,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       chalk: 4.1.2
       cjs-module-lexer: 2.1.1
       collect-v8-coverage: 1.0.3
@@ -8064,7 +8209,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -8083,7 +8228,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.19.2
+      '@types/node': 24.10.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1


### PR DESCRIPTION
## 🔍 PR 요약

- 사용자가 제출한 코드를 실행하기 위해 서버와 분리된 가상공간 Docker 컨테이너 사용한 격리 환경 구축
- 바인드 마운트 방식을 사용하여 코드 실행 스크립트 개발

## 🧾 관련 이슈

- close #104 
- close #105 
- close #106 

## 🛠️ 주요 변경 사항
### STORY 3-1: Node.js 실행 환경 구축
#### apps/judge/runner/Dockerfile
- 단순히 Node.js를 설치한 것이 아니라, **'보안'** 과 **'격리'** 에 초점을 맞추어 환경을 구성
- **Docker를 사용한 격리 (Isolation)**: 사용자가 제출한 코드는 어떤 위험한 로직(예: 서버 파일 삭제, 무한 루프, 외부 해킹 시도)이 있을지 모르기 때문에 서버 본체와 분리된 가상의 공간(컨테이너)에서만 실행되게 하여 서버 전체를 보호
- **권한 최소화 (Non-root user coder)**: 컨테이너 안에서도 root(관리자) 권한으로 실행하면 혹시 모를 취약점을 통해 서버 본체까지 위협받을 수 있기 때문에 권한이 거의 없는 coder라는 별도 계정을 만들어 그 안에서만 코드가 실행
- **불필요한 도구 제거(npm, curl, wget 삭제)**: 실행 환경에 불필요한 도구가 있으면 악성 코드가 외부에서 공격 도구를 다운로드하거나 네트워크 공격을 할 수 있기 때문에 이를 원천 차단하기 위해 핵심 실행기(node)만 세팅

### STORY 3-2: 코드 실행 스크립트 개발 (run.js)
- 사용자가 입출력 로직을 직접 짜지 않고, solution 함수만 작성하면 되는 '프로그래머스 스타일'로 실행 환경을 구성 (함수형 실행)
#### apps/judge/runner/run.js
- 관리자 역할
- Docker 명령 인자로 전달된 ${submissionId}으로 실행
- 바인드 마운트 방식을 활용하기 위해 `IS_DOCKER` 환경변수를 사용한 경로 설정
- meta.json의 실행 타입(TEST/SUBMISSION)에 따라 test.json / submission.json 로드
- 각 테스트 게이스마다 spawn을 사용하여 격리된 자식 프로세스로 wrapper 실행
- 시간 초과(Time Limit Exceeded) 감시 타이머는 실제 timeLimit보다 약간의 여유(1초)를 주어 시스템 오버헤드를 허용

#### apps/judge/runner/wrapper.js
- 실행 래퍼 역할
- run.js 내부 spawn의 명령어에 의해 실행
- VM 환경을 설정하여 가상의 방(샌드박스) 형태로 격리성과 자유도를 보장
- `stdin`으로 받은 입력을 함수의 인자로 전달하고, 함수의 `return` 값을 `stdout`으로 출력
- `process.memoryUsage().heapUsed`을 사용하여 메모리 측정

## 📸 스크린샷 (선택)
#### 도커 기반 채점 환경 테스트
실행 환경
- Docker 이미지: judge-javascript
- 마운트: judge-data (테스트 케이스 분리 적용)
- 사용자 코드: solution.js (함수형)

**Step 1: 도커 이미지 빌드**
`docker build -t judge-javascript ./apps/judge/runner`
<img width="1104" height="832" alt="image" src="https://github.com/user-attachments/assets/25acdcd0-184a-4d23-9190-4422efdf51e1" />

**Step 2: 채점 실행 테스트**
실제 배포 환경과 동일하게 바인드 마운트를 사용하여 컨테이너를 실행
```
submissionId=1024
memoryLimit=256

docker run --rm \
  -v $(pwd)/judge-data:/app/data:ro \
  -v $(pwd)/judge-data/submissions/${submissionId}:/app/output:rw \
  -e IS_DOCKER=true \
  --network none \
  --memory ${memoryLimit}m \
  --cpus 0.5 \
  --pids-limit 10 \  //  제외
  --tmpfs /tmp:size=32m \
  judge-javascript \
  node /runner/run.js ${submissionId}
```
- -v ... :ro: 문제 데이터는 읽기 전용으로 보호
- -v ... :rw: 유저 폴더(1024)는 결과 기록을 위해 쓰기 권한
- --network none: 유저 코드가 인터넷을 쓰지 못하게 차단
-  --pids-limit: Node.js 내부 스레드들까지 동작하기 위해 제거하여 진행
- 메모리 제한(256M), CPU 제한(0.5개)

**Step 3: 결과 확인**
- output_0.json ~ output_4.json: 유저의 함수가 리턴한 값과 최대 시간, 메모리 값이 저장
- error_*.txt: (에러가 발생했을 경우에만 생성) 런타임 에러 메시지가 저장
- 상태값: 터미널 로그에 ACCEPTED, TIME_LIMIT_EXCEEDED 등 우리가 설정한 긴 이름의 상태값이 잘 찍히는지 확인
- 함수 실행: solution.js에는 module.exports가 없는데도 wrapper.js가 함수를 잘 찾아 실행했는지 확인

<img width="1173" height="305" alt="image" src="https://github.com/user-attachments/assets/517450cb-7db0-42d4-9129-52bfd29bd7b3" />

## 🧠 의도 및 배경

- 사용자 코드를 안전하게 실행시킬 수 있는 샌드박스 환경을 구축하기 위함
- 도커 스토리지의 데이터를 저장하는 방법 중 **바인드 마운트 방식**을 사용하여 **개발 환경과 배포 환경의 구성을 100% 일치**시키기 위함

## 💬 리뷰 요구사항(선택)
- docker run 명령어로 테스트를 실행할 때 기존에 설계한 명령어로 하게되면 계속해서 `TIME_LIMIT_EXCEEDED` 에러가 발생하며 컨테이너가 터졌습니다. 
- PID 10개라는 제한이 Node.js가 내부적으로 기동하는 데 너무 빡빡해서 프로세스가 멈췄을 가능성이 매우 높기 때문이라고 판단했습니다.
- 프로세스 수 제한 대신 --cpus 0.5, TLE 타이머(timeLimit + 1초) 같은 속성을 부여해서 **프로세스 폭탄에도 방어**를 할 수 있도록 하였습니다.
- 그래서 `--pids-limit 10` 옵션을 제외하고 테스트를 진행하니 ACCEPTED로 잘 실행이 되었습니다.
- 도커 컨테이너를 실행하기 위한 옵션에 대한 논의도 진행해보면 좋을 것 같습니다.

- [개발일지 wiki 작성](https://github.com/boostcampwm2025/web30-TADAK/wiki/Docker-%EA%B8%B0%EB%B0%98%EC%9D%98-%EC%BD%94%EB%93%9C-%EC%8B%A4%ED%96%89-%ED%99%98%EA%B2%BD-%EA%B0%9C%EB%B0%9C)