### PR TITLE
[FEAT] 제출자의 상대방과 관전자 실시간 상태 UI 변경 (#168)

### DIFF
--- a/apps/api/src/battle/battle.gateway.ts
+++ b/apps/api/src/battle/battle.gateway.ts
@@ -44,6 +44,18 @@ export class BattleGateway {
         language,
       });
 
+      // 상대방에게 코드 변경 알림 전송
+      const opponent = battle.users.find((user) => user.userId !== userId);
+      if (opponent) {
+        const opponentSocketId = await this.battleService.getSocketIdByUserId(opponent.userId);
+        if (opponentSocketId) {
+          this.server.to(opponentSocketId).emit(BATTLE_EVENTS.CODE_METADATA, {
+            userId,
+            codeLines: code.split('\n').filter((line) => line.trim().length > 0).length,
+          });
+        }
+      }
+
       return { success: true };
     } catch (error) {
       console.error('Error handling code change:', error);

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -1,14 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { BATTLE_CONFIG } from '@packages/constants/battle';
 import { Battle, BattleUser, CreateBattleDTO, UpdateUserCodeDTO } from '@packages/types/battle';
 import { RoomUser } from '@packages/types/user';
+import Redis from 'ioredis';
 
 import { BattleRedisService } from '@/battle/battle-redis.service';
 import { ProblemService } from '@/problem/problem.service';
+import { REDIS_CLIENT } from '@/redis/redis.module';
+import { RedisKeys } from '@/redis/redis-key.constant';
 
 @Injectable()
 export class BattleService {
   constructor(
+    @Inject(REDIS_CLIENT) private readonly redisClient: Redis,
     private readonly battleRedisService: BattleRedisService,
     private readonly problemService: ProblemService,
   ) {}
@@ -143,5 +147,11 @@ export class BattleService {
     if (battleId) {
       await this.battleRedisService.deleteBattle(battleId, roomId);
     }
+  }
+
+  async getSocketIdByUserId(userId: string): Promise<string | null> {
+    const socketId = await this.redisClient.hget(RedisKeys.matchingUser(userId), 'socketId');
+
+    return socketId;
   }
 }

--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -85,7 +85,18 @@ export class PubsubSubscriberService implements OnModuleInit {
     // TEST 타입 (DryRun)
     if (!submission && message.socketId) {
       this.logger.log(`[FINAL_RESULT] Sending to socket ${message.socketId} (TEST type)`);
-      this.pubsubGateway.emitFinalResult(message.socketId, message);
+      // 본인에게 결과 전송
+      this.pubsubGateway.emitFinalResultToSocket(message.socketId, message);
+
+      // 방에 테스트 결과 브로드캐스트
+      const userInfo = await this.getUserInfoBySocketId(message.socketId);
+      if (userInfo?.roomId) {
+        this.pubsubGateway.emitTestResult(userInfo.roomId, message, userInfo.userId);
+        this.pubsubGateway.emitSystemChat(
+          userInfo.roomId,
+          `${userInfo.username}님이 테스트를 실행했습니다. (${message.result.passed}/${message.result.total})`,
+        );
+      }
       return;
     }
 
@@ -199,6 +210,29 @@ export class PubsubSubscriberService implements OnModuleInit {
       const parsed = Number(value);
       return Number.isFinite(parsed) ? parsed : null;
     }
+    return null;
+  }
+
+  // socketId로 유저 정보 조회
+  private async getUserInfoBySocketId(
+    socketId: string,
+  ): Promise<{ roomId: string; userId: string; username: string } | null> {
+    // Redis에서 socketId로 userId 찾기 (모든 matching:user:* 키 순회)
+    const keys = await this.redisClient.keys('matching:user:*');
+
+    for (const key of keys) {
+      const userData = await this.redisClient.hgetall(key);
+      if (userData?.socketId === socketId && userData?.roomId) {
+        const userId = key.replace('matching:user:', '');
+        return {
+          roomId: userData.roomId,
+          userId,
+          username: userData.username ?? '플레이어',
+        };
+      }
+    }
+
+    this.logger.warn(`User info not found for socketId ${socketId}`);
     return null;
   }
 }

