### PR TITLE
[FEAT] 배틀페이지 제출하기/코드실행 API 연결 및 경로/채점 로직 버그 수정

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -15,6 +15,13 @@ DB_DATABASE=web30
 REDIS_HOST=redis
 REDIS_PORT=6379
 
+# Judge Docker 경로 (호스트 절대경로)
+# macOS/Linux: 비워두면 ${PWD}/judge-data 사용
+# Windows(WSL): /mnt/c/Users/.../web30-boostcamp/judge-data 형태로 설정
+JUDGE_HOST_PATH=
+JUDGE_VOLUME=/judge-data
+JUDGE_DISABLE_CLEANUP=false
+
 # 서버 설정
 PORT=3000
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -5,15 +5,16 @@
 ```bash
 # 1. 환경 변수 설정
 cp .env.dev.example .env.dev
+# Windows(WSL): .env.dev의 JUDGE_HOST_PATH를 /mnt/c/.../judge-data로 설정
 
 # 2. Docker 실행 (빌드 + 백그라운드)
-docker compose -f docker-compose.dev.yml up --build -d
+docker compose --env-file .env.dev -f docker-compose.dev.yml up --build -d
 
 # 3. 로그 확인
-docker compose -f docker-compose.dev.yml logs -f
+docker compose --env-file .env.dev -f docker-compose.dev.yml logs -f
 
 # 4. 종료
-docker compose -f docker-compose.dev.yml down
+docker compose --env-file .env.dev -f docker-compose.dev.yml down
 ```
 
 ### 서비스 접속
@@ -53,16 +54,16 @@ docker compose -f docker-compose.prod.yml up -d redis
 
 ```bash
 # 컨테이너 상태 확인
-docker compose -f docker-compose.dev.yml ps
+docker compose --env-file .env.dev -f docker-compose.dev.yml ps
 
 # 데이터베이스 초기화 (볼륨 삭제)
-docker compose -f docker-compose.dev.yml down -v
+docker compose --env-file .env.dev -f docker-compose.dev.yml down -v
 
 # MySQL 접속
-docker compose -f docker-compose.dev.yml exec mysql mysql -u web30 -p
+docker compose --env-file .env.dev -f docker-compose.dev.yml exec mysql mysql -u web30 -p
 
 # Redis 접속
-docker compose -f docker-compose.dev.yml exec redis redis-cli
+docker compose --env-file .env.dev -f docker-compose.dev.yml exec redis redis-cli
 ```
 
 ## 참고사항

