### PR TITLE
[FIX] 빌드 시 problems.json이 dist에 복사되도록 assets 설정 추가 (#177)

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [{ "include": "data/**/*.json", "outDir": "dist/apps/api/src" }],
+    "watchAssets": true
   }
 }


### PR DESCRIPTION


## 🔍 PR 요약

- nest-cli.json : assets 복사 경로 설정

## 🧾 관련 이슈

- close #177 

## 🛠️ 주요 변경 사항

- nest-cli.json : assets 복사 경로 설정

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

<img width="1095" height="113" alt="image" src="https://github.com/user-attachments/assets/b88b19e7-b160-4da4-b274-ac3b192c8bcf" />

기존 빌드 시에는 json 파일이 포함되지 않아 문제 파일을 읽을 수 없었음

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 배포 환경에서 문제 데이터를 읽어오기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?💬 리뷰 요구사항(선택)
