### PR TITLE
[FEAT] 채점 타입에 따른 DB 업데이트

### DIFF
--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -64,6 +64,31 @@ export class PubsubSubscriberService implements OnModuleInit {
       `[FINAL_RESULT] Submission ${message.submissionId}: ${message.status} (${message.result.passed}/${message.result.total})`,
     );
 
+    // submissionId로 type 확인
+    const submissionType = await this.getSubmissionType(message.submissionId);
+
+    // SUBMISSION 타입만 DB 업데이트
+    if (submissionType === 'SUBMISSION') {
+      try {
+        await this.submissionRepository.update(message.submissionId, {
+          status: message.status,
+          passedTestCases: message.result.passed,
+          totalTestCases: message.result.total,
+          executionTime: message.result.time,
+          memoryUsed: message.result.memory,
+        });
+        this.logger.log(`[FINAL_RESULT] DB updated for submission ${message.submissionId}`);
+      } catch (error) {
+        this.logger.error(
+          `[FINAL_RESULT] Failed to update DB for submission ${message.submissionId}`,
+          error,
+        );
+      }
+    } else {
+      this.logger.debug(`[FINAL_RESULT] Skipping DB update for TEST type: ${message.submissionId}`);
+    }
+
+    // WebSocket 전송
     const userInfo = await this.getUserInfoBySubmissionId(message.submissionId);
 
     if (userInfo?.roomId) {
@@ -73,6 +98,28 @@ export class PubsubSubscriberService implements OnModuleInit {
         userId: userInfo.userId,
         username: userInfo.username,
       });
+    }
+  }
+
+  private async getSubmissionType(submissionId: number): Promise<'TEST' | 'SUBMISSION' | null> {
+    const fs = await import('fs');
+    const path = await import('path');
+
+    const metaPath = path.join('/judge-data/submissions', String(submissionId), 'meta.json');
+
+    try {
+      if (!fs.existsSync(metaPath)) {
+        this.logger.warn(`[getSubmissionType] meta.json not found for ${submissionId}`);
+        return null;
+      }
+
+      const metaContent = fs.readFileSync(metaPath, 'utf-8');
+      const meta = JSON.parse(metaContent) as { type: 'TEST' | 'SUBMISSION' };
+
+      return meta.type;
+    } catch (error) {
+      this.logger.error(`[getSubmissionType] Failed to read meta.json for ${submissionId}`, error);
+      return null;
     }
   }
 

--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -54,10 +54,13 @@ export class SubmissionService {
   }
 
   async executeTest(dto: CreateSubmissionDto, userId: string, socketId: string) {
+    // 테스트용 submissionId 생성
+    const testSubmissionId = `test-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
     // 큐에 작업 등록
     await this.submissionQueue.add('test-job', {
       type: 'TEST',
-      submissionId: null,
+      submissionId: testSubmissionId,
       problemId: dto.problemId,
       code: dto.code,
       language: dto.language,


### PR DESCRIPTION
## 🔍 PR 요약

TEST와 SUBMISSION을 구분하여 DB 업데이트

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #132 

## 🛠️ 주요 변경 사항

### TEST 타입에 임시 submissionId 생성
- `apps/api/src/submission/submission.service.ts`
  - `executeTest()` 메서드에서 submissionId 생성
  - 형식: `test-{timestamp}-{random}`
  - DB에 저장하지 않고 큐에만 전달
  - Judge 서버에서 파일 구분을 위해 사용

### SUBMISSION 타입만 DB 업데이트
- `apps/api/src/pubsub/pubsub-subscriber.service.ts`
  - `getSubmissionType()` 메서드 추가: `/judge-data/submissions/{id}/meta.json` 파일에서 type 읽기
  - `handleFinalResult()` 수정: meta.json의 type이 'SUBMISSION'일 때만 DB 업데이트
  - TEST 타입은 DB 업데이트를 건너뛰고 로그만 기록

## 🧠 의도 및 배경

TEST와 SUBMISSION을 구분하여 DB 업데이트가 필요
