### PR TITLE
[FIX] 배틀페이지 UI(반응형) 및 버그 수정 (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
   <sub>실시간 1:1 알고리즘 배틀 플랫폼</sub>
 </p>
 
-
-
 <p align="center">
   📝 <a href="https://www.notion.so/web30-2c319e920f6080b2908dfb28ba83275a?source=copy_link">팀 노션</a> &nbsp;|&nbsp;
   🎨 <a href="https://www.figma.com/board/AKXDZaAymXKSg5XShewk1A/%ED%85%8C%EC%98%A4%EC%9D%98-%EC%8A%A4%ED%94%84%EB%A6%B0%ED%8A%B8-%ED%85%9C%ED%94%8C%EB%A6%BF--web30-?node-id=0-1&t=epjZ5ONDNW74eWT7-1">피그잼</a> &nbsp;|&nbsp;
@@ -17,8 +15,8 @@
 
 ---
 
-
 ## 📖 프로젝트 소개 (Introduction)
+
 > **"코딩도 E-Sports가 될 수 있다!"**
 
 **TADAK(타닥)** 은 혼자서 외롭게 풀던 알고리즘 문제 풀이를 **실시간 경쟁 게임**으로 재해석한 웹 서비스입니다.
@@ -61,25 +59,27 @@
 # Web30 - PORT:30
 
 > 안녕하세요! 부스트캠프 웹·모바일 10기 WEB-30팀 **PORT:30**입니다.
-> 
+>
 > 저희는 “언제나 열려있는 30번 포트처럼 소통하고, 항구처럼 목표에 확실하게 정박하자"라는 의미를 담은 PORT: 30 팀입니다.
 
 <br>
 
 ## 👥 팀원
 
-| [J029\_김다연](https://github.com/dyeon-dev) | [J074\_김채영](https://github.com/cchaeyoung) | [J213\_이준섭](https://github.com/SubJeeLee) | [J278\_최효진](https://github.com/eeekeee) |
-| :---: | :---: | :---: | :---: |
+|                       [J029\_김다연](https://github.com/dyeon-dev)                        |                       [J074\_김채영](https://github.com/cchaeyoung)                        |                        [J213\_이준섭](https://github.com/SubJeeLee)                        |                         [J278\_최효진](https://github.com/eeekeee)                         |
+| :---------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: |
 | <img src="https://avatars.githubusercontent.com/u/93921784?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/123921311?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/176148148?v=4" width="130" height="130"> | <img src="https://avatars.githubusercontent.com/u/144501864?v=4" width="130" height="130"> |
 
 <br>
 
 ## 🎯 목표 (Goals)
+
 **Team Goal:** "근거 있는 기술 선택을 하는 개발자 되기"
 
 **Project Goal:** 개발자들의 고립감을 해소하고, 코딩을 E-Sports처럼 즐길 수 있는 문화를 만든다.
 
 ## 🤝 협업 문화 (Ground Rules)
+
 **Core Time:** 평일 10:00 ~ 18:00 집중 개발
 
 **Communication:** 모르는 것은 10분 고민 후 바로 공유하기
@@ -87,7 +87,6 @@
 **Process:** 매주 금요일 데모 데이 진행, 스크럼을 통한 매일의 이슈 공유
 
 [👉 자세한 그라운드 룰 보러가기](https://github.com/boostcampwm2025/web30-TADAK/wiki/%EA%B7%B8%EB%9D%BC%EC%9A%B4%EB%93%9C%EB%A3%B0)
-
 
 <br>
 
@@ -121,12 +120,12 @@
 
 프로젝트의 상세 설계 내용은 아래 문서에서 확인하실 수 있습니다.
 
-| 문서 종류 | 설명 | 링크 |
-| :-- | :-- | :-- |
-| **User Scenario** | 사용자 흐름 및 기능 명세 | [위키 바로가기](https://github.com/boostcampwm2025/web30-TADAK/wiki/%EC%9C%A0%EC%A0%80-%EC%8B%9C%EB%82%98%EB%A6%AC%EC%98%A4) |
-| **API Docs** | API 명세서 (Swagger/Wiki) | [API 문서 보기](링크_입력_필요) |
-| **ER Diagram** | 데이터베이스 구조도 | [ERD 보기](링크_입력_필요) |
-| **Figma** | 와이어프레임 및 디자인 | [Figma 보기](링크_입력_필요) |
+| 문서 종류         | 설명                      | 링크                                                                                                                         |
+| :---------------- | :------------------------ | :--------------------------------------------------------------------------------------------------------------------------- |
+| **User Scenario** | 사용자 흐름 및 기능 명세  | [위키 바로가기](https://github.com/boostcampwm2025/web30-TADAK/wiki/%EC%9C%A0%EC%A0%80-%EC%8B%9C%EB%82%98%EB%A6%AC%EC%98%A4) |
+| **API Docs**      | API 명세서 (Swagger/Wiki) | [API 문서 보기](링크_입력_필요)                                                                                              |
+| **ER Diagram**    | 데이터베이스 구조도       | [ERD 보기](링크_입력_필요)                                                                                                   |
+| **Figma**         | 와이어프레임 및 디자인    | [Figma 보기](링크_입력_필요)                                                                                                 |
 
 <br>
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,17 @@
+import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import { useUserStore } from '@/stores/userStore';
+
 function App() {
+  const fetchUser = useUserStore((state) => state.fetchUser);
+
+  useEffect(() => {
+    if (localStorage.getItem('accessToken')) {
+      fetchUser();
+    }
+  }, [fetchUser]);
+
   return (
     <>
       <Outlet />

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -342,7 +342,7 @@ function CodeEditor() {
             <button className="rounded-md bg-base-muted px-3 py-1 text-xs">JavaScript</button>
           </div>
         </div>
-        <div className="min-h-0 bg-(bg-layer-2) px-5 py-4 font-mono text-sm text-base-primary xl:flex-1">
+        <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) px-5 py-4 font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
           <BaseCodeEditor
             value={code}
             onChange={(value) => handleChange(value || '')}

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -342,7 +342,7 @@ function CodeEditor() {
             <button className="rounded-md bg-base-muted px-3 py-1 text-xs">JavaScript</button>
           </div>
         </div>
-        <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) px-5 py-4 font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
+        <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
           <BaseCodeEditor
             value={code}
             onChange={(value) => handleChange(value || '')}

--- a/apps/web/src/components/Battle/Spectator/BattleSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/BattleSpectator.tsx
@@ -53,11 +53,12 @@ function BattleSpectator() {
           <div className={`fade-slide-in xl:h-full xl:min-h-0 ${codeSpanClass}`}>
             <CodeSpectator />
           </div>
-          {showChat && (
-            <div ref={chatRef} className="fade-slide-in xl:h-full xl:min-h-0">
-              <ChatSpectator />
-            </div>
-          )}
+          <div
+            ref={chatRef}
+            className={`fade-slide-in xl:h-full xl:min-h-0 ${showChat ? '' : 'hidden'}`}
+          >
+            <ChatSpectator />
+          </div>
         </div>
       </div>
     </>

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -18,6 +18,7 @@ function ChatSpectator() {
   const user = useUserStore((state) => state.user);
   const socket = useBattleSocketStore((state) => state.socket);
   const connectSocket = useBattleSocketStore((state) => state.connect);
+  const leaveRoom = useBattleSocketStore((state) => state.leaveRoom);
   const listRef = useRef<HTMLDivElement>(null);
 
   const myNickname = useMemo(() => {
@@ -81,6 +82,18 @@ function ChatSpectator() {
       avatarUrl: myAvatar,
     });
     setInput('');
+  };
+
+  const handleLoginClick = () => {
+    if (roomId) {
+      leaveRoom(roomId);
+    }
+    try {
+      sessionStorage.removeItem('battle-session');
+    } catch {
+      // ignore
+    }
+    navigate('/login');
   };
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
@@ -199,7 +212,7 @@ function ChatSpectator() {
           {!isLoggedIn && (
             <button
               type="button"
-              onClick={() => navigate('/login')}
+              onClick={handleLoginClick}
               className="rounded-lg border border-border-soft px-3 py-2 text-xs font-bold text-base-primary transition hover:bg-base-muted"
             >
               로그인

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -93,7 +93,7 @@ function ChatSpectator() {
     } catch {
       // ignore
     }
-    navigate('/login');
+    navigate('/login', { replace: true });
   };
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -132,7 +132,7 @@ function CodeSpectator() {
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 bg-(--bg-layer-2) px-4 py-3 font-mono text-sm leading-relaxed text-base-primary overflow-hidden">
+          <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
             <BaseCodeEditor
               value={selectedCode}
               options={{

--- a/apps/web/src/stores/battleSocketStore.ts
+++ b/apps/web/src/stores/battleSocketStore.ts
@@ -301,6 +301,7 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
     if (!session) return;
     if (options?.roomId && options.roomId !== session.roomId) return;
 
+    const profile = useUserStore.getState().user;
     const requestedRole =
       (session.role as 'player' | 'spectator') ??
       (options?.roleHint as 'player' | 'spectator') ??
@@ -308,9 +309,9 @@ export const useBattleSocketStore = create<BattleSocketState>((set, get) => ({
     await get().joinRoom({
       roomId: session.roomId,
       requestedRole,
-      userId: session.userId,
-      username: session.username,
-      avatarUrl: session.avatarUrl,
+      userId: profile?.id ?? session.userId,
+      username: profile?.username ?? session.username,
+      avatarUrl: profile?.avatarUrl ?? session.avatarUrl,
     });
   },
   subscribeRoomList: () => {


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

반응형에서 코드 에디터 영역 입력 불가 오류와 채팅 토글 시 히스토리가 초기화되는 문제를 수정했습니다

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #193 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- CodeEditor.tsx에 최소 높이 및 vh 기반 높이를 추가해 반응형에서도 입력 영역 확보
- CodeSpectator.tsx에 최소 높이 및 vh 기반 높이를 추가해 관전자 화면에서도 가독성 확보
- BattleSpectator.tsx에서 채팅 패널을 unmount하지 않고 hidden 처리하여 토글 시 히스토리 유지

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### 로그인 풀림 오류 수정


https://github.com/user-attachments/assets/0fd989d2-6a09-4410-8034-001f4e7ac7d9

### 채팅 -> 로그인 버튼 오류 수정


https://github.com/user-attachments/assets/ba7b76b0-c3fe-4fc5-aaa9-6d00869a7cbd




## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 모바일/반응형 레이아웃에서 코드 입력/관전 영역이 너무 작아지는 문제를 개선하고, 
- 채팅 토글 시 이전 대화가 사라지는 UX 이슈를 해결하기 위함입니다.


## 💬 리뷰 요구사항(선택)

추가로 배틀페이지에서 일어나는 버그들을 찾아보고 현재 PR에서 수정할 계획입니다.


## 추가 사항 (NEW)

### 고민 사항

- 반응형 이슈만 해결했는데도 관전자 새로고침/로그인 전환에서 상태가 꼬이는 문제가 계속 발생
- 원인을 추적해 보니 Header에서만 로그인 복구(fetchUser)가 실행되고, 배틀 페이지는 Header가 없어서 새로고침 시 로그인 상태가 날아가는 구조

### 문제점 정리
1. 관전자 새로고침 시 로그인 풀림
- 로그인 복구가 Header 내부에만 있어 배틀 페이지에서는 실행되지 않음
- 그래서 관전 중 새로고침 → userStore가 비어짐 → 비로그인 상태로 처리

2. 비로그인 → 로그인 후 재관전 시 게스트 정보가 남음
- 비로그인 입장은 userId = socket.id(게스트)로 저장됨
- resumeSession()이 세션의 게스트 userId를 그대로 재사용
- 서버는 userId 기준으로 기존 참가자를 찾으므로 게스트 정보가 유지
- 결과적으로 로그인 후에도 user-xxxx 같은 게스트 이름으로 보임

### 해결 방법

#### 로그인 복구 전역화
- App.tsx에서 토큰이 있으면 fetchUser() 실행 → 배틀 페이지 새로고침에도 유저 정보 복구

#### 게스트 정보 잔존 정리 (관전자 로그인 버튼)
- ChatSpectator의 로그인 버튼 클릭 시 leaveRoom() 호출
- battle-session 제거 후 navigate('/login', { replace: true })로 이동
- → Redis의 관전자 정보가 제거되어 실시간 관전자 수 불일치 문제도 함께 해결

### 정리된 효과

- 배틀 페이지에서 새로고침해도 로그인 상태 유지
- 로그인 전환 시 게스트 정보가 남지 않음
- 뒤로가기로 배틀 복귀되는 문제 방지 (replace 적용)
- 관전자 수 실시간 집계 오류 개선