### PR TITLE
[FIX] 매칭 관련 오류 수정 (#198)

### DIFF
--- a/apps/api/test/matching/matching-scheduler.service.spec.ts
+++ b/apps/api/test/matching/matching-scheduler.service.spec.ts
@@ -22,6 +22,13 @@ describe('MatchingSchedulerService', () => {
     status: 'MATCHED',
     waitingSince: new Date(),
     socketId: `socket-${userId}`,
+    myRate: {
+      win: 10,
+      lose: 5,
+      draw: 0,
+      winRate: 66,
+    },
+    avatarUrl: `https://avatar.com/${userId}`,
   });
 
   beforeEach(async () => {
@@ -29,6 +36,7 @@ describe('MatchingSchedulerService', () => {
       matchUsers: jest.fn(),
       getMatchingStats: jest.fn(),
       getMatchingQueueSocketIds: jest.fn(),
+      findTimeoutUsers: jest.fn().mockResolvedValue(undefined),
     };
 
     mockMatchingGateway = {
@@ -59,6 +67,14 @@ describe('MatchingSchedulerService', () => {
       await service.handleMatchingTick();
 
       expect(mockMatchingService.matchUsers).toHaveBeenCalledTimes(1);
+    });
+
+    it('매칭 후 findTimeoutUsers()를 호출해야 한다', async () => {
+      mockMatchingService.matchUsers.mockResolvedValue([]);
+
+      await service.handleMatchingTick();
+
+      expect(mockMatchingService.findTimeoutUsers).toHaveBeenCalledTimes(1);
     });
 
     it('매칭 성공 시 성공 로그를 출력해야 한다', async () => {
@@ -111,6 +127,56 @@ describe('MatchingSchedulerService', () => {
       await service.handleMatchingTick();
 
       expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('매칭 성공: 3쌍 (6명)'));
+    });
+  });
+
+  describe('handleStatsUpdate', () => {
+    it('매칭 통계를 대기 중인 소켓들에게 브로드캐스트해야 한다', async () => {
+      const mockStats = {
+        waitingPlayers: 5,
+        ongoingBattles: 3,
+        avgMatchTime: 15,
+      };
+      const mockSocketIds = ['socket-1', 'socket-2'];
+
+      mockMatchingService.getMatchingStats.mockResolvedValue(mockStats);
+      mockMatchingService.getMatchingQueueSocketIds.mockResolvedValue(mockSocketIds);
+
+      await service.handleStatsUpdate();
+
+      expect(mockMatchingService.getMatchingStats).toHaveBeenCalled();
+      expect(mockMatchingService.getMatchingQueueSocketIds).toHaveBeenCalled();
+      expect(mockMatchingGateway.broadcastMatchingStats).toHaveBeenCalledWith(
+        mockStats,
+        mockSocketIds,
+      );
+    });
+
+    it('대기 중인 소켓이 없어도 브로드캐스트를 호출해야 한다', async () => {
+      const mockStats = {
+        waitingPlayers: 0,
+        ongoingBattles: 0,
+        avgMatchTime: 0,
+      };
+      mockMatchingService.getMatchingStats.mockResolvedValue(mockStats);
+      mockMatchingService.getMatchingQueueSocketIds.mockResolvedValue([]);
+
+      await service.handleStatsUpdate();
+
+      expect(mockMatchingGateway.broadcastMatchingStats).toHaveBeenCalledWith(mockStats, []);
+    });
+
+    it('에러 발생 시 에러 로그를 출력해야 한다', async () => {
+      const error = new Error('Stats fetch failed');
+      mockMatchingService.getMatchingStats.mockRejectedValue(error);
+
+      const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+
+      await service.handleStatsUpdate();
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('통계 업데이트 에러: Stats fetch failed'),
+      );
     });
   });
 });

--- a/apps/api/test/matching/matching.gateway.spec.ts
+++ b/apps/api/test/matching/matching.gateway.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { SOCKET_EVENT } from '@packages/constants/socket-event';
@@ -10,10 +9,14 @@ import { MatchingUser } from '@packages/types/matching';
 import { Room } from '@packages/types/room';
 
 import { MatchingGateway } from '../../src/matching/matching.gateway';
+import { MatchingService } from '../../src/matching/matching.service';
+import { RoomService } from '../../src/room/room.service';
 
 describe('MatchingGateway', () => {
   let gateway: MatchingGateway;
   let mockServer: any;
+  let mockMatchingService: any;
+  let mockRoomService: any;
 
   const createMockUser = (userId: string, rating: number, username: string): MatchingUser => ({
     userId,
@@ -23,6 +26,8 @@ describe('MatchingGateway', () => {
     status: 'MATCHED',
     waitingSince: new Date(),
     socketId: `socket-${userId}`,
+    myRate: { win: 10, lose: 5, draw: 0, winRate: 66 },
+    avatarUrl: `https://avatar.com/${userId}`,
   });
 
   const mockRoom: Room = {
@@ -39,20 +44,46 @@ describe('MatchingGateway', () => {
   const mockBattle: Battle = {
     battleId: 'battle-123',
     roomId: 'room-123',
+    problemId: 'problem-123',
     status: 'running',
     config: { duration: 300 },
     startedAt: new Date(),
     users: [],
   };
 
+  const mockProblemInfo = {
+    id: 'problem-123',
+    title: 'Test Problem',
+  };
+
   beforeEach(async () => {
     mockServer = {
       to: jest.fn().mockReturnThis(),
       emit: jest.fn(),
+      sockets: new Map(),
+    };
+
+    mockMatchingService = {
+      cancelMatching: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockRoomService = {
+      listRooms: jest.fn().mockResolvedValue([]),
+      toPublicRooms: jest.fn().mockReturnValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MatchingGateway],
+      providers: [
+        MatchingGateway,
+        {
+          provide: MatchingService,
+          useValue: mockMatchingService,
+        },
+        {
+          provide: RoomService,
+          useValue: mockRoomService,
+        },
+      ],
     }).compile();
 
     gateway = module.get<MatchingGateway>(MatchingGateway);
@@ -64,7 +95,7 @@ describe('MatchingGateway', () => {
       const user1 = createMockUser('user1', 1500, 'User1');
       const user2 = createMockUser('user2', 1550, 'User2');
 
-      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle);
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
 
       expect(mockServer.to).toHaveBeenCalledWith('socket-user1');
       expect(mockServer.emit).toHaveBeenCalledWith(
@@ -72,14 +103,16 @@ describe('MatchingGateway', () => {
         expect.objectContaining({
           roomId: 'room-123',
           battleId: 'battle-123',
-          room: mockRoom,
-          battle: mockBattle,
+          myRate: user1.myRate,
           opponent: {
             userId: 'user2',
             username: 'User2',
+            avatarUrl: 'https://avatar.com/user2',
             rating: 1550,
             tier: { tier: 'Gold', division: 3 },
+            rate: user2.myRate,
           },
+          problem: mockProblemInfo,
         }),
       );
     });
@@ -88,7 +121,7 @@ describe('MatchingGateway', () => {
       const user1 = createMockUser('user1', 1500, 'User1');
       const user2 = createMockUser('user2', 1550, 'User2');
 
-      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle);
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
 
       expect(mockServer.to).toHaveBeenCalledWith('socket-user2');
       expect(mockServer.emit).toHaveBeenCalledWith(
@@ -96,14 +129,16 @@ describe('MatchingGateway', () => {
         expect.objectContaining({
           roomId: 'room-123',
           battleId: 'battle-123',
-          room: mockRoom,
-          battle: mockBattle,
+          myRate: user2.myRate,
           opponent: {
             userId: 'user1',
             username: 'User1',
+            avatarUrl: 'https://avatar.com/user1',
             rating: 1500,
             tier: { tier: 'Gold', division: 3 },
+            rate: user1.myRate,
           },
+          problem: mockProblemInfo,
         }),
       );
     });
@@ -112,7 +147,7 @@ describe('MatchingGateway', () => {
       const user1 = createMockUser('user1', 1500, 'User1');
       const user2 = createMockUser('user2', 1550, 'User2');
 
-      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle);
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
 
       expect(mockServer.to).toHaveBeenCalledTimes(2);
       expect(mockServer.emit).toHaveBeenCalledTimes(2);
@@ -122,38 +157,38 @@ describe('MatchingGateway', () => {
       const user1 = createMockUser('user1', 1500, 'User1');
       const user2 = createMockUser('user2', 1550, 'User2');
 
-      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle);
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
 
       // user1이 받는 데이터에는 user2 정보
-      const user1CallArgs = mockServer.emit.mock.calls.find(
-        (call) =>
-          call[1].opponent.userId === 'user2' &&
-          mockServer.to.mock.calls.some((toCall) => toCall[0] === 'socket-user1'),
+      const user1Call = mockServer.emit.mock.calls.find(
+        (call: any[]) => call[1].opponent.userId === 'user2',
       );
-      expect(user1CallArgs).toBeDefined();
-      expect(user1CallArgs[1].opponent.username).toBe('User2');
+      expect(user1Call).toBeDefined();
+      expect(user1Call[1].opponent.username).toBe('User2');
+      expect(user1Call[1].opponent.avatarUrl).toBe('https://avatar.com/user2');
 
       // user2가 받는 데이터에는 user1 정보
-      const user2CallArgs = mockServer.emit.mock.calls.find(
-        (call) =>
-          call[1].opponent.userId === 'user1' &&
-          mockServer.to.mock.calls.some((toCall) => toCall[0] === 'socket-user2'),
+      const user2Call = mockServer.emit.mock.calls.find(
+        (call: any[]) => call[1].opponent.userId === 'user1',
       );
-      expect(user2CallArgs).toBeDefined();
-      expect(user2CallArgs[1].opponent.username).toBe('User1');
+      expect(user2Call).toBeDefined();
+      expect(user2Call[1].opponent.username).toBe('User1');
+      expect(user2Call[1].opponent.avatarUrl).toBe('https://avatar.com/user1');
     });
 
-    it('room과 battle 정보가 포함되어야 한다', () => {
+    it('problem 정보가 포함되어야 한다', () => {
       const user1 = createMockUser('user1', 1500, 'User1');
       const user2 = createMockUser('user2', 1550, 'User2');
 
-      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle);
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
 
       expect(mockServer.emit).toHaveBeenCalledWith(
         SOCKET_EVENT.MATCH_SUCCESS,
         expect.objectContaining({
-          room: mockRoom,
-          battle: mockBattle,
+          problem: {
+            id: 'problem-123',
+            title: 'Test Problem',
+          },
         }),
       );
     });
@@ -162,9 +197,137 @@ describe('MatchingGateway', () => {
       const user1 = createMockUser('user1', 1500, 'User1');
       const user2 = createMockUser('user2', 1550, 'User2');
 
-      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle);
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
 
       expect(mockServer.emit).toHaveBeenCalledWith(SOCKET_EVENT.MATCH_SUCCESS, expect.any(Object));
+    });
+
+    it('myRate가 각 유저에게 올바르게 전송되어야 한다', () => {
+      const user1 = createMockUser('user1', 1500, 'User1');
+      const user2 = createMockUser('user2', 1550, 'User2');
+
+      gateway.emitMatchSuccess(user1, user2, mockRoom, mockBattle, mockProblemInfo);
+
+      // 첫 번째 emit (user1에게)
+      const firstCall = mockServer.emit.mock.calls[0];
+      expect(firstCall[1].myRate).toEqual(user1.myRate);
+
+      // 두 번째 emit (user2에게)
+      const secondCall = mockServer.emit.mock.calls[1];
+      expect(secondCall[1].myRate).toEqual(user2.myRate);
+    });
+  });
+
+  describe('broadcastMatchingStats', () => {
+    it('지정된 소켓들에게 통계를 브로드캐스트해야 한다', () => {
+      const stats = {
+        waitingPlayers: 5,
+        ongoingBattles: 3,
+        avgMatchTime: 15,
+      };
+      const socketIds = ['socket-1', 'socket-2', 'socket-3'];
+
+      gateway.broadcastMatchingStats(stats, socketIds);
+
+      expect(mockServer.to).toHaveBeenCalledTimes(3);
+      expect(mockServer.to).toHaveBeenCalledWith('socket-1');
+      expect(mockServer.to).toHaveBeenCalledWith('socket-2');
+      expect(mockServer.to).toHaveBeenCalledWith('socket-3');
+      expect(mockServer.emit).toHaveBeenCalledWith(SOCKET_EVENT.STATS_UPDATE, stats);
+    });
+
+    it('소켓 ID가 없으면 emit하지 않아야 한다', () => {
+      const stats = {
+        waitingPlayers: 5,
+        ongoingBattles: 3,
+        avgMatchTime: 15,
+      };
+
+      gateway.broadcastMatchingStats(stats, []);
+
+      expect(mockServer.to).not.toHaveBeenCalled();
+      expect(mockServer.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emitMatchingTimeout', () => {
+    it('매칭 지연 알림을 전송해야 한다', () => {
+      gateway.emitMatchingTimeout('socket-user1');
+
+      expect(mockServer.to).toHaveBeenCalledWith('socket-user1');
+      expect(mockServer.emit).toHaveBeenCalledWith(SOCKET_EVENT.MATCHING_TIMEOUT, {
+        message: '매칭이 지연되고 있습니다.',
+      });
+    });
+  });
+
+  describe('emitOpponentDisconnected', () => {
+    it('상대방 연결 끊김 알림을 전송해야 한다', () => {
+      gateway.emitOpponentDisconnected('socket-user1');
+
+      expect(mockServer.to).toHaveBeenCalledWith('socket-user1');
+      expect(mockServer.emit).toHaveBeenCalledWith(SOCKET_EVENT.OPPONENT_DISCONNECTED, {
+        message: '상대방의 연결이 끊겨 매칭이 취소되었습니다.',
+      });
+    });
+  });
+
+  describe('handleDisconnect', () => {
+    it('유저 ID가 있으면 매칭을 취소해야 한다', async () => {
+      const mockSocket = {
+        data: { userId: 'user1' },
+      } as any;
+
+      await gateway.handleDisconnect(mockSocket);
+
+      expect(mockMatchingService.cancelMatching).toHaveBeenCalledWith('user1');
+    });
+
+    it('유저 ID가 없으면 매칭 취소를 호출하지 않아야 한다', async () => {
+      const mockSocket = {
+        data: {},
+      } as any;
+
+      await gateway.handleDisconnect(mockSocket);
+
+      expect(mockMatchingService.cancelMatching).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('registerUserSocket', () => {
+    it('소켓에 유저 ID를 등록해야 한다', () => {
+      const mockSocket = {
+        data: {} as { userId?: string },
+      };
+      mockServer.sockets.set('socket-user1', mockSocket);
+
+      gateway.registerUserSocket('socket-user1', 'user1');
+
+      expect(mockSocket.data.userId).toBe('user1');
+    });
+
+    it('소켓이 없으면 등록하지 않아야 한다', () => {
+      // 소켓이 없는 상태에서 호출해도 에러가 발생하지 않아야 함
+      expect(() => {
+        gateway.registerUserSocket('nonexistent-socket', 'user1');
+      }).not.toThrow();
+    });
+  });
+
+  describe('broadcastRoomList', () => {
+    it('방 목록을 모든 클라이언트에게 브로드캐스트해야 한다', async () => {
+      const mockRooms = [
+        { roomId: 'room-1', title: 'Room 1' },
+        { roomId: 'room-2', title: 'Room 2' },
+      ];
+      mockRoomService.listRooms.mockResolvedValue(mockRooms);
+      mockRoomService.toPublicRooms.mockReturnValue(mockRooms);
+
+      await gateway.broadcastRoomList();
+
+      expect(mockRoomService.listRooms).toHaveBeenCalled();
+      expect(mockRoomService.toPublicRooms).toHaveBeenCalledWith(mockRooms);
+      expect(mockServer.emit).toHaveBeenCalledWith(SOCKET_EVENT.ROOM_LIST, mockRooms);
     });
   });
 });

--- a/apps/api/test/matching/matching.service.spec.ts
+++ b/apps/api/test/matching/matching.service.spec.ts
@@ -4,8 +4,10 @@
 
 import { Test, TestingModule } from '@nestjs/testing';
 import { MATCHING_CONFIG } from '@packages/constants/matching';
+import { MatchingUser } from '@packages/types/matching';
 import RedisMock from 'ioredis-mock';
 
+import { BattleService } from '../../src/battle/battle.service';
 import { MatchingGateway } from '../../src/matching/matching.gateway';
 import { MatchingService } from '../../src/matching/matching.service';
 import { REDIS_CLIENT } from '../../src/redis/redis.module';
@@ -16,9 +18,27 @@ describe('MatchingService with ioredis-mock', () => {
   let service: MatchingService;
   let redis: RedisMock;
   let mockRoomService: any;
+  let mockBattleService: any;
   let mockMatchingGateway: any;
 
-  // 헬퍼: Redis에 유저 데이터 추가
+  // 헬퍼: MatchingUser 객체 생성
+  const createMockUser = (
+    userId: string,
+    rating: number,
+    waitingSince: Date = new Date(),
+  ): MatchingUser => ({
+    userId,
+    username: `User_${userId}`,
+    rating,
+    tier: { tier: 'Gold', division: 3 },
+    status: 'WAITING',
+    waitingSince,
+    socketId: `socket-${userId}`,
+    myRate: { win: 10, lose: 5, draw: 0, winRate: 66 },
+    avatarUrl: `https://avatar.com/${userId}`,
+  });
+
+  // 헬퍼: Redis에 유저 데이터 추가 (매칭 대기 상태로)
   const addUserToQueue = async (
     userId: string,
     rating: number,
@@ -32,12 +52,14 @@ describe('MatchingService with ioredis-mock', () => {
     // HASH에 유저 메타데이터 추가
     await redis.hset(RedisKeys.matchingUser(userId), {
       userId,
-      username: `User${userId}`,
+      username: `User_${userId}`,
       rating: String(rating),
       tier: JSON.stringify({ tier: 'Gold', division: 3 }),
       status: 'WAITING',
       waitingSince: waitingSince.toISOString(),
       socketId: `socket-${userId}`,
+      myRate: JSON.stringify({ win: 10, lose: 5, draw: 0, winRate: 66 }),
+      avatarUrl: `https://avatar.com/${userId}`,
     });
   };
 
@@ -57,11 +79,25 @@ describe('MatchingService with ioredis-mock', () => {
           status: 'running',
           startedAt: new Date(),
         },
+        problem: {
+          id: 'problem-123',
+          title: 'Test Problem',
+        },
       }),
+      deleteRoom: jest.fn().mockResolvedValue(undefined),
+      listRooms: jest.fn().mockResolvedValue([]),
+      toPublicRooms: jest.fn().mockReturnValue([]),
+    };
+
+    mockBattleService = {
+      deleteBattle: jest.fn().mockResolvedValue(undefined),
     };
 
     mockMatchingGateway = {
       emitMatchSuccess: jest.fn(),
+      registerUserSocket: jest.fn(),
+      emitOpponentDisconnected: jest.fn(),
+      broadcastRoomList: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -76,6 +112,10 @@ describe('MatchingService with ioredis-mock', () => {
           useValue: mockRoomService,
         },
         {
+          provide: BattleService,
+          useValue: mockBattleService,
+        },
+        {
           provide: MatchingGateway,
           useValue: mockMatchingGateway,
         },
@@ -87,6 +127,79 @@ describe('MatchingService with ioredis-mock', () => {
 
   afterEach(async () => {
     await redis.flushall();
+  });
+
+  describe('startMatching', () => {
+    it('매칭 시작 시 유저 상태가 WAITING으로 설정되어야 한다', async () => {
+      const user = createMockUser('user1', 1500);
+
+      await service.startMatching(user);
+
+      // Redis HSET에서 status 확인
+      const status = await redis.hget(RedisKeys.matchingUser('user1'), 'status');
+      expect(status).toBe('WAITING');
+
+      // ZSET에 추가되었는지 확인
+      const queueSize = await redis.zcard(RedisKeys.matchingQueue());
+      expect(queueSize).toBe(1);
+
+      // Gateway의 registerUserSocket이 호출되었는지 확인
+      expect(mockMatchingGateway.registerUserSocket).toHaveBeenCalledWith('socket-user1', 'user1');
+    });
+
+    it('매칭 시작 시 유저 정보가 Redis에 저장되어야 한다', async () => {
+      const user = createMockUser('user1', 1500);
+
+      await service.startMatching(user);
+
+      const userData = await redis.hgetall(RedisKeys.matchingUser('user1'));
+      expect(userData.userId).toBe('user1');
+      expect(userData.username).toBe('User_user1');
+      expect(userData.rating).toBe('1500');
+      expect(userData.status).toBe('WAITING');
+      expect(userData.socketId).toBe('socket-user1');
+    });
+
+    it('이미 WAITING 상태인 유저는 중복 매칭 시작이 되지 않아야 한다', async () => {
+      const user = createMockUser('user1', 1500);
+
+      // 첫 번째 매칭 시작
+      await service.startMatching(user);
+
+      // 두 번째 매칭 시작 시도
+      await service.startMatching(user);
+
+      // ZSET에 1번만 추가되어야 함
+      const queueSize = await redis.zcard(RedisKeys.matchingQueue());
+      expect(queueSize).toBe(1);
+
+      // registerUserSocket도 1번만 호출
+      expect(mockMatchingGateway.registerUserSocket).toHaveBeenCalledTimes(1);
+    });
+
+    it('이미 MATCHED 상태인 유저는 매칭 시작이 되지 않아야 한다', async () => {
+      // 유저를 MATCHED 상태로 설정
+      await redis.hset(RedisKeys.matchingUser('user1'), { status: 'MATCHED' });
+
+      const user = createMockUser('user1', 1500);
+      await service.startMatching(user);
+
+      // ZSET에 추가되지 않아야 함
+      const queueSize = await redis.zcard(RedisKeys.matchingQueue());
+      expect(queueSize).toBe(0);
+    });
+
+    it('이미 IN_ROOM 상태인 유저는 매칭 시작이 되지 않아야 한다', async () => {
+      // 유저를 IN_ROOM 상태로 설정
+      await redis.hset(RedisKeys.matchingUser('user1'), { status: 'IN_ROOM' });
+
+      const user = createMockUser('user1', 1500);
+      await service.startMatching(user);
+
+      // ZSET에 추가되지 않아야 함
+      const queueSize = await redis.zcard(RedisKeys.matchingQueue());
+      expect(queueSize).toBe(0);
+    });
   });
 
   describe('matchUsers', () => {
@@ -129,7 +242,21 @@ describe('MatchingService with ioredis-mock', () => {
       );
     });
 
-    it('매칭 성공 후 Redis에서 상태를 업데이트해야 한다', async () => {
+    it('매칭 성공 후 유저 상태가 MATCHED로 변경되어야 한다', async () => {
+      const now = new Date();
+      await addUserToQueue('user1', 1500, now);
+      await addUserToQueue('user2', 1550, now);
+
+      await service.matchUsers();
+
+      // 상태가 MATCHED로 변경되었는지 확인
+      const user1Status = await redis.hget(RedisKeys.matchingUser('user1'), 'status');
+      const user2Status = await redis.hget(RedisKeys.matchingUser('user2'), 'status');
+      expect(user1Status).toBe('MATCHED');
+      expect(user2Status).toBe('MATCHED');
+    });
+
+    it('매칭 성공 후 Redis 큐에서 유저가 제거되어야 한다', async () => {
       const now = new Date();
       await addUserToQueue('user1', 1500, now);
       await addUserToQueue('user2', 1550, now);
@@ -139,12 +266,36 @@ describe('MatchingService with ioredis-mock', () => {
       // Redis에서 유저가 제거되었는지 확인
       const queueSize = await redis.zcard(RedisKeys.matchingQueue());
       expect(queueSize).toBe(0);
+    });
 
-      // 상태가 MATCHED로 변경되었는지 확인
-      const user1Status = await redis.hget(RedisKeys.matchingUser('user1'), 'status');
-      const user2Status = await redis.hget(RedisKeys.matchingUser('user2'), 'status');
-      expect(user1Status).toBe('MATCHED');
-      expect(user2Status).toBe('MATCHED');
+    it('매칭 성공 후 roomId와 opponentId가 저장되어야 한다', async () => {
+      const now = new Date();
+      await addUserToQueue('user1', 1500, now);
+      await addUserToQueue('user2', 1550, now);
+
+      await service.matchUsers();
+
+      // user1의 데이터 확인
+      const user1Data = await redis.hgetall(RedisKeys.matchingUser('user1'));
+      expect(user1Data.roomId).toBe('room-123');
+      expect(user1Data.opponentId).toBe('user2');
+
+      // user2의 데이터 확인
+      const user2Data = await redis.hgetall(RedisKeys.matchingUser('user2'));
+      expect(user2Data.roomId).toBe('room-123');
+      expect(user2Data.opponentId).toBe('user1');
+    });
+
+    it('매칭 성공 후 matchedAt 시간이 저장되어야 한다', async () => {
+      const now = new Date();
+      await addUserToQueue('user1', 1500, now);
+      await addUserToQueue('user2', 1550, now);
+
+      await service.matchUsers();
+
+      const user1Data = await redis.hgetall(RedisKeys.matchingUser('user1'));
+      expect(user1Data.matchedAt).toBeDefined();
+      expect(new Date(user1Data.matchedAt).getTime()).toBeGreaterThan(0);
     });
 
     it('레이팅 차이가 허용 범위를 벗어나면 매칭하지 않아야 한다', async () => {
@@ -229,6 +380,109 @@ describe('MatchingService with ioredis-mock', () => {
 
       // 최소 1쌍은 매칭되어야 함
       expect(result.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('cancelMatching', () => {
+    it('WAITING 상태의 유저를 취소하면 큐와 데이터가 삭제되어야 한다', async () => {
+      await addUserToQueue('user1', 1500);
+
+      await service.cancelMatching('user1');
+
+      const queueSize = await redis.zcard(RedisKeys.matchingQueue());
+      expect(queueSize).toBe(0);
+
+      const userData = await redis.hgetall(RedisKeys.matchingUser('user1'));
+      expect(Object.keys(userData as Record<string, string>).length).toBe(0);
+    });
+
+    it('MATCHED 상태에서 취소하면 상대방에게 알림을 보내야 한다', async () => {
+      // 두 유저를 MATCHED 상태로 설정
+      const now = new Date();
+      await addUserToQueue('user1', 1500, now);
+      await addUserToQueue('user2', 1550, now);
+      await service.matchUsers();
+
+      // matchedAt을 최근으로 설정 (5초 이내)
+      await redis.hset(RedisKeys.matchingUser('user1'), {
+        matchedAt: new Date().toISOString(),
+      });
+      await redis.hset(RedisKeys.matchingUser('user2'), {
+        matchedAt: new Date().toISOString(),
+      });
+
+      // user1이 취소
+      await service.cancelMatching('user1');
+
+      // 상대방에게 알림이 전송되어야 함
+      expect(mockMatchingGateway.emitOpponentDisconnected).toHaveBeenCalledWith('socket-user2');
+    });
+
+    it('IN_ROOM 상태의 유저는 취소해도 데이터가 유지되어야 한다', async () => {
+      // 유저를 IN_ROOM 상태로 설정
+      await redis.hset(RedisKeys.matchingUser('user1'), {
+        userId: 'user1',
+        status: 'IN_ROOM',
+        roomId: 'room-123',
+      });
+
+      await service.cancelMatching('user1');
+
+      // 데이터가 유지되어야 함
+      const userData = await redis.hgetall(RedisKeys.matchingUser('user1'));
+      expect(userData.status).toBe('IN_ROOM');
+    });
+  });
+
+  describe('상태 전환 흐름 (WAITING -> MATCHED)', () => {
+    it('전체 흐름: 매칭 시작 -> 매칭 성공 시 상태가 올바르게 전환되어야 한다', async () => {
+      const user1 = createMockUser('user1', 1500);
+      const user2 = createMockUser('user2', 1550);
+
+      // 1. 매칭 시작 - WAITING 상태
+      await service.startMatching(user1);
+      await service.startMatching(user2);
+
+      const user1StatusBefore = await redis.hget(RedisKeys.matchingUser('user1'), 'status');
+      const user2StatusBefore = await redis.hget(RedisKeys.matchingUser('user2'), 'status');
+      expect(user1StatusBefore).toBe('WAITING');
+      expect(user2StatusBefore).toBe('WAITING');
+
+      // 2. 매칭 실행 - MATCHED 상태
+      await service.matchUsers();
+
+      const user1StatusAfter = await redis.hget(RedisKeys.matchingUser('user1'), 'status');
+      const user2StatusAfter = await redis.hget(RedisKeys.matchingUser('user2'), 'status');
+      expect(user1StatusAfter).toBe('MATCHED');
+      expect(user2StatusAfter).toBe('MATCHED');
+    });
+  });
+
+  describe('getMatchingStats', () => {
+    it('매칭 통계를 올바르게 반환해야 한다', async () => {
+      // 대기 유저 2명 추가
+      await addUserToQueue('user1', 1500);
+      await addUserToQueue('user2', 1550);
+
+      const stats = await service.getMatchingStats();
+
+      expect(stats.waitingPlayers).toBe(2);
+      expect(stats.ongoingBattles).toBe(0);
+      expect(stats.avgMatchTime).toBe(0);
+    });
+  });
+
+  describe('clearUserMatchingStatus', () => {
+    it('유저의 매칭 상태를 완전히 삭제해야 한다', async () => {
+      await addUserToQueue('user1', 1500);
+
+      await service.clearUserMatchingStatus('user1');
+
+      const queueSize = await redis.zcard(RedisKeys.matchingQueue());
+      expect(queueSize).toBe(0);
+
+      const userData = await redis.hgetall(RedisKeys.matchingUser('user1'));
+      expect(Object.keys(userData as Record<string, string>).length).toBe(0);
     });
   });
 });

--- a/apps/web/src/components/Matching/MatchingCancelButton.tsx
+++ b/apps/web/src/components/Matching/MatchingCancelButton.tsx
@@ -6,7 +6,8 @@ import { useUserStore } from '@/stores/userStore';
 
 export function MatchingCancelButton() {
   const navigate = useNavigate();
-  const { cancelMatching, unregisterMatchingListeners, cleanup } = useMatchingStore();
+  const { cancelMatching, unregisterMatchingListeners } = useMatchingStore();
+  const setAllowNavigation = useMatchingStore((s) => s.setAllowNavigation);
   const user = useUserStore((state) => state.user);
   const socket = useBattleSocketStore((state) => state.socket);
 
@@ -16,7 +17,7 @@ export function MatchingCancelButton() {
     try {
       unregisterMatchingListeners(socket);
       await cancelMatching(user.id);
-      cleanup();
+      setAllowNavigation(true);
       navigate('/');
     } catch (error) {
       console.error('매칭 취소 실패:', error);

--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -11,11 +11,13 @@ export default function MatchingSuccess() {
 
   const matchResult = useMatchingStore((state) => state.matchResult);
   const user = useUserStore((state) => state.user);
+  const setAllowNavigation = useMatchingStore((s) => s.setAllowNavigation);
 
   // 카운트다운 로직
   useEffect(() => {
     if (countdown === 0) {
       if (matchResult?.roomId) {
+        setAllowNavigation(true);
         navigate(`/room/${matchResult.roomId}`);
       }
       return;
@@ -26,7 +28,7 @@ export default function MatchingSuccess() {
     }, 1000);
 
     return () => clearTimeout(timer);
-  }, [countdown, matchResult, navigate]);
+  }, [countdown, matchResult, navigate, setAllowNavigation]);
 
   if (!matchResult || !user) {
     return null;

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -6,7 +6,6 @@ import Modal from '@/components/Common/Modal';
 import Header from '@/components/Header/Header';
 import RoomCardList from '@/components/Main/RoomCardList';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
-import { useMatchingStore } from '@/stores/matchingStore';
 import { useUserStore } from '@/stores/userStore';
 
 const tierFilters = [
@@ -31,8 +30,6 @@ function MainPage() {
   const rooms = useBattleSocketStore((state) => state.rooms);
   const socket = useBattleSocketStore((state) => state.socket);
 
-  const startMatching = useMatchingStore((state) => state.startMatching);
-  const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
   const [joiningRoomId, setJoiningRoomId] = useState<string | null>(null);
 
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -71,22 +68,13 @@ function MainPage() {
     return { totalBattles, totalSpectators, totalPlayers };
   }, [rooms]);
 
-  const handleStartBattle = async () => {
+  const handleStartBattle = () => {
     if (!user?.id) {
       setShowLoginModal(true);
       return;
     }
 
-    try {
-      const activeSocket = await ensureSocketReady();
-      if (!activeSocket.id) throw new Error('Socket ID를 받지 못했습니다.');
-
-      registerMatchingListeners(activeSocket);
-      await startMatching(user.id, activeSocket.id);
-      navigate('/matching');
-    } catch (error) {
-      console.error('매칭 시작 중 오류:', error);
-    }
+    navigate('/matching');
   };
 
   const handleJoinSpectator = async (roomId: string) => {

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,17 +1,71 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import Toast from '@/components/Common/Toast';
 import Header from '@/components/Header/Header';
 import { MatchingCancelButton } from '@/components/Matching/MatchingCancelButton';
 import MatchingSuccess from '@/components/Matching/MatchingSuccess';
 import MatchingWait from '@/components/Matching/MatchingWait';
+import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useMatchingStore } from '@/stores/matchingStore';
+import { useUserStore } from '@/stores/userStore';
 
 function MatchingPage() {
+  const navigate = useNavigate();
   const [waitTime, setWaitTime] = useState(0);
+  const isMatchingStartedRef = useRef(false);
+  const user = useUserStore((state) => state.user);
+  const isLoading = useUserStore((state) => state.isLoading);
+  const fetchUser = useUserStore((state) => state.fetchUser);
+  const connect = useBattleSocketStore((state) => state.connect);
   const matchResult = useMatchingStore((state) => state.matchResult);
   const toastMessage = useMatchingStore((state) => state.toastMessage);
   const clearToast = useMatchingStore((state) => state.clearToast);
+  const startMatching = useMatchingStore((state) => state.startMatching);
+  const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
+
+  // 토큰 존재 여부 확인
+  const hasToken = typeof window !== 'undefined' && !!localStorage.getItem('accessToken');
+
+  // 유저 정보 로드 (토큰 있을 때만)
+  useEffect(() => {
+    if (hasToken && !user && !isLoading) {
+      fetchUser();
+    }
+  }, [hasToken, user, isLoading, fetchUser]);
+
+  // 페이지 진입 시 매칭 시작
+  useEffect(() => {
+    if (!hasToken) {
+      navigate('/login');
+      return;
+    }
+
+    // 토큰 있으면 유저 로딩 완료 대기
+    if (isLoading || !user?.id) return;
+
+    // 이미 매칭 시작했으면 중복 실행 방지
+    if (isMatchingStartedRef.current) return;
+    isMatchingStartedRef.current = true;
+
+    const socket = connect();
+
+    const start = () => {
+      registerMatchingListeners(socket);
+      startMatching(user.id, socket.id!);
+    };
+
+    if (!socket.id) {
+      socket.once('connect', start);
+    } else {
+      start();
+    }
+
+    return () => {
+      isMatchingStartedRef.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasToken, user?.id, isLoading]);
 
   // 타이머
   useEffect(() => {
@@ -25,12 +79,44 @@ function MatchingPage() {
   // 페이지 이탈(뒤로가기 등) 시 cleanup
   useEffect(() => {
     return () => {
-      const currentMatchResult = useMatchingStore.getState().matchResult;
-      if (!currentMatchResult) {
-        useMatchingStore.getState().cleanup();
+      const { matchResult, cancelMatching, cleanup } = useMatchingStore.getState();
+      const user = useUserStore.getState().user;
+
+      if (!matchResult && user?.id) {
+        cancelMatching(user.id);
+      } else {
+        cleanup();
       }
     };
   }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const { matchResult } = useMatchingStore.getState();
+      const user = useUserStore.getState().user;
+
+      if (!matchResult && user?.id) {
+        navigator.sendBeacon('/api/matching/cancel', JSON.stringify({ userId: user.id }));
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
+  if (hasToken && (isLoading || !user)) {
+    return (
+      <div className="flex min-h-screen flex-col">
+        <Header />
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-lg text-base-secondary">로딩 중...</div>
+        </div>
+      </div>
+    );
+  }
 
   if (matchResult) {
     return (

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useBlocker, useNavigate } from 'react-router-dom';
 
 import Toast from '@/components/Common/Toast';
 import Header from '@/components/Header/Header';
@@ -23,9 +23,15 @@ function MatchingPage() {
   const clearToast = useMatchingStore((state) => state.clearToast);
   const startMatching = useMatchingStore((state) => state.startMatching);
   const registerMatchingListeners = useMatchingStore((state) => state.registerMatchingListeners);
+  const blocker = useBlocker(() => !useMatchingStore.getState().allowNavigation);
 
   // 토큰 존재 여부 확인
   const hasToken = typeof window !== 'undefined' && !!localStorage.getItem('accessToken');
+
+  // 페이지 진입 시 allowNavigation 초기화
+  useEffect(() => {
+    useMatchingStore.getState().setAllowNavigation(false);
+  }, []);
 
   // 유저 정보 로드 (토큰 있을 때만)
   useEffect(() => {
@@ -89,6 +95,23 @@ function MatchingPage() {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      const ok = window.confirm('매칭을 취소하고 나가시겠습니까?');
+
+      if (ok) {
+        const { cancelMatching } = useMatchingStore.getState();
+        const user = useUserStore.getState().user;
+
+        if (user?.id) cancelMatching(user.id);
+
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker]);
 
   useEffect(() => {
     const handleBeforeUnload = () => {

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useBlocker, useNavigate } from 'react-router-dom';
 
+import Modal from '@/components/Common/Modal';
 import Toast from '@/components/Common/Toast';
 import Header from '@/components/Header/Header';
 import { MatchingCancelButton } from '@/components/Matching/MatchingCancelButton';
@@ -13,6 +14,7 @@ import { useUserStore } from '@/stores/userStore';
 function MatchingPage() {
   const navigate = useNavigate();
   const [waitTime, setWaitTime] = useState(0);
+  const [showCancelModal, setShowCancelModal] = useState(false);
   const isMatchingStartedRef = useRef(false);
   const user = useUserStore((state) => state.user);
   const isLoading = useUserStore((state) => state.isLoading);
@@ -98,20 +100,32 @@ function MatchingPage() {
 
   useEffect(() => {
     if (blocker.state === 'blocked') {
-      const ok = window.confirm('매칭을 취소하고 나가시겠습니까?');
-
-      if (ok) {
-        const { cancelMatching } = useMatchingStore.getState();
-        const user = useUserStore.getState().user;
-
-        if (user?.id) cancelMatching(user.id);
-
-        blocker.proceed();
-      } else {
-        blocker.reset();
-      }
+      setShowCancelModal(true);
     }
   }, [blocker]);
+
+  const handleConfirmCancel = () => {
+    setShowCancelModal(false);
+    const { matchResult, cancelMatching, cleanup } = useMatchingStore.getState();
+    const user = useUserStore.getState().user;
+
+    if (matchResult) {
+      cleanup();
+    } else if (user?.id) {
+      cancelMatching(user.id);
+    }
+
+    if (blocker.state === 'blocked') {
+      blocker.proceed();
+    }
+  };
+
+  const handleCancelModal = () => {
+    setShowCancelModal(false);
+    if (blocker.state === 'blocked') {
+      blocker.reset();
+    }
+  };
 
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -129,6 +143,29 @@ function MatchingPage() {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);
+
+  const cancelModal = (
+    <Modal
+      isOpen={showCancelModal}
+      title="매칭 취소"
+      description={
+        matchResult ? '매칭이 완료되었습니다. 취소하시겠습니까?' : '매칭을 취소하고 나가시겠습니까?'
+      }
+      closeOnBackdrop={false}
+      buttons={[
+        {
+          label: '취소',
+          onClick: handleCancelModal,
+          variant: 'muted',
+        },
+        {
+          label: '확인',
+          onClick: handleConfirmCancel,
+          variant: 'green',
+        },
+      ]}
+    />
+  );
 
   if (hasToken && (isLoading || !user)) {
     return (
@@ -148,6 +185,7 @@ function MatchingPage() {
         <div className="flex flex-1 items-center justify-center">
           <MatchingSuccess />
         </div>
+        {cancelModal}
       </div>
     );
   }
@@ -166,6 +204,7 @@ function MatchingPage() {
           }}
         />
       )}
+      {cancelModal}
     </div>
   );
 }

--- a/apps/web/src/stores/matchingStore.ts
+++ b/apps/web/src/stores/matchingStore.ts
@@ -23,6 +23,8 @@ interface MatchingStore {
   cancelMatching: (userId: string) => Promise<void>;
   cleanup: () => void;
   clearToast: () => void;
+  allowNavigation: boolean;
+  setAllowNavigation: (v: boolean) => void;
 }
 
 export const useMatchingStore = create<MatchingStore>((set, get) => ({
@@ -30,6 +32,7 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
   stats: null,
   timeoutMessage: null,
   toastMessage: null,
+  allowNavigation: false,
 
   // MATCH_SUCCESS, STATS_UPDATE, MATCHING_TIMEOUT, OPPONENT_DISCONNECTED 이벤트 리스너 등록
   registerMatchingListeners: (socket: Socket) => {
@@ -101,11 +104,13 @@ export const useMatchingStore = create<MatchingStore>((set, get) => ({
 
   // 정리
   cleanup: () => {
-    set({ matchResult: null, stats: null, timeoutMessage: null });
+    set({ matchResult: null, stats: null, timeoutMessage: null, allowNavigation: false });
   },
 
   // 토스트 메시지 제거
   clearToast: () => {
     set({ toastMessage: null });
   },
+
+  setAllowNavigation: (v: boolean) => set({ allowNavigation: v }),
 }));


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 매칭 관련 오류들 수정
- 매칭 무한 대기 현상 수정

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #198 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- MainPage.tsx : 단순히 매칭 페이지로 navigate
- MatchingPage.tsx : 매칭 페이지 진입 시 매칭 시작 요청(`startMatchig()`)
  - 매칭 취소 시 정상적으로 매칭 큐에서 제거
  - 새로고침 시 `cancelMatching()` 호출 후 다시 매칭 시작
  - 로고나 뒤로가기 버튼 클릭 시 `useBlocker`를 활용한 Modal 창 띄워줌
  - 탭 강제 종료 시 정상 매칭 취소가 되도록 `navigator.sendBeacon` 사용

- apps/api/test/matching/* : 매칭 관련 테스트 코드 수정 및 개선

## 📸 스크린샷 (선택)

**Modal을 활용한 매칭 취소 알림**
<img width="1652" height="940" alt="image" src="https://github.com/user-attachments/assets/fa04f5fa-d730-4bea-93d0-821f9dcf37fa" />

## 🧠 의도 및 배경

- 정상적으로 매칭이 시작되고 종료되기 위함
- 매칭 페이지에서 새로고침이나 페이지 벗어날 시 큐에서 정상 제거가 되지 않아 무한 대기 상태를 방지하기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- https://github.com/boostcampwm2025/web30-TADAK/discussions/203
