### PR TITLE
[HOTFIX] 로그인 404 에러 해결 및 배포 도메인 CORS/리다이렉트 적용 (#161)

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -26,7 +26,12 @@ export class AuthController {
       maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
     });
 
-    res.redirect(`http://localhost:5173/login?token=${accessToken}`);
+    const redirectUrl =
+      process.env.NODE_ENV === 'production'
+        ? `https://www.tadak.site/login?token=${accessToken}`
+        : `http://localhost:5173/login?token=${accessToken}`;
+
+    res.redirect(redirectUrl);
   }
 
   @Post('refresh')

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
   app.use(cookieParser());
   app.useGlobalPipes(new ValidationPipe());
   app.enableCors({
-    origin: ['http://localhost:5173'],
+    origin: ['http://localhost:5173', 'https://www.tadak.site', 'https://tadak.site'],
     credentials: true,
   });
 

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -24,7 +24,7 @@ server {
 
     # API 프록시 (호스트 nginx 기준)
     location /api/ {
-        proxy_pass http://127.0.0.1:3000/;
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
## 🔍 PR 요약

- 로그인 시 발생하는 404 에러 및 향후 발생 가능한 이슈들을 모두 해결
- GitHub OAuth 설정에서 Homepage URL과 Authorization callback URL을 실제 도메인에 맞춰 업데이트
- 프론트엔드 빌드 시 API 도메인 주소 강제 주입

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #161
- PR #167

## 🛠️ 주요 변경 사항

- Nginx 프록시 설정 수정: nginx.conf의 `proxy_pass http://127.0.0.1:3000/;`에서 끝의 슬래시(/)를 제거했습니다. 이 슬래시 때문에 /api/auth/github가 NestJS에는 /auth/github가 아닌 누락된 경로로 전달되고 있었습니다.
- CORS 허용 도메인 추가: 배포된 도메인(tadak.site)에서 API를 호출할 수 있도록 main.ts에 CORS 설정을 추가했습니다.
- 로그인 리다이렉트 주소 수정: 로그인 성공 후 localhost:5173이 아닌 배포된 도메인 주소로 리다이렉트되도록 AuthController.ts를 보완했습니다.
- deploy-dev.yml 워크플로우에서 프론트엔드 빌드 시점에 `VITE_API_BASE_URL=https://www.tadak.site`를 직접 주입하도록 수정했습니다. 

## 📸 스크린샷 (선택)
[GitHub Developer Settings](https://github.com/settings/applications/3320529) 수정
<img width="667" height="505" alt="image" src="https://github.com/user-attachments/assets/051daa44-dba0-4840-883d-a002a995b7b2" />

로그인 및 API 요청 성공
<img width="1439" height="885" alt="image" src="https://github.com/user-attachments/assets/bacccf02-eb1b-499f-87f7-2ba216dd2d02" />


## 🧠 의도 및 배경

- 배포 환경에서 로그인 시 `{"message":"Cannot GET /auth/github","error":"Not Found","statusCode":404}` 에러가 발생하는 문제 해결을 하기 위함
- API 통신이 될 수 있도록 CORS 허용 추가
- 프론트엔드 API 요청 주소가 IP 주소로 나오는 문제 해결
