### PR TITLE
[FEAT] 배틀 결과 페이지에 실제 레이팅 표시 (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
   <sub>실시간 1:1 알고리즘 배틀 플랫폼</sub>
 </p>
 
-
-
 <p align="center">
   📝 <a href="https://www.notion.so/web30-2c319e920f6080b2908dfb28ba83275a?source=copy_link">팀 노션</a> &nbsp;|&nbsp;
   🎨 <a href="https://www.figma.com/board/AKXDZaAymXKSg5XShewk1A/%ED%85%8C%EC%98%A4%EC%9D%98-%EC%8A%A4%ED%94%84%EB%A6%B0%ED%8A%B8-%ED%85%9C%ED%94%8C%EB%A6%BF--web30-?node-id=0-1&t=epjZ5ONDNW74eWT7-1">피그잼</a> &nbsp;|&nbsp;
@@ -17,8 +15,8 @@
 
 ---
 
-
 ## 📖 프로젝트 소개 (Introduction)
+
 > **"코딩도 E-Sports가 될 수 있다!"**
 
 **TADAK(타닥)** 은 혼자서 외롭게 풀던 알고리즘 문제 풀이를 **실시간 경쟁 게임**으로 재해석한 웹 서비스입니다.
@@ -61,25 +59,27 @@
 # Web30 - PORT:30
 
 > 안녕하세요! 부스트캠프 웹·모바일 10기 WEB-30팀 **PORT:30**입니다.
-> 
+>
 > 저희는 “언제나 열려있는 30번 포트처럼 소통하고, 항구처럼 목표에 확실하게 정박하자"라는 의미를 담은 PORT: 30 팀입니다.
 
 <br>
 
 ## 👥 팀원
 
-| [J029\_김다연](https://github.com/dyeon-dev) | [J074\_김채영](https://github.com/cchaeyoung) | [J213\_이준섭](https://github.com/SubJeeLee) | [J278\_최효진](https://github.com/eeekeee) |
-| :---: | :---: | :---: | :---: |
+|                       [J029\_김다연](https://github.com/dyeon-dev)                        |                       [J074\_김채영](https://github.com/cchaeyoung)                        |                        [J213\_이준섭](https://github.com/SubJeeLee)                        |                         [J278\_최효진](https://github.com/eeekeee)                         |
+| :---------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: |
 | <img src="https://avatars.githubusercontent.com/u/93921784?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/123921311?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/176148148?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/144501864?v=4" width="130" height="130"> |
 
 <br>
 
 ## 🎯 목표 (Goals)
+
 **Team Goal:** "근거 있는 기술 선택을 하는 개발자 되기"
 
 **Project Goal:** 개발자들의 고립감을 해소하고, 코딩을 E-Sports처럼 즐길 수 있는 문화를 만든다.
 
 ## 🤝 협업 문화 (Ground Rules)
+
 **Core Time:** 평일 10:00 ~ 18:00 집중 개발
 
 **Communication:** 모르는 것은 10분 고민 후 바로 공유하기
@@ -87,7 +87,6 @@
 **Process:** 매주 금요일 데모 데이 진행, 스크럼을 통한 매일의 이슈 공유
 
 [👉 자세한 그라운드 룰 보러가기](https://github.com/boostcampwm2025/web30-TADAK/wiki/%EA%B7%B8%EB%9D%BC%EC%9A%B4%EB%93%9C%EB%A3%B0)
-
 
 <br>
 
@@ -121,12 +120,12 @@
 
 프로젝트의 상세 설계 내용은 아래 문서에서 확인하실 수 있습니다.
 
-| 문서 종류 | 설명 | 링크 |
-| :-- | :-- | :-- |
-| **User Scenario** | 사용자 흐름 및 기능 명세 | [위키 바로가기](https://github.com/boostcampwm2025/web30-TADAK/wiki/%EC%9C%A0%EC%A0%80-%EC%8B%9C%EB%82%98%EB%A6%AC%EC%98%A4) |
-| **API Docs** | API 명세서 (Swagger/Wiki) | [API 문서 보기](링크_입력_필요) |
-| **ER Diagram** | 데이터베이스 구조도 | [ERD 보기](링크_입력_필요) |
-| **Figma** | 와이어프레임 및 디자인 | [Figma 보기](링크_입력_필요) |
+| 문서 종류         | 설명                      | 링크                                                                                                                         |
+| :---------------- | :------------------------ | :--------------------------------------------------------------------------------------------------------------------------- |
+| **User Scenario** | 사용자 흐름 및 기능 명세  | [위키 바로가기](https://github.com/boostcampwm2025/web30-TADAK/wiki/%EC%9C%A0%EC%A0%80-%EC%8B%9C%EB%82%98%EB%A6%AC%EC%98%A4) |
+| **API Docs**      | API 명세서 (Swagger/Wiki) | [API 문서 보기](링크_입력_필요)                                                                                              |
+| **ER Diagram**    | 데이터베이스 구조도       | [ERD 보기](링크_입력_필요)                                                                                                   |
+| **Figma**         | 와이어프레임 및 디자인    | [Figma 보기](링크_입력_필요)                                                                                                 |
 
 <br>
 

--- a/apps/api/src/battle/battle.entity.ts
+++ b/apps/api/src/battle/battle.entity.ts
@@ -23,6 +23,12 @@ export class Battle {
   @Column('simple-array')
   playerIds: string[];
 
+  @Column({ type: 'int', nullable: true })
+  player1RatingChange: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  player2RatingChange: number | null;
+
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
 }

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -411,7 +411,7 @@ export class BattleService {
 
     const userMap = new Map(users.map((user) => [user.id, user]));
 
-    const players = playerIds.map((userId) => {
+    const players = playerIds.map((userId, index) => {
       const user = userMap.get(userId);
       const submission = submissionMap.get(userId);
 
@@ -429,6 +429,9 @@ export class BattleService {
 
       const tier = (user?.tier?.tier || 'Bronze') as Tier;
 
+      const ratingChange =
+        index === 0 ? battle.player1RatingChange || 0 : battle.player2RatingChange || 0;
+
       return {
         userId,
         username: user?.username || 'Unknown',
@@ -439,6 +442,7 @@ export class BattleService {
         totalScore: submission?.totalTestCases || 20,
         time,
         code: submission?.code || '',
+        ratingChange,
       };
     });
 

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -281,6 +281,14 @@ export class BattleService {
       ? lastSubmissions.find((s) => s.odUserId === loserId)?.submission || null
       : null;
 
+    const isDraw = winnerId === null;
+    const finalWinnerId = winnerId || battle.users[0].userId;
+    const finalLoserId = loserId || battle.users[1].userId;
+    this.logger.log(
+      `[endBattle] 점수 업데이트 시작 - finalWinnerId: ${finalWinnerId}, finalLoserId: ${finalLoserId}, isDraw: ${isDraw}`,
+    );
+    const ratingResult = await this.userService.updateRatings(finalWinnerId, finalLoserId, isDraw);
+
     // 4. 배틀 엔티티 생성 및 저장
     const battleEntity = new BattleEntity();
     battleEntity.id = battle.battleId;
@@ -291,17 +299,18 @@ export class BattleService {
     battleEntity.loserSubmissionId = loserSubmission?.id || null;
     battleEntity.playerIds = battle.users.map((u) => u.userId);
 
+    const player1Id = battle.users[0].userId;
+    battleEntity.player1RatingChange =
+      finalWinnerId === player1Id
+        ? ratingResult.winner.ratingDelta
+        : ratingResult.loser.ratingDelta;
+    battleEntity.player2RatingChange =
+      finalWinnerId === player1Id
+        ? ratingResult.loser.ratingDelta
+        : ratingResult.winner.ratingDelta;
+
     const savedBattle = await this.battleRepository.save(battleEntity);
     this.logger.log(`[endBattle] 배틀 엔티티 저장 완료 - savedBattle.id: ${savedBattle.id}`);
-
-    // 4.5 유저 점수 업데이트
-    const isDraw = winnerId === null;
-    const finalWinnerId = winnerId || battle.users[0].userId;
-    const finalLoserId = loserId || battle.users[1].userId;
-    this.logger.log(
-      `[endBattle] 점수 업데이트 시작 - finalWinnerId: ${finalWinnerId}, finalLoserId: ${finalLoserId}, isDraw: ${isDraw}`,
-    );
-    await this.userService.updateRatings(finalWinnerId, finalLoserId, isDraw);
 
     // 5. Redis에서 배틀 데이터 삭제
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 시작`);

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -371,15 +371,26 @@ export class BattleService {
     // 참가자 목록
     const playerIds = battle.playerIds;
 
-    // 제출 조회
+    // 제출 조회: 승부가 난 경우 id로 조회, 무승부인 경우 각 유저별 최신 제출 조회
     const submissionIds = [battle.winnerSubmissionId, battle.loserSubmissionId].filter(Boolean);
-    const submissions =
-      submissionIds.length > 0
-        ? await this.submissionRepository
-            .createQueryBuilder('submission')
-            .whereInIds(submissionIds)
-            .getMany()
-        : [];
+    let submissions: Submission[];
+
+    if (submissionIds.length > 0) {
+      submissions = await this.submissionRepository
+        .createQueryBuilder('submission')
+        .whereInIds(submissionIds)
+        .getMany();
+    } else {
+      submissions = await Promise.all(
+        playerIds.map(async (userId) => {
+          const submission = await this.submissionRepository.findOne({
+            where: { battleId, userId },
+            order: { createdAt: 'DESC' },
+          });
+          return submission;
+        }),
+      ).then((results) => results.filter((sub) => sub !== null));
+    }
 
     const submissionMap = new Map(submissions.map((sub) => [sub.userId, sub]));
 

--- a/apps/web/src/components/Result/PlayerCard.tsx
+++ b/apps/web/src/components/Result/PlayerCard.tsx
@@ -11,6 +11,7 @@ interface PlayerCardProps {
     score: number;
     totalScore: number;
     time: string;
+    ratingChange: number;
   };
   rank: number;
   isWinner: boolean;
@@ -19,8 +20,7 @@ interface PlayerCardProps {
 }
 
 function PlayerCard({ player, isWinner, isSelected, onClick }: PlayerCardProps) {
-  const { username, avatarUrl, tier, rate, score, totalScore, time } = player;
-  const scoreChange = isWinner ? 25 : -25;
+  const { username, avatarUrl, tier, rate, score, totalScore, time, ratingChange } = player;
 
   return (
     <button
@@ -57,8 +57,8 @@ function PlayerCard({ player, isWinner, isSelected, onClick }: PlayerCardProps) 
           </div>
           <div>
             <div className={`text-3xl font-bold ${isWinner ? 'text-green-05' : 'text-pink-05'}`}>
-              {scoreChange > 0 ? '+' : ''}
-              {scoreChange}
+              {ratingChange > 0 ? '+' : ''}
+              {ratingChange}
             </div>
             <div className="text-sm font-semibold text-base-secondary">랭크 변동</div>
           </div>

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -91,5 +91,6 @@ export interface BattleResultResponse {
     totalScore: number;
     time: string;
     code: string;
+    ratingChange: number;
   }>;
 }


### PR DESCRIPTION
## 🔍 PR 요약

- 배틀 결과 페이지에서 실제 레이팅 변동을 표시하도록 개선

## 🧾 관련 이슈

- close #192

## 🛠️ 주요 변경 사항

- 점수 변동 표시
  - Battle 엔티티에 player1RatingChange, player2RatingChange 필드 추가
  - endBattle에서 레이팅 업데이트 후 변동값을 배틀 엔티티에 저장
  - PlayerCard 컴포넌트에 실제 레이팅 변동값 표시

- 무승부 배틀 결과 오류 수정
  - 이전엔 무승부 시 winnerSubmissionId와 loserSubmissionId가 모두 null → 제출 기록을 가져오지 못함 → 정보 표시 불가
  - 수정 후 승부가 난 경우 submissionId로 조회, 무승부인 경우 각 플레이어별 최신 제출 기록 조회

## 📸 스크린샷

<img width="1918" height="908" alt="image" src="https://github.com/user-attachments/assets/cdc15ef7-c3ef-4cb8-a086-e2c765748715" />


## 🧠 의도 및 배경

- 점수 변동이 없는 경우 아이콘이 `↓` 으로 되어있는데, 추후 `-` 으로 변경이 필요합니다.

