### PR TITLE
[FIX] 관전자가 0으로 표시되는 문제 해결

### DIFF
--- a/apps/web/src/components/Battle/Spectator/BattleSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/BattleSpectator.tsx
@@ -54,7 +54,10 @@ function BattleSpectator() {
             <CodeSpectator />
           </div>
           {showChat && (
-            <div ref={chatRef} className="fade-slide-in xl:h-full xl:min-h-0">
+            <div
+              ref={chatRef}
+              className={`fade-slide-in xl:h-full xl:min-h-0 ${showChat ? '' : 'hidden'}`}
+            >
               <ChatSpectator />
             </div>
           )}

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -23,6 +23,12 @@ function BattlePage() {
   const resumeSession = useBattleSocketStore((state) => state.resumeSession);
   const connect = useBattleSocketStore((state) => state.connect);
   const joinRoom = useBattleSocketStore((state) => state.joinRoom);
+  const subscribeRoomAvailability = useBattleSocketStore(
+    (state) => state.subscribeRoomAvailability,
+  );
+  const unsubscribeRoomAvailability = useBattleSocketStore(
+    (state) => state.unsubscribeRoomAvailability,
+  );
   const setProblem = useBattleProblemStore((state) => state.setProblem);
   const setTimeOffset = useBattleProblemStore((state) => state.setTimeOffset);
   const user = useUserStore((state) => state.user);
@@ -97,6 +103,16 @@ function BattlePage() {
     };
     attempt();
   }, [me, resumeSession, joinRoom, roomId, isSpectator, user?.avatarUrl, user?.id, user?.username]);
+
+  // 관전자 수 및 인원 변동을 수신하기 위한 구독
+  useEffect(() => {
+    if (!roomId) return;
+
+    subscribeRoomAvailability(roomId);
+    return () => {
+      unsubscribeRoomAvailability();
+    };
+  }, [roomId, subscribeRoomAvailability, unsubscribeRoomAvailability]);
 
   useEffect(() => {
     const socket = connect();


### PR DESCRIPTION


## 🔍 PR 요약

- 방 입장 시 subscribeRoomAvailability를 구독하고 언마운트 때 해제하도록 추가
- 서버가 보내는 spectatorCount 업데이트가 useBattleSocketStore에 반영되고, BattleHeader에서 실제 관전자 수가 표시

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #21

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- backend/.prettierc 삭제
- backend/modules, backend/**test** 폴더 추가
- frontend/public/assets 폴더 추가
- frontend에 apis, components, hooks, pages, types 폴더 추가

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

| 변경 전      | 변경 후      |
| ------------ | ------------ |
| ![이전](URL) | ![이후](URL) |

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 초기 디렉토리 구조를 정리하고, 백엔드/프론트엔드 개발을 위한 공통 기반을 마련하기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?💬 리뷰 요구사항(선택)
