### PR TITLE
[FEAT] 비로그인 관전자 채팅 입력 제한 (#172)

### DIFF
--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -31,6 +31,7 @@ export class RoomGateway {
   @WebSocketServer() server: Server;
   private rateLimitMap: Map<string, { count: number; windowStart: number; blockedUntil: number }> =
     new Map();
+  private readonly chatAuthErrorMessage = '로그인 후 채팅을 이용할 수 있습니다.';
 
   constructor(
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
@@ -298,20 +299,10 @@ export class RoomGateway {
       room.currentSpectators.find((user) => user.socketId === client.id);
 
     // 방에 참가하지 않은 유저는 채팅 불가
-    if (!participant) {
+    if (!participant || participant.userId === client.id) {
       client.emit(SOCKET_EVENT.ERROR, {
         code: SOCKET_ERROR.UNKNOWN,
-        message: '로그인 후 채팅을 이용할 수 있습니다.',
-      });
-      return;
-    }
-
-    // 익명 유저는 채팅 불가
-    const isAnonymous = participant.userId === client.id;
-    if (isAnonymous) {
-      client.emit(SOCKET_EVENT.ERROR, {
-        code: SOCKET_ERROR.UNKNOWN,
-        message: '로그인 후 채팅을 이용할 수 있습니다.',
+        message: this.chatAuthErrorMessage,
       });
       return;
     }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -273,7 +273,7 @@ export class RoomGateway {
   }
 
   @SubscribeMessage(SOCKET_EVENT.SEND_CHAT)
-  handleSendChat(
+  async handleSendChat(
     @ConnectedSocket() client: Socket,
     @MessageBody() data: { roomId: string; message: string; nickname?: string; avatarUrl?: string },
   ) {
@@ -281,6 +281,38 @@ export class RoomGateway {
     const trimmedMessage = message?.trim();
 
     if (!roomId || !trimmedMessage) {
+      return;
+    }
+
+    const room = await this.roomService.getRoom(roomId);
+    if (!room) {
+      client.emit(SOCKET_EVENT.ERROR, {
+        code: SOCKET_ERROR.ROOM_NOT_FOUND,
+        message: '방을 찾을 수 없습니다.',
+      });
+      return;
+    }
+
+    const participant =
+      room.currentPlayers.find((user) => user.socketId === client.id) ??
+      room.currentSpectators.find((user) => user.socketId === client.id);
+
+    // 방에 참가하지 않은 유저는 채팅 불가
+    if (!participant) {
+      client.emit(SOCKET_EVENT.ERROR, {
+        code: SOCKET_ERROR.UNKNOWN,
+        message: '로그인 후 채팅을 이용할 수 있습니다.',
+      });
+      return;
+    }
+
+    // 익명 유저는 채팅 불가
+    const isAnonymous = participant.userId === client.id;
+    if (isAnonymous) {
+      client.emit(SOCKET_EVENT.ERROR, {
+        code: SOCKET_ERROR.UNKNOWN,
+        message: '로그인 후 채팅을 이용할 수 있습니다.',
+      });
       return;
     }
 

--- a/apps/web/src/components/Battle/BattleProblem.tsx
+++ b/apps/web/src/components/Battle/BattleProblem.tsx
@@ -64,7 +64,7 @@ function BattleProblem() {
                   </a>
                 )}
               </div>
-              <div className="grid gap-2 text-[11px] text-base-secondary sm:grid-cols-2">
+              <div className="grid grid-cols-4 gap-2 text-[11px] text-base-secondary xl:grid-cols-2">
                 {problem.source && (
                   <div className="rounded-md border border-border-soft bg-base-primary/5 px-3 py-2">
                     <span className="block text-[9px] uppercase tracking-[0.2em] text-base-secondary">

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -3,16 +3,19 @@ import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { ChatMessage } from '@shared/types/chat';
 import { MessagesSquare } from 'lucide-react';
 import { type KeyboardEventHandler, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
+import { useUserStore } from '@/stores/userStore';
 
 const initialMessages: ChatMessage[] = [];
 
 function ChatSpectator() {
   const { roomId = '1' } = useParams<{ roomId: string }>();
+  const navigate = useNavigate();
   const me = useRoomStore((state) => state.me);
+  const user = useUserStore((state) => state.user);
   const socket = useBattleSocketStore((state) => state.socket);
   const connectSocket = useBattleSocketStore((state) => state.connect);
   const listRef = useRef<HTMLDivElement>(null);
@@ -25,6 +28,7 @@ function ChatSpectator() {
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
   const [input, setInput] = useState('');
   const bottomRef = useRef<HTMLDivElement>(null);
+  const isLoggedIn = Boolean(user?.id);
 
   useEffect(() => {
     // 새 메시지가 추가되면 리스트 하단으로 스크롤
@@ -65,6 +69,7 @@ function ChatSpectator() {
   };
 
   const handleSend = () => {
+    if (!isLoggedIn) return;
     const trimmed = input.trim();
     if (!trimmed) return;
 
@@ -80,6 +85,7 @@ function ChatSpectator() {
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
     if (event.nativeEvent.isComposing) return; // IME 조합 중일 때는 전송하지 않음
+    if (!isLoggedIn) return;
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       handleSend();
@@ -184,14 +190,26 @@ function ChatSpectator() {
             value={input}
             onChange={(event) => setInput(event.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="메시지를 입력하세요..."
-            className="chat-scroll h-10 max-h-32 min-h-10 flex-1 resize-none overflow-y-auto bg-transparent text-sm text-base-primary placeholder:text-base-secondary focus:outline-none"
+            placeholder={
+              isLoggedIn ? '메시지를 입력하세요...' : '로그인 후 채팅을 이용할 수 있어요.'
+            }
+            className="chat-scroll h-10 max-h-32 min-h-10 flex-1 resize-none overflow-y-auto bg-transparent text-sm text-base-primary placeholder:text-base-secondary focus:outline-none disabled:cursor-not-allowed"
+            disabled={!isLoggedIn}
           />
+          {!isLoggedIn && (
+            <button
+              type="button"
+              onClick={() => navigate('/login')}
+              className="rounded-lg border border-border-soft px-3 py-2 text-xs font-bold text-base-primary transition hover:bg-base-muted"
+            >
+              로그인
+            </button>
+          )}
           <button
             type="button"
             onClick={handleSend}
             className="rounded-lg bg-green-05 px-3 py-2 text-xs font-bold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={!input.trim()}
+            disabled={!isLoggedIn || !input.trim()}
           >
             전송
           </button>


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

비로그인 관전자는 채팅 입력을 할 수 없도록 UI에서 제한을 추가

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #172 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- ChatSpectator.tsx에서 로그인 여부에 따라 입력창/전송 버튼 비활성화 및 로그인 안내 버튼 제공

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

<img width="553" height="221" alt="image" src="https://github.com/user-attachments/assets/e1c26716-cc53-4a90-87b8-f4da12ccddf6" />


https://github.com/user-attachments/assets/cc8b34dd-52df-4769-a673-c5388bd5bed6




## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 관전자는 로그인 없이 입장 가능하지만, 채팅은 로그인 사용자만 허용하여 남용/스팸을 예방하고 사용자 경험을 명확히 하기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