--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -111,7 +111,7 @@ export class PubsubSubscriberService implements OnModuleInit {
       const userInfo = await this.getUserInfoBySubmissionId(message.submissionId);
 
       if (userInfo?.roomId) {
-        this.pubsubGateway.emitFinalResult(userInfo.roomId, message);
+        this.pubsubGateway.emitFinalResult(userInfo.roomId, message, userInfo.userId);
         this.battleGateway.handleUserFinished({
           roomId: userInfo.roomId,
           userId: userInfo.userId,

--- a/apps/api/src/pubsub/pubsub.gateway.ts
+++ b/apps/api/src/pubsub/pubsub.gateway.ts
@@ -51,4 +51,26 @@ export class PubsubGateway {
     });
     this.logger.log(`Sent final-result to socket ${socketId}`);
   }
+
+  // 방 전체에 테스트 실행 결과 브로드캐스트
+  emitTestResult(roomId: string, message: FinalResultMessage, userId: string): void {
+    this.server.to(roomId).emit('test-result', {
+      submissionId: message.submissionId,
+      status: message.status,
+      result: message.result,
+      userId,
+    });
+    this.logger.log(`Broadcast test-result to room ${roomId} for user ${userId}`);
+  }
+
+  // 방 전체에 시스템 채팅 메시지 전송
+  emitSystemChat(roomId: string, message: string): void {
+    this.server.to(roomId).emit('receive-chat', {
+      type: 'SYSTEM',
+      nickname: '시스템',
+      message,
+      timestamp: new Date().toISOString(),
+    });
+    this.logger.log(`Broadcast system chat to room ${roomId}: ${message}`);
+  }
 }

--- a/apps/api/src/pubsub/pubsub.gateway.ts
+++ b/apps/api/src/pubsub/pubsub.gateway.ts
@@ -32,13 +32,14 @@ export class PubsubGateway {
   }
 
   // 방 전체에 최종 결과 브로드캐스트
-  emitFinalResult(roomId: string, message: FinalResultMessage): void {
+  emitFinalResult(roomId: string, message: FinalResultMessage, userId?: string): void {
     this.server.to(roomId).emit('submission-result', {
       submissionId: message.submissionId,
       status: message.status,
       result: message.result,
+      userId,
     });
-    this.logger.log(`Broadcast final-result to room ${roomId}`);
+    this.logger.log(`Broadcast final-result to room ${roomId} for user ${userId}`);
   }
 
   // 특정 소켓에 최종 결과 전달 (테스트 실행 등)

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -149,6 +149,7 @@ export class RoomGateway {
           joinedAt: new Date().toISOString(),
           roomId: roomId,
           username: resolvedUsername,
+          socketId: client.id,
         });
       } catch {
         // ignore
@@ -157,7 +158,6 @@ export class RoomGateway {
 
     // 방 전체에 최신 참여자 목록 브로드캐스트 (통계 포함)
     const playersWithStats = await this.getPlayersWithStats(room.currentPlayers);
-    console.warn('Players : ', playersWithStats);
     this.server.to(roomId).emit(SOCKET_EVENT.ROOM_PLAYERS, {
       roomId: room.roomId,
       players: playersWithStats,

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -12,6 +12,7 @@ import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
 import { ProblemService } from '@/problem/problem.service';
+import { UserService } from '@/user/user.service';
 
 import { CHAT_TYPE } from '../../../../packages/constants/chat';
 import {
@@ -37,6 +38,7 @@ export class RoomGateway {
     private readonly roomService: RoomService,
     private readonly battleService: BattleService,
     private readonly problemService: ProblemService,
+    private readonly userService: UserService,
   ) {}
 
   @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
@@ -153,11 +155,12 @@ export class RoomGateway {
       }
     }
 
-    // 방 전체에 최신 참여자 목록 브로드캐스트
-    const players = [...room.currentPlayers];
+    // 방 전체에 최신 참여자 목록 브로드캐스트 (통계 포함)
+    const playersWithStats = await this.getPlayersWithStats(room.currentPlayers);
+    console.warn('Players : ', playersWithStats);
     this.server.to(roomId).emit(SOCKET_EVENT.ROOM_PLAYERS, {
       roomId: room.roomId,
-      players,
+      players: playersWithStats,
     });
 
     client.emit(SOCKET_EVENT.ROOM_STATE_ROLE, {
@@ -344,5 +347,26 @@ export class RoomGateway {
       .replace(/'/g, '&#39;');
 
     return escaped.replace(/javascript:/gi, '').replace(/on\w+="[^"]*"/gi, '');
+  }
+
+  private async getPlayersWithStats(players: RoomUser[]): Promise<RoomUser[]> {
+    const playersWithStats = await Promise.all(
+      players.map(async (player) => {
+        const user = await this.userService.findOne(player.userId);
+        if (user) {
+          return {
+            ...player,
+            stats: {
+              wins: user.wins,
+              losses: user.losses,
+              rating: user.rating,
+              tier: user.tier,
+            },
+          };
+        }
+        return player;
+      }),
+    );
+    return playersWithStats;
   }
 }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -145,6 +145,7 @@ export class RoomGateway {
           status: 'IN_ROOM',
           joinedAt: new Date().toISOString(),
           roomId: roomId,
+          username: resolvedUsername,
         });
       } catch {
         // ignore

--- a/apps/api/src/room/room.module.ts
+++ b/apps/api/src/room/room.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 
 import { BattleModule } from '@/battle/battle.module';
 import { ProblemModule } from '@/problem/problem.module';
+import { UserModule } from '@/user/user.module';
 
 import { RoomController } from './room.controller';
 import { RoomGateway } from './room.gateway';
 import { RoomService } from './room.service';
 
 @Module({
-  imports: [BattleModule, ProblemModule],
+  imports: [BattleModule, ProblemModule, UserModule],
   providers: [RoomService, RoomGateway],
   controllers: [RoomController],
   exports: [RoomService], // MatchingModule에서 사용할 수 있도록 export

--- a/apps/web/src/components/Battle/Player/BattlePlayer.tsx
+++ b/apps/web/src/components/Battle/Player/BattlePlayer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import BattleProblem from '@/components/Battle/BattleProblem';
-import BattleProgress from '@/components/Battle/Player/BattleSituation';
+import BattleSituation from '@/components/Battle/Player/BattleSituation';
 import CodeEditor from '@/components/Battle/Player/CodeEditor';
 import ProgressBar from '@/components/Battle/Player/ProgressBar';
 
@@ -58,7 +58,7 @@ function BattlePlayer() {
           </div>
           {showProgress && (
             <div ref={progressRef} className="fade-slide-in xl:h-full xl:min-h-0">
-              <BattleProgress />
+              <BattleSituation />
             </div>
           )}
         </div>

--- a/apps/web/src/components/Battle/Player/BattleSituation.tsx
+++ b/apps/web/src/components/Battle/Player/BattleSituation.tsx
@@ -46,11 +46,11 @@ function BattleSituation() {
     };
 
     socket.on(BATTLE_EVENTS.CODE_METADATA, handleCodeMetadata);
-    socket.on('test-result', handleTestResult);
+    socket.on(BATTLE_EVENTS.TEST_RESULT, handleTestResult);
 
     return () => {
       socket.off(BATTLE_EVENTS.CODE_METADATA, handleCodeMetadata);
-      socket.off('test-result', handleTestResult);
+      socket.off(BATTLE_EVENTS.TEST_RESULT, handleTestResult);
     };
   }, [socket, me?.userId, updateCodeLines, addActivityLog]);
 

--- a/apps/web/src/components/Battle/Player/BattleSituation.tsx
+++ b/apps/web/src/components/Battle/Player/BattleSituation.tsx
@@ -14,9 +14,8 @@ type TestResultPayload = {
 function BattleSituation() {
   const me = useRoomStore((state) => state.me);
   const players = useRoomStore((state) => state.players);
-  const codes = useRoomStore((state) => state.codes);
-  const upsertCode = useRoomStore((state) => state.upsertCode);
   const progresses = useBattleProgressStore((state) => state.progresses);
+  const updateCodeLines = useBattleProgressStore((state) => state.updateCodeLines);
   const addActivityLog = useBattleProgressStore((state) => state.addActivityLog);
   const socket = useBattleSocketStore((state) => state.socket);
 
@@ -28,9 +27,10 @@ function BattleSituation() {
   useEffect(() => {
     if (!socket) return;
 
-    const handleCodeUpdate = (payload: { userId: string; code: string }) => {
+    const handleCodeMetadata = (payload: { userId: string; codeLines: number }) => {
       if (payload.userId !== me?.userId) {
-        upsertCode(payload.userId, payload.code);
+        // upsertCode(payload.userId, payload.code);
+        updateCodeLines(payload.userId, payload.codeLines);
       }
     };
 
@@ -45,20 +45,16 @@ function BattleSituation() {
       }
     };
 
-    socket.on(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
+    socket.on(BATTLE_EVENTS.CODE_METADATA, handleCodeMetadata);
     socket.on('test-result', handleTestResult);
 
     return () => {
-      socket.off(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
+      socket.off(BATTLE_EVENTS.CODE_METADATA, handleCodeMetadata);
       socket.off('test-result', handleTestResult);
     };
-  }, [socket, me?.userId, upsertCode, addActivityLog]);
+  }, [socket, me?.userId, updateCodeLines, addActivityLog]);
 
-  const codeLines = useMemo(() => {
-    if (!opponent?.userId) return 0;
-    const code = codes[opponent.userId] ?? '';
-    return code.split('\n').filter((line) => line.trim().length > 0).length;
-  }, [codes, opponent?.userId]);
+  const codeLines = opponent?.userId ? (progresses[opponent.userId]?.codeLines ?? 0) : 0;
 
   const activityLogs = opponent?.userId ? (progresses[opponent.userId]?.activityLogs ?? []) : [];
 

--- a/apps/web/src/components/Battle/Player/BattleSituation.tsx
+++ b/apps/web/src/components/Battle/Player/BattleSituation.tsx
@@ -6,12 +6,18 @@ import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
 
+type TestResultPayload = {
+  userId: string;
+  result: { passed: number; total: number };
+};
+
 function BattleSituation() {
   const me = useRoomStore((state) => state.me);
   const players = useRoomStore((state) => state.players);
   const codes = useRoomStore((state) => state.codes);
   const upsertCode = useRoomStore((state) => state.upsertCode);
   const progresses = useBattleProgressStore((state) => state.progresses);
+  const addActivityLog = useBattleProgressStore((state) => state.addActivityLog);
   const socket = useBattleSocketStore((state) => state.socket);
 
   const opponent = useMemo(
@@ -28,11 +34,25 @@ function BattleSituation() {
       }
     };
 
+    // 상대방 테스트 결과 수신 (활동 기록용)
+    const handleTestResult = (payload: TestResultPayload) => {
+      if (payload.userId !== me?.userId && payload.result) {
+        addActivityLog(payload.userId, {
+          type: 'TEST',
+          passed: payload.result.passed,
+          total: payload.result.total,
+        });
+      }
+    };
+
     socket.on(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
+    socket.on('test-result', handleTestResult);
+
     return () => {
       socket.off(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
+      socket.off('test-result', handleTestResult);
     };
-  }, [socket, me?.userId, upsertCode]);
+  }, [socket, me?.userId, upsertCode, addActivityLog]);
 
   const codeLines = useMemo(() => {
     if (!opponent?.userId) return 0;
@@ -40,7 +60,7 @@ function BattleSituation() {
     return code.split('\n').filter((line) => line.trim().length > 0).length;
   }, [codes, opponent?.userId]);
 
-  const submitLogs = opponent?.userId ? (progresses[opponent.userId]?.submitLogs ?? []) : [];
+  const activityLogs = opponent?.userId ? (progresses[opponent.userId]?.activityLogs ?? []) : [];
 
   const formatTime = (timestamp: number) => {
     const date = new Date(timestamp);
@@ -106,8 +126,8 @@ function BattleSituation() {
                 <p className="text-lg text-base-primary">{codeLines}</p>
               </div>
               <div className="rounded-lg  bg-base-primary/5 px-3 py-2">
-                <p className="text-base-secondary">제출 횟수</p>
-                <p className="text-lg text-base-primary">{submitLogs.length}</p>
+                <p className="text-base-secondary">실행 횟수</p>
+                <p className="text-lg text-base-primary">{activityLogs.length}</p>
               </div>
             </div>
           </div>
@@ -119,16 +139,16 @@ function BattleSituation() {
             <p className="font-semibold text-green-05">활동 기록</p>
           </div>
           <div className="flex-1 space-y-2 overflow-y-auto rounded-md bg-base-primary/5 p-3 text-xs text-base-primary">
-            {submitLogs.length === 0 ? (
+            {activityLogs.length === 0 ? (
               <p className="text-center text-base-secondary py-2">아직 활동 기록이 없습니다</p>
             ) : (
-              [...submitLogs].reverse().map((log, idx) => (
+              [...activityLogs].reverse().map((log, idx) => (
                 <div
                   key={log.timestamp}
                   className="flex items-center justify-between rounded-lg bg-(--bg-layer-2) px-3 py-2"
                 >
                   <span>
-                    코드 제출 #{submitLogs.length - idx}{' '}
+                    {log.type === 'TEST' ? '테스트' : '제출'} #{activityLogs.length - idx}{' '}
                     <span className={log.passed === log.total ? 'text-green-05' : 'text-pink-05'}>
                       ({log.passed}/{log.total})
                     </span>

--- a/apps/web/src/components/Battle/Player/BattleSituation.tsx
+++ b/apps/web/src/components/Battle/Player/BattleSituation.tsx
@@ -1,15 +1,61 @@
+import { BATTLE_EVENTS } from '@shared/constants/battle';
 import { Activity, BarChart3, ListChecks } from 'lucide-react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
+import { useBattleProgressStore } from '@/stores/battleProgressStore';
+import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
 
 function BattleSituation() {
   const me = useRoomStore((state) => state.me);
   const players = useRoomStore((state) => state.players);
+  const codes = useRoomStore((state) => state.codes);
+  const upsertCode = useRoomStore((state) => state.upsertCode);
+  const progresses = useBattleProgressStore((state) => state.progresses);
+  const socket = useBattleSocketStore((state) => state.socket);
+
   const opponent = useMemo(
     () => players.find((p) => p.userId !== me?.userId),
     [players, me?.userId],
   );
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleCodeUpdate = (payload: { userId: string; code: string }) => {
+      if (payload.userId !== me?.userId) {
+        upsertCode(payload.userId, payload.code);
+      }
+    };
+
+    socket.on(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
+    return () => {
+      socket.off(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
+    };
+  }, [socket, me?.userId, upsertCode]);
+
+  const codeLines = useMemo(() => {
+    if (!opponent?.userId) return 0;
+    const code = codes[opponent.userId] ?? '';
+    return code.split('\n').filter((line) => line.trim().length > 0).length;
+  }, [codes, opponent?.userId]);
+
+  const submitLogs = opponent?.userId ? (progresses[opponent.userId]?.submitLogs ?? []) : [];
+
+  const formatTime = (timestamp: number) => {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString('ko-KR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  };
+
+  const status = useMemo(() => {
+    if (!opponent?.userId) return '대기 중';
+    if (codeLines > 0) return '코딩 중';
+    return '대기 중';
+  }, [opponent?.userId, codeLines]);
 
   const { stats, totalBattles } = useMemo(() => {
     const s = opponent?.stats ?? {
@@ -23,12 +69,6 @@ function BattleSituation() {
       totalBattles: s.wins + s.losses,
     };
   }, [opponent]);
-
-  const activityLogs = [
-    { label: '코드 작성 시작', time: '00:15' },
-    { label: '첫 번째 테스트 실행', time: '02:30' },
-    { label: '코드 수정 중', time: '04:45' },
-  ];
 
   return (
     <>
@@ -59,39 +99,48 @@ function BattleSituation() {
             <p className="font-semibold text-green-05">실시간 상태</p>
           </div>
           <div className="space-y-3 rounded-md bg-base-primary/5 p-3">
-            <p className="text-sm">코딩 중...</p>
+            <p className="text-sm">{status}</p>
             <div className="grid grid-cols-2 gap-2 text-xs font-semibold text-base-primary">
               <div className="rounded-lg  bg-base-primary/5 px-3 py-2">
                 <p className="text-base-secondary">코드 라인</p>
-                <p className="text-lg text-base-primary">42</p>
+                <p className="text-lg text-base-primary">{codeLines}</p>
               </div>
               <div className="rounded-lg  bg-base-primary/5 px-3 py-2">
-                <p className="text-base-secondary">실행 횟수</p>
-                <p className="text-lg text-base-primary">6</p>
+                <p className="text-base-secondary">제출 횟수</p>
+                <p className="text-lg text-base-primary">{submitLogs.length}</p>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="space-y-3 text-sm leading-relaxed text-base-primary">
+        <div className="flex min-h-0 flex-1 flex-col space-y-3 text-sm leading-relaxed text-base-primary">
           <div className="flex items-center gap-2 text-lg">
             <ListChecks className="h-5 w-5 text-green-05" strokeWidth={2.5} />
             <p className="font-semibold text-green-05">활동 기록</p>
           </div>
-          <div className="space-y-2 rounded-md bg-base-primary/5 p-3 text-xs text-base-primary">
-            {activityLogs.map((log) => (
-              <div
-                key={log.label}
-                className="flex items-center justify-between rounded-lg  bg-(--bg-layer-2) px-3 py-2"
-              >
-                <span>{log.label}</span>
-                <span className="text-base-secondary">{log.time}</span>
-              </div>
-            ))}
+          <div className="flex-1 space-y-2 overflow-y-auto rounded-md bg-base-primary/5 p-3 text-xs text-base-primary">
+            {submitLogs.length === 0 ? (
+              <p className="text-center text-base-secondary py-2">아직 활동 기록이 없습니다</p>
+            ) : (
+              [...submitLogs].reverse().map((log, idx) => (
+                <div
+                  key={log.timestamp}
+                  className="flex items-center justify-between rounded-lg bg-(--bg-layer-2) px-3 py-2"
+                >
+                  <span>
+                    코드 제출 #{submitLogs.length - idx}{' '}
+                    <span className={log.passed === log.total ? 'text-green-05' : 'text-pink-05'}>
+                      ({log.passed}/{log.total})
+                    </span>
+                  </span>
+                  <span className="text-base-secondary">{formatTime(log.timestamp)}</span>
+                </div>
+              ))
+            )}
           </div>
         </div>
 
-        <div className="space-y-3 text-sm leading-relaxed text-base-primary">
+        <div className="mt-auto space-y-3 text-sm leading-relaxed text-base-primary">
           <div className="flex items-center gap-2 text-lg">
             <BarChart3 className="h-5 w-5 text-green-05" strokeWidth={2.5} />
             <p className="font-semibold text-green-05">상대 통계</p>

--- a/apps/web/src/components/Battle/Player/BattleSituation.tsx
+++ b/apps/web/src/components/Battle/Player/BattleSituation.tsx
@@ -1,22 +1,56 @@
 import { Activity, BarChart3, ListChecks } from 'lucide-react';
+import { useMemo } from 'react';
 
-function BattleProgress() {
+import { useRoomStore } from '@/stores/roomStore';
+
+function BattleSituation() {
+  const me = useRoomStore((state) => state.me);
+  const players = useRoomStore((state) => state.players);
+  const opponent = useMemo(
+    () => players.find((p) => p.userId !== me?.userId),
+    [players, me?.userId],
+  );
+
+  const { stats, totalBattles } = useMemo(() => {
+    const s = opponent?.stats ?? {
+      wins: 0,
+      losses: 0,
+      rating: 1000,
+      tier: { tier: 'BRONZE', division: 4 },
+    };
+    return {
+      stats: s,
+      totalBattles: s.wins + s.losses,
+    };
+  }, [opponent]);
+
   const activityLogs = [
     { label: '코드 작성 시작', time: '00:15' },
     { label: '첫 번째 테스트 실행', time: '02:30' },
     { label: '코드 수정 중', time: '04:45' },
   ];
+
   return (
     <>
       <section className="flex flex-col gap-5 rounded-2xl  bg-(--bg-layer-2) p-5 border border-border-soft text-base-primary xl:h-full xl:min-h-0 xl:overflow-y-auto">
         <div className="flex items-start justify-between">
           <div className="space-y-1">
-            <p className="text-sm font-semibold text-base-secondary">플레이어</p>
-            <p className="text-lg font-semibold text-base-primary">CodeNinja</p>
+            <p className="text-sm font-semibold text-base-secondary">상대방</p>
+            <p className="text-lg font-semibold text-base-primary">
+              {opponent?.username ?? '대기 중'}
+            </p>
           </div>
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-pink-05 text-lg font-bold text-white">
-            C
-          </div>
+          {opponent?.avatarUrl ? (
+            <img
+              src={opponent.avatarUrl}
+              alt={opponent.username}
+              className="h-10 w-10 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-pink-05 text-lg font-bold text-white">
+              {opponent?.username?.charAt(0).toUpperCase() ?? '?'}
+            </div>
+          )}
         </div>
 
         <div className="space-y-3 text-sm leading-relaxed text-base-primary">
@@ -65,13 +99,13 @@ function BattleProgress() {
           <div className="rounded-md bg-base-primary/5 p-3">
             <div className="mt-1 flex items-center justify-center gap-4 text-sm font-bold text-base-primary">
               <div className="text-green-05">
-                156 <span className="text-base-secondary font-semibold">배틀</span>
+                {totalBattles} <span className="text-base-secondary font-semibold">배틀</span>
               </div>
               <div className="text-green-05">
-                112 <span className="text-base-secondary font-semibold">승리</span>
+                {stats.wins} <span className="text-base-secondary font-semibold">승리</span>
               </div>
               <div className="text-pink-05">
-                44 <span className="text-base-secondary font-semibold">패배</span>
+                {stats.losses} <span className="text-base-secondary font-semibold">패배</span>
               </div>
             </div>
           </div>
@@ -81,4 +115,4 @@ function BattleProgress() {
   );
 }
 
-export default BattleProgress;
+export default BattleSituation;

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -7,6 +7,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 
 import { createDryRun, createSubmission } from '@/apis/submission';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
+import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import type { Player } from '@/stores/roomStore';
 import { useRoomStore } from '@/stores/roomStore';
@@ -21,7 +22,9 @@ type TestcaseResult = TestcaseUpdateMessage['testcase'] & {
 type TestcaseUpdatePayload = Omit<TestcaseUpdateMessage, 'type'> & {
   results?: TestcaseUpdateMessage['results'];
 };
-type SubmissionResultPayload = Omit<FinalResultMessage, 'type'>;
+type SubmissionResultPayload = Omit<FinalResultMessage, 'type'> & {
+  userId?: string;
+};
 
 // 실행 상태 타입
 type ExecutionState = {
@@ -42,6 +45,7 @@ function CodeEditor() {
 
   const socket = useBattleSocketStore((state) => state.socket);
   const connect = useBattleSocketStore((state) => state.connect);
+  const upsertProgress = useBattleProgressStore((state) => state.upsertProgress);
 
   const [code, setCode] = useState(`function solution() {
   // TODO
@@ -82,6 +86,7 @@ function CodeEditor() {
       role: string;
       userId: string;
       username: string;
+      avatarUrl?: string;
     }) => {
       if (payload.roomId !== roomId) return;
       setMe({
@@ -89,6 +94,7 @@ function CodeEditor() {
         role: payload.role as never,
         userId: payload.userId,
         username: payload.username,
+        avatarUrl: payload.avatarUrl,
       });
     };
 
@@ -133,8 +139,16 @@ function CodeEditor() {
     };
 
     const handleSubmissionResult = (payload: SubmissionResultPayload) => {
+      // 모든 플레이어의 제출 결과를 store에 저장 (ProgressBar용)
+      if (payload.userId && payload.result) {
+        upsertProgress(payload.userId, {
+          passed: payload.result.passed,
+          total: payload.result.total,
+        });
+      }
+
       const execution = executionRef.current;
-      // 실행 중이 아니면 무시
+      // 본인의 실행 중이 아니면 UI 업데이트 스킵
       if (!execution) return;
 
       const incomingId = String(payload.submissionId);
@@ -176,7 +190,7 @@ function CodeEditor() {
       socket.off('testcase-update', handleTestcaseUpdate);
       socket.off('submission-result', handleSubmissionResult);
     };
-  }, [socket]);
+  }, [socket, upsertProgress]);
 
   const handleChange = (value: string) => {
     setCode(value);

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -6,14 +6,13 @@ import { useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { createDryRun, createSubmission } from '@/apis/submission';
+import EditorFooter from '@/components/Battle/Player/EditorFooter';
+import TestcaseResultPanel from '@/components/Battle/Player/TestcaseResultPanel';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import type { Player } from '@/stores/roomStore';
 import { useRoomStore } from '@/stores/roomStore';
-
-import EditorFooter from './EditorFooter';
-import TestcaseResultPanel from './TestcaseResultPanel';
 
 type SubmissionProgress = TestcaseUpdateMessage['progress'];
 type TestcaseResult = TestcaseUpdateMessage['testcase'] & {

--- a/apps/web/src/components/Battle/Player/ProgressBar.tsx
+++ b/apps/web/src/components/Battle/Player/ProgressBar.tsx
@@ -1,34 +1,76 @@
+import { useBattleProgressStore } from '@/stores/battleProgressStore';
+import { useRoomStore } from '@/stores/roomStore';
+
 function ProgressBar() {
+  const me = useRoomStore((state) => state.me);
+  const players = useRoomStore((state) => state.players);
+  const progresses = useBattleProgressStore((state) => state.progresses);
+
+  const opponent = players.find((p) => p.userId !== me?.userId);
+
+  const myProgress = me?.userId ? progresses[me.userId] : null;
+  const opponentProgress = opponent?.userId ? progresses[opponent.userId] : null;
+
+  const myPercent = myProgress?.total
+    ? Math.round((myProgress.passed / myProgress.total) * 100)
+    : 0;
+  const opponentPercent = opponentProgress?.total
+    ? Math.round((opponentProgress.passed / opponentProgress.total) * 100)
+    : 0;
+
   return (
     <div className="flex w-full flex-row gap-5">
+      {/* 나의 진행률 */}
       <div className="flex min-w-55 flex-1 items-center gap-2">
         <div className="flex items-center gap-2 text-xs font-semibold text-base-primary">
-          <span className="h-2 w-2 rounded-full bg-color-green-05" />
-          You
+          {me?.avatarUrl ? (
+            <img
+              src={me.avatarUrl}
+              alt={me.username}
+              className="h-6 w-6 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-green-05 text-[10px] font-bold text-white">
+              {me?.username?.charAt(0).toUpperCase() ?? 'Y'}
+            </div>
+          )}
         </div>
         <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-base-muted">
-          <span className="absolute left-0 top-0 h-full w-[12%] bg-color-green-05" />
           <span className="absolute left-0 top-0 h-full w-full bg-[rgba(34,197,94,0.2)]" />
-          <span className="absolute left-0 top-0 h-full w-[60%] bg-color-green-05" />
+          <span
+            className="absolute left-0 top-0 h-full bg-green-05 transition-all duration-300"
+            style={{ width: `${myPercent}%` }}
+          />
         </div>
         <div className="flex items-center gap-2 text-xs font-semibold text-base-primary">
-          <span>0%</span>
+          <span>{myPercent}%</span>
         </div>
       </div>
 
+      {/* 상대방 진행률 */}
       <div className="flex min-w-55 flex-1 items-center gap-2">
         <div className="flex items-center gap-2 text-xs font-semibold text-base-primary">
-          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-pink-05 text-[10px] font-bold text-white">
-            C
-          </div>
+          {opponent?.avatarUrl ? (
+            <img
+              src={opponent.avatarUrl}
+              alt={opponent.username}
+              className="h-6 w-6 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-pink-05 text-[10px] font-bold text-white">
+              {opponent?.username?.charAt(0).toUpperCase() ?? '?'}
+            </div>
+          )}
         </div>
         <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-base-muted">
-          <span className="absolute left-0 top-0 h-full w-[12%] bg-color-green-05" />
           <span className="absolute left-0 top-0 h-full w-full bg-[rgba(244,63,94,0.2)]" />
-          <span className="absolute left-0 top-0 h-full w-[60%] bg-pink-05" />
+          <span
+            className="absolute left-0 top-0 h-full bg-pink-05 transition-all duration-300"
+            style={{ width: `${opponentPercent}%` }}
+          />
         </div>
         <div className="flex items-center gap-2 text-xs font-semibold text-pink-05">
-          <span>0%</span>
+          <span>{opponentPercent}%</span>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -1,12 +1,14 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
 import type { FinalResultMessage } from '@shared/types/pubsub';
-import { Code, Trophy } from 'lucide-react';
+import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
+
+import ProgressBarSpectator from './ProgressBarSpectator';
 
 type SubmissionResultPayload = Omit<FinalResultMessage, 'type'> & {
   userId?: string;
@@ -103,72 +105,14 @@ function CodeSpectator() {
   const selectedCode = activeSelectedId ? (codes[activeSelectedId] ?? '') : '';
   const selectedProgress = activeSelectedId ? progresses[activeSelectedId] : null;
 
-  const participantCards = useMemo(
-    () =>
-      participants.map((p, idx) => {
-        const progress = progresses[p.userId];
-        const percent = progress?.total ? Math.round((progress.passed / progress.total) * 100) : 0;
-        return {
-          ...p,
-          percent,
-          passed: progress?.passed ?? 0,
-          total: progress?.total ?? 0,
-          color: idx === 0 ? 'var(--color-green-05)' : 'var(--color-pink-05)',
-          bg: idx === 0 ? 'bg-[var(--color-green-05)]' : 'bg-[var(--color-pink-05)]',
-        };
-      }),
-    [participants, progresses],
-  );
-
   return (
     <>
       <section className="flex flex-col gap-4 overflow-hidden rounded-2xl text-base-primary xl:h-full xl:min-h-0">
-        <div className="grid gap-3 sm:grid-cols-2">
-          {participantCards.map((player) => (
-            <button
-              key={player.userId}
-              type="button"
-              onClick={() => setSelectedId(player.userId)}
-              className={`flex flex-col gap-2 rounded-2xl border px-4 py-3 text-left transition ${
-                selectedId === player.userId
-                  ? 'border-green-05 bg-(--bg-layer-2)'
-                  : 'border-border-soft bg-(--bg-layer-2) hover:brightness-105'
-              }`}
-            >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <span
-                    className={`flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white ${player.bg} overflow-hidden`}
-                  >
-                    {player.avatarUrl ? (
-                      <img
-                        src={player.avatarUrl}
-                        alt={player.username}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      player.userId[0]
-                    )}
-                  </span>
-                  <div className="space-y-1">
-                    <p className="text-base font-semibold text-base-primary">{player.username}</p>
-                    <div className="flex items-center gap-1 text-xs font-semibold text-amber-500">
-                      <Trophy className="h-4 w-4" />
-                      <span>Gold</span>
-                    </div>
-                  </div>
-                </div>
-                <span className="text-sm font-bold text-base-primary">{player.percent}%</span>
-              </div>
-              <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
-                <span
-                  className="block h-full rounded-full"
-                  style={{ width: `${player.percent}%`, backgroundColor: player.color }}
-                />
-              </div>
-            </button>
-          ))}
-        </div>
+        <ProgressBarSpectator
+          participants={participants}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+        />
 
         <div className="flex flex-col overflow-hidden rounded-2xl border border-border-soft bg-(bg-layer-2) text-base-primary shadow-inner shadow-slate-950/10 xl:flex-1 xl:min-h-0">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-soft bg-(--bg-layer-2) px-4 py-3 text-sm font-semibold">

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -4,11 +4,10 @@ import { Code } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
+import ProgressBarSpectator from '@/components/Battle/Spectator/ProgressBarSpectator';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
-
-import ProgressBarSpectator from './ProgressBarSpectator';
 
 type SubmissionResultPayload = Omit<FinalResultMessage, 'type'> & {
   userId?: string;

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -1,10 +1,16 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
+import type { FinalResultMessage } from '@shared/types/pubsub';
 import { Code, Trophy } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
+import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
+
+type SubmissionResultPayload = Omit<FinalResultMessage, 'type'> & {
+  userId?: string;
+};
 
 function CodeSpectator() {
   const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
@@ -15,6 +21,8 @@ function CodeSpectator() {
 
   const socket = useBattleSocketStore((state) => state.socket);
   const connect = useBattleSocketStore((state) => state.connect);
+  const progresses = useBattleProgressStore((state) => state.progresses);
+  const upsertProgress = useBattleProgressStore((state) => state.upsertProgress);
 
   useEffect(() => {
     const client = socket ?? connect();
@@ -38,6 +46,25 @@ function CodeSpectator() {
       client.off(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdate);
     };
   }, [connect, roomId, selectedId, socket]);
+
+  useEffect(() => {
+    const client = socket ?? connect();
+
+    const handleSubmissionResult = (payload: SubmissionResultPayload) => {
+      if (payload.userId && payload.result) {
+        upsertProgress(payload.userId, {
+          passed: payload.result.passed,
+          total: payload.result.total,
+        });
+      }
+    };
+
+    client.on('submission-result', handleSubmissionResult);
+
+    return () => {
+      client.off('submission-result', handleSubmissionResult);
+    };
+  }, [socket, connect, upsertProgress]);
 
   const participants = useMemo(() => {
     if (players.length > 0) return players.slice(0, 2);
@@ -74,16 +101,23 @@ function CodeSpectator() {
 
   const activeSelectedId = selectedId ?? firstParticipantId;
   const selectedCode = activeSelectedId ? (codes[activeSelectedId] ?? '') : '';
+  const selectedProgress = activeSelectedId ? progresses[activeSelectedId] : null;
 
   const participantCards = useMemo(
     () =>
-      participants.map((p, idx) => ({
-        ...p,
-        percent: 75,
-        color: idx === 0 ? 'var(--color-green-05)' : 'var(--color-pink-05)',
-        bg: idx === 0 ? 'bg-[var(--color-green-05)]' : 'bg-[var(--color-pink-05)]',
-      })),
-    [participants],
+      participants.map((p, idx) => {
+        const progress = progresses[p.userId];
+        const percent = progress?.total ? Math.round((progress.passed / progress.total) * 100) : 0;
+        return {
+          ...p,
+          percent,
+          passed: progress?.passed ?? 0,
+          total: progress?.total ?? 0,
+          color: idx === 0 ? 'var(--color-green-05)' : 'var(--color-pink-05)',
+          bg: idx === 0 ? 'bg-[var(--color-green-05)]' : 'bg-[var(--color-pink-05)]',
+        };
+      }),
+    [participants, progresses],
   );
 
   return (
@@ -157,17 +191,13 @@ function CodeSpectator() {
               {selectedCode}
             </pre>
           </div>
-
-          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-soft bg-(--bg-layer-2) px-4 py-3 text-xs text-base-secondary">
-            <div className="flex items-center gap-4">
-              <span className="flex items-center gap-1 text-green-05">
-                ● {/* {selected.progress.passedCount} */}개 테스트 통과
-              </span>
-              <span className="flex items-center gap-1 text-pink-05">
-                ● {/* {selected.progress.totalCount - selected.progress.passedCount} */}개 실패
-              </span>
-            </div>
-            <span>마지막 업데이트: 방금 전</span>
+          <div className="flex items-center justify-end gap-4 border-t border-border-soft bg-(--bg-layer-2) px-4 py-3 text-xs text-base-secondary">
+            <span className="flex items-center gap-1 text-green-05">
+              ● {selectedProgress?.passed ?? 0}개 테스트 통과
+            </span>
+            <span className="flex items-center gap-1 text-pink-05">
+              ● {(selectedProgress?.total ?? 0) - (selectedProgress?.passed ?? 0)}개 실패
+            </span>
           </div>
         </div>
       </section>

--- a/apps/web/src/components/Battle/Spectator/ProgressBarSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ProgressBarSpectator.tsx
@@ -1,0 +1,83 @@
+import { Trophy } from 'lucide-react';
+
+import { useBattleProgressStore } from '@/stores/battleProgressStore';
+
+type Participant = {
+  userId: string;
+  username: string;
+  avatarUrl?: string;
+};
+
+type Props = {
+  participants: Participant[];
+  selectedId: string | null;
+  onSelect: (userId: string) => void;
+};
+
+function ProgressBarSpectator({ participants, selectedId, onSelect }: Props) {
+  const progresses = useBattleProgressStore((state) => state.progresses);
+
+  const participantCards = participants.map((p, idx) => {
+    const progress = progresses[p.userId];
+    const percent = progress?.total ? Math.round((progress.passed / progress.total) * 100) : 0;
+    return {
+      ...p,
+      percent,
+      passed: progress?.passed ?? 0,
+      total: progress?.total ?? 0,
+      color: idx === 0 ? 'var(--color-green-05)' : 'var(--color-pink-05)',
+      bg: idx === 0 ? 'bg-[var(--color-green-05)]' : 'bg-[var(--color-pink-05)]',
+    };
+  });
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {participantCards.map((player) => (
+        <button
+          key={player.userId}
+          type="button"
+          onClick={() => onSelect(player.userId)}
+          className={`flex flex-col gap-2 rounded-2xl border px-4 py-3 text-left transition ${
+            selectedId === player.userId
+              ? 'border-green-05 bg-(--bg-layer-2)'
+              : 'border-border-soft bg-(--bg-layer-2) hover:brightness-105'
+          }`}
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <span
+                className={`flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white ${player.bg} overflow-hidden`}
+              >
+                {player.avatarUrl ? (
+                  <img
+                    src={player.avatarUrl}
+                    alt={player.username}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  player.userId[0]
+                )}
+              </span>
+              <div className="space-y-1">
+                <p className="text-base font-semibold text-base-primary">{player.username}</p>
+                <div className="flex items-center gap-1 text-xs font-semibold text-amber-500">
+                  <Trophy className="h-4 w-4" />
+                  <span>Gold</span>
+                </div>
+              </div>
+            </div>
+            <span className="text-sm font-bold text-base-primary">{player.percent}%</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
+            <span
+              className="block h-full rounded-full"
+              style={{ width: `${player.percent}%`, backgroundColor: player.color }}
+            />
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default ProgressBarSpectator;

--- a/apps/web/src/stores/battleProgressStore.ts
+++ b/apps/web/src/stores/battleProgressStore.ts
@@ -11,6 +11,7 @@ export type ActivityLog = {
 export type PlayerProgress = {
   passed: number;
   total: number;
+  codeLines?: number;
   activityLogs: ActivityLog[];
 };
 
@@ -23,6 +24,7 @@ type State = {
     userId: string,
     log: { type: 'TEST' | 'SUBMIT'; passed: number; total: number },
   ) => void;
+  updateCodeLines: (userId: string, codeLines: number) => void;
   resetProgresses: () => void;
 };
 
@@ -44,6 +46,7 @@ export const useBattleProgressStore = create<State>()(
               ...s.progresses,
               [userId]: {
                 ...progress,
+                codeLines: current?.codeLines ?? 0,
                 activityLogs: [...(current?.activityLogs ?? []), newLog],
               },
             },
@@ -62,7 +65,23 @@ export const useBattleProgressStore = create<State>()(
               [userId]: {
                 passed: current?.passed ?? 0,
                 total: current?.total ?? 0,
+                codeLines: current?.codeLines ?? 0,
                 activityLogs: [...(current?.activityLogs ?? []), newLog],
+              },
+            },
+          };
+        }),
+      updateCodeLines: (userId, codeLines) =>
+        set((s) => {
+          const current = s.progresses[userId];
+          return {
+            progresses: {
+              ...s.progresses,
+              [userId]: {
+                passed: current?.passed ?? 0,
+                total: current?.total ?? 0,
+                codeLines,
+                activityLogs: current?.activityLogs ?? [],
               },
             },
           };

--- a/apps/web/src/stores/battleProgressStore.ts
+++ b/apps/web/src/stores/battleProgressStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type PlayerProgress = {
+  passed: number;
+  total: number;
+};
+
+type ProgressMap = Record<string, PlayerProgress>;
+
+type State = {
+  progresses: ProgressMap;
+  upsertProgress: (userId: string, progress: PlayerProgress) => void;
+  resetProgresses: () => void;
+};
+
+export const useBattleProgressStore = create<State>()(
+  persist(
+    (set) => ({
+      progresses: {},
+      upsertProgress: (userId, progress) =>
+        set((s) => ({ progresses: { ...s.progresses, [userId]: progress } })),
+      resetProgresses: () => set({ progresses: {} }),
+    }),
+    {
+      name: 'battle-progress',
+      storage: {
+        getItem: (name) => {
+          const str = sessionStorage.getItem(name);
+          return str ? JSON.parse(str) : null;
+        },
+        setItem: (name, value) => {
+          sessionStorage.setItem(name, JSON.stringify(value));
+        },
+        removeItem: (name) => {
+          sessionStorage.removeItem(name);
+        },
+      },
+    },
+  ),
+);

--- a/apps/web/src/stores/battleProgressStore.ts
+++ b/apps/web/src/stores/battleProgressStore.ts
@@ -1,16 +1,23 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+export type SubmitLog = {
+  passed: number;
+  total: number;
+  timestamp: number;
+};
+
 export type PlayerProgress = {
   passed: number;
   total: number;
+  submitLogs: SubmitLog[];
 };
 
 type ProgressMap = Record<string, PlayerProgress>;
 
 type State = {
   progresses: ProgressMap;
-  upsertProgress: (userId: string, progress: PlayerProgress) => void;
+  upsertProgress: (userId: string, progress: { passed: number; total: number }) => void;
   resetProgresses: () => void;
 };
 
@@ -19,7 +26,23 @@ export const useBattleProgressStore = create<State>()(
     (set) => ({
       progresses: {},
       upsertProgress: (userId, progress) =>
-        set((s) => ({ progresses: { ...s.progresses, [userId]: progress } })),
+        set((s) => {
+          const current = s.progresses[userId];
+          const newLog: SubmitLog = {
+            passed: progress.passed,
+            total: progress.total,
+            timestamp: Date.now(),
+          };
+          return {
+            progresses: {
+              ...s.progresses,
+              [userId]: {
+                ...progress,
+                submitLogs: [...(current?.submitLogs ?? []), newLog],
+              },
+            },
+          };
+        }),
       resetProgresses: () => set({ progresses: {} }),
     }),
     {

--- a/apps/web/src/stores/battleProgressStore.ts
+++ b/apps/web/src/stores/battleProgressStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type SubmitLog = {
+export type ActivityLog = {
+  type: 'TEST' | 'SUBMIT';
   passed: number;
   total: number;
   timestamp: number;
@@ -10,7 +11,7 @@ export type SubmitLog = {
 export type PlayerProgress = {
   passed: number;
   total: number;
-  submitLogs: SubmitLog[];
+  activityLogs: ActivityLog[];
 };
 
 type ProgressMap = Record<string, PlayerProgress>;
@@ -18,6 +19,10 @@ type ProgressMap = Record<string, PlayerProgress>;
 type State = {
   progresses: ProgressMap;
   upsertProgress: (userId: string, progress: { passed: number; total: number }) => void;
+  addActivityLog: (
+    userId: string,
+    log: { type: 'TEST' | 'SUBMIT'; passed: number; total: number },
+  ) => void;
   resetProgresses: () => void;
 };
 
@@ -28,7 +33,8 @@ export const useBattleProgressStore = create<State>()(
       upsertProgress: (userId, progress) =>
         set((s) => {
           const current = s.progresses[userId];
-          const newLog: SubmitLog = {
+          const newLog: ActivityLog = {
+            type: 'SUBMIT',
             passed: progress.passed,
             total: progress.total,
             timestamp: Date.now(),
@@ -38,7 +44,25 @@ export const useBattleProgressStore = create<State>()(
               ...s.progresses,
               [userId]: {
                 ...progress,
-                submitLogs: [...(current?.submitLogs ?? []), newLog],
+                activityLogs: [...(current?.activityLogs ?? []), newLog],
+              },
+            },
+          };
+        }),
+      addActivityLog: (userId, log) =>
+        set((s) => {
+          const current = s.progresses[userId];
+          const newLog: ActivityLog = {
+            ...log,
+            timestamp: Date.now(),
+          };
+          return {
+            progresses: {
+              ...s.progresses,
+              [userId]: {
+                passed: current?.passed ?? 0,
+                total: current?.total ?? 0,
+                activityLogs: [...(current?.activityLogs ?? []), newLog],
               },
             },
           };

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -166,6 +166,7 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
             userId: p.userId,
             username: p.username,
             avatarUrl: p.avatarUrl,
+            stats: p.stats,
           })),
         );
       };

--- a/apps/web/src/stores/roomStore.ts
+++ b/apps/web/src/stores/roomStore.ts
@@ -1,4 +1,4 @@
-import type { UserRole } from '@shared/types/user';
+import type { UserRole, UserStats } from '@shared/types/user';
 import { create } from 'zustand';
 
 export type Player = {
@@ -7,6 +7,7 @@ export type Player = {
   userId: string;
   username: string;
   avatarUrl?: string;
+  stats?: UserStats;
 };
 type CodeMap = Record<string, string>;
 

--- a/packages/constants/battle.ts
+++ b/packages/constants/battle.ts
@@ -12,6 +12,7 @@ export const BATTLE_EVENTS = {
   // 코드 변경
   CODE_CHANGE: 'code-change',
   CODE_UPDATED: 'code-updated',
+  CODE_METADATA: 'code-metadata', // 상대방에게 코드 변경 알림
 
   // 유저 상태 변경
   USER_CONNECTED: 'user-connected',

--- a/packages/constants/battle.ts
+++ b/packages/constants/battle.ts
@@ -21,6 +21,7 @@ export const BATTLE_EVENTS = {
 
   // 진행 상황 업데이트
   PROGRESS_UPDATE: 'progress-update',
+  TEST_RESULT: 'test-result',
 
   // 유저 진행률
   USER_TEST_RESULT: 'user-test-result',

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -1,5 +1,12 @@
 export type UserRole = 'player' | 'spectator';
 
+export interface UserStats {
+  wins: number;
+  losses: number;
+  rating: number;
+  tier: { tier: string; division: number };
+}
+
 // 방에 들어가지 않은 사용자
 export interface User {
   userId: string;
@@ -13,4 +20,5 @@ export interface RoomUser extends User {
   socketId: string;
   role: UserRole;
   joinedAt: Date;
+  stats?: UserStats;
 }


### PR DESCRIPTION
## 🔍 PR 요약

- 참가자: 상대방의 코드 변경이나 제출 시 실시간 통계 확인
- 관전자: 실시간 제출 내역 확인

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #168 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- zustand-persist를 활용하여 sessionStorage에 BattleProgress 데이터 저장
  - 새로고침해도 데이터 보장
- 테스트(dry-run) 제출 시 시스템 알림 추가
- 오른쪽 상대방의 실시간 현황 표시
- `CODE_METADATA` 이벤트 생성
  - 코드 변경시 상대방에게 코드라인수 전달
- BattleProgressStore를 만들어 실시간 통계 데이터 저장
  - 활동 로그 저장
  - 제출 통과 수 저장
  - 코드 라인 수 저장
## 📸 스크린샷 (선택)

**참가자들의 ProgressBar**
<img width="1363" height="148" alt="image" src="https://github.com/user-attachments/assets/a5282a33-3789-45d0-8f4a-a03db193c6f7" />

**관전자들의 ProgressBar**
<img width="1630" height="222" alt="image" src="https://github.com/user-attachments/assets/cf827e29-f951-4b42-88e9-7e9e712d1105" />

**관전자 채팅에서 제출 시스템 메시지**
<img width="448" height="713" alt="image" src="https://github.com/user-attachments/assets/1aa6a8b2-7514-4468-9250-ca29605385c4" />

**상대방 실시간 상태**
<img width="553" height="787" alt="image" src="https://github.com/user-attachments/assets/282cf4cd-b340-4229-820c-acdef2986185" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 초기 디렉토리 구조를 정리하고, 백엔드/프론트엔드 개발을 위한 공통 기반을 마련하기 위함

## 💬 리뷰 요구사항(선택)

- A 참가자의 기존 제출 점수가 70점이고, 이후에 제출했을 때 점수가 떨어질 경우 이를 화면에 반영해야 할지 궁금합니다.
- 이벤트를 너무 많이 만들면 코드가 복잡해질까봐 기존 이벤트를 최대한 활용해서 구현했는데, 이벤트가 너무 많이 오는 것은 아닐까 우려됩니다.
- 문제점 : `CODE_UPDATED` 이벤트 자체가 해당 방의 모든 사용자에게 전달되고 있기 때문에 상대방에게도 이 이벤트가 전달되고 있습니다. 그래서 네트워크 탭을 열면 상대방이 제출한 코드를 확인할 수 있습니다.