--- a/apps/judge/src/docker/docker.cleanup.service.ts
+++ b/apps/judge/src/docker/docker.cleanup.service.ts
@@ -18,9 +18,10 @@ export class DockerCleanupService {
   }
 
   private async removeSubmissionFiles(executionId: string): Promise<void> {
-    const submissionsPath = path.resolve(
-      this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH),
-    );
+    const volumePath = this.getString('JUDGE_VOLUME', '');
+    const submissionsPath = volumePath
+      ? path.resolve(volumePath, 'submissions')
+      : path.resolve(this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH));
     const targetPath = path.join(submissionsPath, executionId);
 
     try {

--- a/apps/judge/src/docker/docker.service.ts
+++ b/apps/judge/src/docker/docker.service.ts
@@ -39,10 +39,13 @@ export class DockerRunnerService {
 
   private buildRunArgs(options: DockerRunOptions): string[] {
     const image = this.getString('JUDGE_RUNNER_IMAGE', DOCKER_RUNNER_IMAGE);
-    const problemsPath = path.resolve(this.getString('JUDGE_PROBLEMS_PATH', DOCKER_PROBLEMS_PATH));
-    const submissionsPath = path.resolve(
-      this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH),
-    );
+    const hostBasePath = this.getString('JUDGE_HOST_PATH', '');
+    const problemsPath = hostBasePath
+      ? path.resolve(hostBasePath)
+      : path.resolve(this.getString('JUDGE_PROBLEMS_PATH', DOCKER_PROBLEMS_PATH));
+    const submissionsPath = hostBasePath
+      ? path.resolve(hostBasePath, 'submissions')
+      : path.resolve(this.getString('JUDGE_SUBMISSIONS_PATH', DOCKER_SUBMISSIONS_PATH));
     const submissionOutputPath = path.join(submissionsPath, options.submissionId);
     const memoryLimitMb =
       options.memoryLimitMb ??

--- a/apps/judge/src/judge/judge.context.ts
+++ b/apps/judge/src/judge/judge.context.ts
@@ -13,7 +13,7 @@ export class JudgeContext {
   private finalStatus: TestcaseStatus = 'ACCEPTED';
 
   constructor(
-    public readonly submissionId: number,
+    public readonly submissionId: string,
     private readonly testcases: Testcase[],
     private readonly reader: JudgeReader,
     private readonly checker: JudgeChecker,
@@ -54,9 +54,10 @@ export class JudgeContext {
   }
 
   async reportFinalResult(): Promise<void> {
+    const submissionId = this.submissionId as unknown as number;
     await this.pubsub.publishFinalResult({
       type: 'FINAL_RESULT',
-      submissionId: this.submissionId,
+      submissionId,
       status: this.finalStatus,
       result: {
         passed: this.passed,
@@ -75,9 +76,10 @@ export class JudgeContext {
   }
 
   private async publishUpdate(index: number, status: TestcaseStatus, time: number, memory: number) {
+    const submissionId = this.submissionId as unknown as number;
     await this.pubsub.publishTestcaseUpdate({
       type: 'TESTCASE_UPDATE',
-      submissionId: this.submissionId,
+      submissionId,
       testcase: { index: index + 1, status, time, memory },
       progress: {
         completed: index + 1,

--- a/apps/judge/src/judge/judge.reader.ts
+++ b/apps/judge/src/judge/judge.reader.ts
@@ -8,7 +8,7 @@ import type { Metadata, OutputResult, SubmissionJobType, Testcase } from './judg
 export class JudgeReader {
   private readonly DATA_DIR = process.env.JUDGE_VOLUME || '/judge-data';
 
-  readMetadata(submissionId: number): Metadata {
+  readMetadata(submissionId: string): Metadata {
     const submissionDir = this.getSubmissionDir(submissionId);
     const metadataPath = path.join(submissionDir, 'metadata.json');
 
@@ -19,7 +19,7 @@ export class JudgeReader {
     return JSON.parse(fs.readFileSync(metadataPath, 'utf8')) as Metadata;
   }
 
-  loadTestcases(problemId: number, type: SubmissionJobType): Testcase[] {
+  loadTestcases(problemId: string, type: SubmissionJobType): Testcase[] {
     const problemDir = path.join(this.DATA_DIR, 'problems', problemId.toString());
     const filename = type === 'TEST' ? 'test.json' : 'submission.json';
     const testcasePath = path.join(problemDir, filename);
@@ -28,23 +28,32 @@ export class JudgeReader {
       throw new Error(`Testcase file not found for problem ${problemId}`);
     }
 
-    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as { testcases: Testcase[] };
-    return Array.isArray(data) ? data : data.testcases;
+    const data = JSON.parse(fs.readFileSync(testcasePath, 'utf8')) as
+      | Testcase[]
+      | { testcases?: Testcase[]; testCases?: Testcase[] };
+    if (Array.isArray(data)) {
+      return data;
+    }
+    const testcases = data.testcases ?? data.testCases;
+    if (!testcases) {
+      throw new Error(`Testcase format invalid for problem ${problemId}`);
+    }
+    return testcases;
   }
 
-  hasOutputFile(submissionId: number, index: number): boolean {
+  hasOutputFile(submissionId: string, index: number): boolean {
     const submissionDir = this.getSubmissionDir(submissionId);
     const outputPath = path.join(submissionDir, `output_${index}.json`);
     return fs.existsSync(outputPath);
   }
 
-  readOutputFile(submissionId: number, index: number): OutputResult {
+  readOutputFile(submissionId: string, index: number): OutputResult {
     const submissionDir = this.getSubmissionDir(submissionId);
     const outputPath = path.join(submissionDir, `output_${index}.json`);
     return JSON.parse(fs.readFileSync(outputPath, 'utf8')) as OutputResult;
   }
 
-  private getSubmissionDir(submissionId: number): string {
+  private getSubmissionDir(submissionId: string): string {
     return path.join(this.DATA_DIR, 'submissions', submissionId.toString());
   }
 }

--- a/apps/judge/src/judge/judge.service.ts
+++ b/apps/judge/src/judge/judge.service.ts
@@ -18,7 +18,7 @@ export class JudgeService {
   ) {}
 
   // 전체 채점 흐름 관리
-  async judgeSubmission(submissionId: number): Promise<void> {
+  async judgeSubmission(submissionId: string): Promise<void> {
     try {
       const metadata = this.reader.readMetadata(submissionId);
       const testcases = this.reader.loadTestcases(metadata.problemId, metadata.type);

--- a/apps/judge/src/judge/judge.types.ts
+++ b/apps/judge/src/judge/judge.types.ts
@@ -3,7 +3,7 @@ import type { TestcaseStatus } from '@packages/types/pubsub';
 export type SubmissionJobType = 'TEST' | 'SUBMISSION';
 
 export interface Metadata {
-  problemId: number;
+  problemId: string;
   timeLimit: number;
   memoryLimit: number;
   type: SubmissionJobType;

--- a/apps/judge/src/submission/submission.module.ts
+++ b/apps/judge/src/submission/submission.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { DockerModule } from '../docker/docker.module';
+import { JudgeModule } from '../judge/judge.module';
 import { Problem } from '../problem/problem.entity';
 import { SUBMISSION_QUEUE } from './submission.constants';
 import { SubmissionProcessor } from './submission.processor';
@@ -12,6 +13,7 @@ import { SubmissionService } from './submission.service';
   imports: [
     BullModule.registerQueue({ name: SUBMISSION_QUEUE }),
     DockerModule,
+    JudgeModule,
     TypeOrmModule.forFeature([Problem]),
   ],
   providers: [SubmissionProcessor, SubmissionService],

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -4,6 +4,7 @@ import { Job } from 'bullmq';
 
 import { DockerCleanupService } from '../docker/docker.cleanup.service';
 import { DockerRunnerService } from '../docker/docker.service';
+import { JudgeService } from '../judge/judge.service';
 import { SUBMISSION_QUEUE, SUBMISSION_WORKER_CONCURRENCY } from './submission.constants';
 import { parseSubmissionJobPayload, SubmissionJobPayload } from './submission.payload';
 import { SubmissionService } from './submission.service';
@@ -16,6 +17,7 @@ export class SubmissionProcessor extends WorkerHost {
     private readonly dockerRunnerService: DockerRunnerService,
     private readonly dockerCleanupService: DockerCleanupService,
     private readonly submissionService: SubmissionService,
+    private readonly judgeService: JudgeService,
   ) {
     super();
   }
@@ -41,11 +43,14 @@ export class SubmissionProcessor extends WorkerHost {
         payload.code,
       );
 
+      const judgePromise = this.judgeService.judgeSubmission(executionId);
       const result = await this.dockerRunnerService.runSubmission({ submissionId: executionId });
 
       this.logger.log(
         `Docker run completed: exitCode=${result.exitCode ?? 'null'}, signal=${result.signal ?? 'null'}`,
       );
+
+      await judgePromise;
     } finally {
       await this.dockerCleanupService.cleanupExecution(executionId);
     }

--- a/apps/web/src/apis/submission.ts
+++ b/apps/web/src/apis/submission.ts
@@ -1,0 +1,31 @@
+import { axiosInstance } from './axios';
+
+export type SubmissionRequest = {
+  problemId: string;
+  code: string;
+  language: string;
+};
+
+export type SubmissionResponse = {
+  submissionId: string | number;
+  status: string;
+  message?: string;
+};
+
+export const createSubmission = async (payload: SubmissionRequest) => {
+  const response = await axiosInstance.post<SubmissionResponse>('/submissions', payload);
+  return response.data;
+};
+
+export const createDryRun = async (payload: SubmissionRequest, socketId: string) => {
+  const response = await axiosInstance.post<SubmissionResponse | void>(
+    '/submissions/dry-run',
+    payload,
+    {
+      headers: {
+        'x-socket-id': socketId,
+      },
+    },
+  );
+  return response.data;
+};

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -1,9 +1,11 @@
-import { BATTLE_EVENTS } from '@shared/constants/battle';
+import { BATTLE_CONFIG, BATTLE_EVENTS } from '@shared/constants/battle';
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
+import type { ProblemDataPayload } from '@shared/types/problem';
 import { Code } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
+import { createDryRun, createSubmission } from '@/apis/submission';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import type { Player } from '@/stores/roomStore';
 import { useRoomStore } from '@/stores/roomStore';
@@ -21,6 +23,10 @@ function CodeEditor() {
   const [code, setCode] = useState(`function solution() {
   // TODO
 }`);
+  const [problemId, setProblemId] = useState<string | null>(null);
+  const [statusText, setStatusText] = useState('대기 중');
+  const [isTesting, setIsTesting] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     connect();
@@ -50,6 +56,21 @@ function CodeEditor() {
     };
   }, [roomId, setMe, socket]);
 
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleProblemInfo = (payload: ProblemDataPayload) => {
+      if (payload?.id) {
+        setProblemId(payload.id);
+      }
+    };
+
+    socket.on(SOCKET_EVENT.PROBLEM_INFO, handleProblemInfo);
+    return () => {
+      socket.off(SOCKET_EVENT.PROBLEM_INFO, handleProblemInfo);
+    };
+  }, [socket]);
+
   const handleChange = (value: string) => {
     setCode(value);
     if (!socket?.connected) return;
@@ -59,8 +80,52 @@ function CodeEditor() {
       roomId,
       userId: me.userId,
       code: value,
-      language: 'javascript',
+      language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
     });
+  };
+
+  const handleDryRun = async () => {
+    if (!socket?.connected || !socket.id) {
+      setStatusText('소켓 연결이 필요합니다');
+      return;
+    }
+    if (!problemId) {
+      setStatusText('문제 정보를 불러오는 중입니다');
+      return;
+    }
+    if (isTesting || isSubmitting) return;
+
+    setIsTesting(true);
+    setStatusText('테스트 요청 중');
+    try {
+      await createDryRun({ problemId, code, language: BATTLE_CONFIG.DEFAULT_LANGUAGE }, socket.id);
+      setStatusText('테스트 대기 중');
+    } catch (error) {
+      console.error(error);
+      setStatusText('테스트 요청 실패');
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!problemId) {
+      setStatusText('문제 정보를 불러오는 중입니다');
+      return;
+    }
+    if (isTesting || isSubmitting) return;
+
+    setIsSubmitting(true);
+    setStatusText('제출 요청 중');
+    try {
+      await createSubmission({ problemId, code, language: BATTLE_CONFIG.DEFAULT_LANGUAGE });
+      setStatusText('채점 대기 중');
+    } catch (error) {
+      console.error(error);
+      setStatusText('제출 요청 실패');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -91,37 +156,23 @@ function CodeEditor() {
           />
         </div>
         <div className="flex items-center justify-between rounded-xl  bg-(bg-layer-2) px-4 py-3 text-sm font-semibold">
-          <button className="inline-flex items-center gap-2 rounded-lg bg-base-muted px-3 py-2 text-xs font-semibold text-base-primary transition hover:brightness-110">
+          <button
+            type="button"
+            onClick={handleDryRun}
+            disabled={isTesting || isSubmitting}
+            className="inline-flex items-center gap-2 rounded-lg bg-base-muted px-3 py-2 text-xs font-semibold text-base-primary transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+          >
             ▶ 코드 실행
           </button>
           <div className="text-xs text-base-secondary">
-            테스트: <span className="text-green-05">0/10</span> 통과
+            {statusText} · <span className="text-green-05">0/10</span> 통과
           </div>
           <div className="flex items-center gap-2">
             <button
-              type="button"
-              onClick={() => {
-                if (!socket) return;
-                socket.emit(BATTLE_EVENTS.USER_TEST_RESULT, {
-                  roomId,
-                  username: me?.username ?? '플레이어',
-                  passed: true,
-                });
-              }}
-              className="rounded-lg bg-base-muted px-3 py-2 text-xs font-semibold text-base-primary transition hover:brightness-110"
-            >
-              테스트 메시지
-            </button>
-            <button
               className="rounded-lg bg-green-05 px-4 py-2 text-xs font-bold text-white shadow-lg shadow-emerald-500/30 transition hover:brightness-110"
               type="button"
-              onClick={() => {
-                if (!socket) return;
-                socket.emit(BATTLE_EVENTS.USER_FINISHED, {
-                  roomId,
-                  username: me?.username ?? '플레이어',
-                });
-              }}
+              onClick={handleSubmit}
+              disabled={isTesting || isSubmitting}
             >
               제출하기
             </button>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -86,10 +86,14 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
       - WATCHPACK_POLLING=true
+      - JUDGE_VOLUME=/judge-data
+      - JUDGE_HOST_PATH=${JUDGE_HOST_PATH:-${PWD}/judge-data}
+      - JUDGE_DISABLE_CLEANUP=${JUDGE_DISABLE_CLEANUP}
     ports:
       - "4000:4000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # 도커 소켓 마운트 (코드 실행용 컨테이너 생성을 위해 필수)
+      - ${JUDGE_HOST_PATH:-${PWD}/judge-data}:/judge-data
       - ./apps/judge:/app/apps/judge
       - ./packages:/app/packages
       - /app/apps/judge/node_modules


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

배틀 페이지에서 제출하기/코드 실행 API 연동 및 채점 워커-채점 로직 연결, 도커 경로 설정 보완

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #143 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- submission.ts 추가 및 CodeEditor.tsx에서 제출/실행 API 호출 연결
- submission.processor.ts에서 JudgeService 호출로 채점 폴링 실행 연결
- apps/judge/src/judge/*에서 TEST용 문자열 submissionId와 testCases/testcases 포맷 대응
- docker-compose.dev.yml, .env.dev, .env.dev.example, DOCKER.md에서 JUDGE_HOST_PATH 기반 경로 설정 및 dev 실행 방법 보완

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

<img width="1170" height="233" alt="스크린샷 2026-01-17 오후 5 31 05" src="https://github.com/user-attachments/assets/4c825304-b7ca-444d-b6a3-e1c5be0b7b96" />

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 배틀 페이지에서 실제 제출/실행 흐름이 API와 연결되도록 하고, 채점 워커가 결과를 읽어 Pub/Sub로 전달하는 흐름이 정상 동작하도록 하기 위함
- 개발 환경에서 OS별 경로 문제로 도커 실행이 깨지지 않도록 경로 설정 방식을 정리하기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- JUDGE_HOST_PATH/JUDGE_VOLUME 경로 분리가 팀 내 개발 환경(Windows/WSL 포함)에 문제 없는지 확인 부탁드립니다
