### PR TITLE
[HOTFIX] 스크립트 최신 상태로 강제 전환 안정화 (#161)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,10 +41,26 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script: |
             cd /root/web30-boostcamp
-            git pull origin dev
+            # 1. dev 브랜치 강제 동기화
+            git fetch origin dev
+            git checkout -f dev
+            git reset --hard origin/dev
+            
+            # 2. 의존성 설치
             pnpm install --frozen-lockfile
-            # 프론트엔드 빌드 및 동기화
-            pnpm --filter ./apps/web... build
-            sudo rsync -av --delete /root/web30-boostcamp/apps/web/dist/ /var/www/port30/web/
-            # 백엔드 및 기타 서비스 재빌드 및 실행
+            
+            # 3. 프론트엔드 강제 빌드 (캐시 무시 및 상태 확인)
+            echo "Current Directory: $(pwd)"
+            npx turbo run build --filter=web --force
+            
+            # 4. 정적 파일 동기화 및 권한 최적화
+            echo "Syncing files to /var/www/port30/web/"
+            sudo mkdir -p /var/www/port30/web
+            sudo rsync -av --delete ./apps/web/dist/ /var/www/port30/web/
+            sudo chown -R www-data:www-data /var/www/port30/web
+            
+            # 5. 백엔드 및 기타 서비스 재실행
             docker compose -f docker-compose.prod.yml up -d --build
+            
+            # 6. Nginx 설정 정합성 확인 및 반영
+            sudo nginx -t && sudo systemctl reload nginx


### PR DESCRIPTION
## 🔍 PR 요약

CICD 배포 완료 시 웹사이트에 최신 상태가 반영되지 않는 문제를 해결

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #161 

## 🛠️ 주요 변경 사항
#### .github/workflows/deploy-dev.yml
1. 강력해진 소스 동기화 (git reset --hard)
- 이전: 단순히 git pull을 사용했습니다. 만약 서버에 누군가 파일을 수정했거나(Permission 문제 등), Git 인덱스가 꼬여있으면 pull이 실패하거나 충돌이 날 수 있었습니다.
- 변경: git fetch 후 git reset --hard origin/dev를 실행합니다. 서버의 상태가 어떻든 상관없이 무조건 GitHub 최신 소스와 100% 똑같이 강제로 일치시킵니다.
2. 빌드 캐시 무효화 (--force)
- 이전: pnpm build는 이전에 빌드된 결과물이 있으면 빌드를 건너뛰기도 합니다.
- 변경: npx turbo run build ... --force 옵션을 추가했습니다. Turbo 캐시를 무시하고 무조건 새롭게 빌드하게 만들어서, 옛날 결과물이 남지 않도록 보장했습니다.
3. 소유권 보정 (chown -R www-data)
- 이전: 단순히 파일을 복사했습니다.
- 변경: sudo chown -R www-data:www-data를 추가했습니다. Nginx는 보통 www-data 권한으로 파일을 읽는데, 배포 과정에서 권한이 꼬여 "권한 없음" 에러가 나거나 옛날 파일을 보여주는 일을 원천 차단했습니다.
4. Nginx 강제 재시작 (reload nginx)
- 이전: 파일을 바꾸고 끝냈습니다.
- 변경: sudo systemctl reload nginx를 추가했습니다. Nginx에게 **"설정과 파일이 바뀌었으니 지금 즉시 다시 읽어라"**라고 명령을 내린 것입니다. 이 과정이 없으면 Nginx가 메모리에 들고 있던 옛날 파일을 잠시 동안 더 보여줄 수 있습니다.

## 📸 스크린샷 (선택)

<img width="1458" height="885" alt="image" src="https://github.com/user-attachments/assets/2a59dceb-81c9-4a99-a28b-35865e3c1c53" />

## 🧠 의도 및 배경

CI/CD 파이프라인을 더욱 견고하게 하기 위함


## 💬 리뷰 요구사항(선택)

이전 스크립트는 "별일 없겠지?"라는 가정하에 동작했다면, 수정된 스크립트는 "무슨 일이 있어도 무조건 GitHub의 최신 상태로 강제 전환해!"라는 훨씬 더 방어적이고 강력한 방식으로 동작합니다.