### PR TITLE
[FIX] 배틀 종료 시 검증 로직 강화 및 결과 페이지 초기화 로직 추가 (#197)

### DIFF
--- a/apps/api/src/battle/battle.gateway.ts
+++ b/apps/api/src/battle/battle.gateway.ts
@@ -126,14 +126,18 @@ export class BattleGateway {
       console.warn(
         `[BattleGateway] handleTimerEnd error or battle not found: ${error instanceof Error ? error.message : String(error)}`,
       );
-      this.server.to(roomIdFromClient).emit(BATTLE_EVENTS.BATTLE_ENDED, { battleId });
+      if (roomIdFromClient) {
+        this.server.to(roomIdFromClient).emit(BATTLE_EVENTS.BATTLE_ENDED, { battleId });
 
-      // 방 상태 정리 및 목록 업데이트 시도
-      try {
-        await this.roomService.completeBattleRoom(roomIdFromClient);
-        await this.broadcastRoomList();
-      } catch (e) {
-        console.error('[BattleGateway] Failed to cleanup room on error:', e);
+        // 방 상태 정리 및 목록 업데이트 시도
+        try {
+          await this.roomService.completeBattleRoom(roomIdFromClient);
+          await this.broadcastRoomList();
+        } catch (e) {
+          console.error('[BattleGateway] Failed to cleanup room on error:', e);
+        }
+      } else {
+        console.error('[BattleGateway] handleTimerEnd failed and no roomId provided');
       }
     }
   }

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -19,7 +19,6 @@ import { MatchingService } from '@/matching/matching.service';
 import { ProblemService } from '@/problem/problem.service';
 import { REDIS_CLIENT } from '@/redis/redis.module';
 import { RedisKeys } from '@/redis/redis-key.constant';
-import { RoomService } from '@/room/room.service';
 import { Submission } from '@/submission/submission.entity';
 import { User } from '@/user/user.entity';
 import { UserService } from '@/user/user.service';
@@ -41,8 +40,6 @@ export class BattleService {
     @Inject(forwardRef(() => MatchingService))
     private readonly matchingService: MatchingService,
     private readonly userService: UserService,
-    @Inject(forwardRef(() => RoomService))
-    private readonly roomService: RoomService,
   ) {}
 
   async createBattle(dto: CreateBattleDTO): Promise<Battle> {
@@ -75,7 +72,7 @@ export class BattleService {
       status: 'running',
       config: {
         // duration: problem.battleTimeLimit || BATTLE_CONFIG.DURATION,
-        duration: 10,
+        duration: 5 * 60,
       },
       startedAt: new Date(),
       users,
@@ -179,8 +176,6 @@ export class BattleService {
     if (battleId) {
       await this.battleRedisService.deleteBattle(battleId, roomId);
     }
-    // 방 데이터도 함께 삭제
-    await this.roomService.deleteRoom(roomId);
   }
 
   async getSocketIdByUserId(userId: string): Promise<string | null> {
@@ -321,11 +316,6 @@ export class BattleService {
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 시작`);
     await this.battleRedisService.deleteBattle(battle.battleId, battle.roomId);
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 완료`);
-
-    // 5.1. Redis에서 방 데이터 삭제
-    this.logger.log(`[endBattle] Redis 방 데이터 삭제 시작`);
-    await this.roomService.deleteRoom(battle.roomId);
-    this.logger.log(`[endBattle] Redis 방 데이터 삭제 완료`);
 
     // 6. 진행 중인 배틀 목록에서 제거
     await this.redisClient.srem(RedisKeys.activeBattles(), battle.battleId);

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -19,6 +19,7 @@ import { MatchingService } from '@/matching/matching.service';
 import { ProblemService } from '@/problem/problem.service';
 import { REDIS_CLIENT } from '@/redis/redis.module';
 import { RedisKeys } from '@/redis/redis-key.constant';
+import { RoomService } from '@/room/room.service';
 import { Submission } from '@/submission/submission.entity';
 import { User } from '@/user/user.entity';
 import { UserService } from '@/user/user.service';
@@ -40,6 +41,8 @@ export class BattleService {
     @Inject(forwardRef(() => MatchingService))
     private readonly matchingService: MatchingService,
     private readonly userService: UserService,
+    @Inject(forwardRef(() => RoomService))
+    private readonly roomService: RoomService,
   ) {}
 
   async createBattle(dto: CreateBattleDTO): Promise<Battle> {
@@ -72,7 +75,7 @@ export class BattleService {
       status: 'running',
       config: {
         // duration: problem.battleTimeLimit || BATTLE_CONFIG.DURATION,
-        duration: 5 * 60,
+        duration: 10,
       },
       startedAt: new Date(),
       users,
@@ -176,6 +179,8 @@ export class BattleService {
     if (battleId) {
       await this.battleRedisService.deleteBattle(battleId, roomId);
     }
+    // 방 데이터도 함께 삭제
+    await this.roomService.deleteRoom(roomId);
   }
 
   async getSocketIdByUserId(userId: string): Promise<string | null> {
@@ -316,6 +321,11 @@ export class BattleService {
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 시작`);
     await this.battleRedisService.deleteBattle(battle.battleId, battle.roomId);
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 완료`);
+
+    // 5.1. Redis에서 방 데이터 삭제
+    this.logger.log(`[endBattle] Redis 방 데이터 삭제 시작`);
+    await this.roomService.deleteRoom(battle.roomId);
+    this.logger.log(`[endBattle] Redis 방 데이터 삭제 완료`);
 
     // 6. 진행 중인 배틀 목록에서 제거
     await this.redisClient.srem(RedisKeys.activeBattles(), battle.battleId);

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -43,8 +43,8 @@ export class BattleService {
   ) {}
 
   async createBattle(dto: CreateBattleDTO): Promise<Battle> {
-    // TODO: 배틀 ID 생성 로직 추가
-    const battleId = `battle-${Date.now()}`;
+    // 배틀 ID 생성 로직 추가
+    const battleId = `battle-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 
     // 임시 문제 선택
     const problem = await this.problemService.findFirst();

--- a/apps/api/test/battle/battle.service.spec.ts
+++ b/apps/api/test/battle/battle.service.spec.ts
@@ -11,6 +11,7 @@ import { BattleService } from '@/battle/battle.service';
 import { BattleRedisService } from '@/battle/battle-redis.service';
 import { ProblemService } from '@/problem/problem.service';
 import { REDIS_CLIENT } from '@/redis/redis.module';
+import { RoomService } from '@/room/room.service';
 import { Submission } from '@/submission/submission.entity';
 import { User } from '@/user/user.entity';
 
@@ -19,6 +20,7 @@ describe('BattleService', () => {
   let mockBattleRepository: any;
   let mockSubmissionRepository: any;
   let mockUserRepository: any;
+  let mockRoomService: any;
   let redis: RedisMock;
 
   beforeEach(async () => {
@@ -44,6 +46,11 @@ describe('BattleService', () => {
       })),
     };
 
+    // room service mock 설정
+    mockRoomService = {
+      deleteRoom: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BattleService,
@@ -65,11 +72,36 @@ describe('BattleService', () => {
         },
         {
           provide: BattleRedisService,
-          useValue: {},
+          useValue: {
+            getBattle: jest.fn(),
+            getBattleIdByRoomId: jest.fn(),
+            deleteBattle: jest.fn(),
+          },
         },
         {
           provide: ProblemService,
-          useValue: {},
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: RoomService,
+          useValue: mockRoomService,
+        },
+        {
+          provide: 'MatchingService', // forwardRef 대응
+          useValue: {
+            clearUserMatchingStatus: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: 'UserService',
+          useValue: {
+            updateRatings: jest.fn().mockResolvedValue({
+              winner: { ratingDelta: 10 },
+              loser: { ratingDelta: -10 },
+            }),
+          },
         },
       ],
     }).compile();

--- a/apps/api/test/battle/battle.service.spec.ts
+++ b/apps/api/test/battle/battle.service.spec.ts
@@ -9,18 +9,18 @@ import RedisMock from 'ioredis-mock';
 import { Battle as BattleEntity } from '@/battle/battle.entity';
 import { BattleService } from '@/battle/battle.service';
 import { BattleRedisService } from '@/battle/battle-redis.service';
+import { MatchingService } from '@/matching/matching.service';
 import { ProblemService } from '@/problem/problem.service';
 import { REDIS_CLIENT } from '@/redis/redis.module';
-import { RoomService } from '@/room/room.service';
 import { Submission } from '@/submission/submission.entity';
 import { User } from '@/user/user.entity';
+import { UserService } from '@/user/user.service';
 
 describe('BattleService', () => {
   let service: BattleService;
   let mockBattleRepository: any;
   let mockSubmissionRepository: any;
   let mockUserRepository: any;
-  let mockRoomService: any;
   let redis: RedisMock;
 
   beforeEach(async () => {
@@ -28,10 +28,12 @@ describe('BattleService', () => {
 
     mockBattleRepository = {
       findOne: jest.fn(),
+      save: jest.fn().mockImplementation((entity) => Promise.resolve(entity)),
     };
 
     // submission repository mock 설정
     mockSubmissionRepository = {
+      findOne: jest.fn(),
       createQueryBuilder: jest.fn(() => ({
         whereInIds: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([]),
@@ -44,11 +46,6 @@ describe('BattleService', () => {
         whereInIds: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([]),
       })),
-    };
-
-    // room service mock 설정
-    mockRoomService = {
-      deleteRoom: jest.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -76,26 +73,25 @@ describe('BattleService', () => {
             getBattle: jest.fn(),
             getBattleIdByRoomId: jest.fn(),
             deleteBattle: jest.fn(),
+            createBattle: jest.fn(),
+            updateBattle: jest.fn(),
           },
         },
         {
           provide: ProblemService,
           useValue: {
             findOne: jest.fn(),
+            findFirst: jest.fn(),
           },
         },
         {
-          provide: RoomService,
-          useValue: mockRoomService,
-        },
-        {
-          provide: 'MatchingService', // forwardRef 대응
+          provide: MatchingService,
           useValue: {
             clearUserMatchingStatus: jest.fn().mockResolvedValue(undefined),
           },
         },
         {
-          provide: 'UserService',
+          provide: UserService,
           useValue: {
             updateRatings: jest.fn().mockResolvedValue({
               winner: { ratingDelta: 10 },
@@ -248,5 +244,35 @@ describe('BattleService', () => {
     await expect(service.getBattleResult('non-existent')).rejects.toThrow(
       '배틀 정보를 찾을 수 없습니다.',
     );
+  });
+
+  describe('배틀 정리 로직', () => {
+    it('deleteBattle 호출 시 battleRedisService.deleteBattle이 호출되어야 한다', async () => {
+      const roomId = 'room-123';
+      const battleId = 'battle-456';
+
+      const battleRedisService = (service as any).battleRedisService;
+      battleRedisService.getBattleIdByRoomId = jest.fn().mockResolvedValue(battleId);
+      battleRedisService.deleteBattle = jest.fn().mockResolvedValue(undefined);
+
+      await service.deleteBattle(roomId);
+
+      expect(battleRedisService.deleteBattle).toHaveBeenCalledWith(battleId, roomId);
+    });
+
+    it('endBattle 호출 시 battleRedisService.deleteBattle이 호출되어야 한다', async () => {
+      const battleId = 'battle-123';
+      const roomId = 'room-123';
+      const mockBattleData = { battleId, roomId, users: [{ userId: 'u1' }, { userId: 'u2' }] };
+
+      const battleRedisService = (service as any).battleRedisService;
+      battleRedisService.getBattle = jest.fn().mockResolvedValue(mockBattleData);
+      battleRedisService.deleteBattle = jest.fn().mockResolvedValue(undefined);
+      (service as any).redisClient = { srem: jest.fn().mockResolvedValue(1) };
+
+      await service.endBattle(battleId);
+
+      expect(battleRedisService.deleteBattle).toHaveBeenCalledWith(battleId, roomId);
+    });
   });
 });

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -63,6 +63,15 @@ function BattlePage() {
   useEffect(() => {
     const socket = connect();
     const handleBattleEnded = (data: { battleId: string }) => {
+      // 현재 배틀의 ID가 아닌 경우 무시 (다른 방의 종료 이벤트가 전역으로 퍼지는 문제 대비)
+      const currentBattleId = useBattleProblemStore.getState().problem?.battleId;
+      if (currentBattleId && data.battleId !== currentBattleId) {
+        console.warn(
+          `[BattlePage] Received BATTLE_ENDED for a different battle: ${data.battleId}. Current: ${currentBattleId}`,
+        );
+        return;
+      }
+
       // 배틀 종료 시 세션 스토리지 정리
       try {
         sessionStorage.removeItem('battle-session');

--- a/apps/web/src/pages/ResultPage.tsx
+++ b/apps/web/src/pages/ResultPage.tsx
@@ -36,16 +36,18 @@ function ResultPage() {
       });
   }, [battleId]);
 
+  // 페이지 이탈 시(unmount) 모든 배틀 상태 초기화
+  useEffect(() => {
+    return () => {
+      clearMatching();
+      clearProblem();
+      clearRoom();
+      sessionStorage.removeItem('battle-session');
+    };
+  }, [clearMatching, clearProblem, clearRoom]);
+
   const handleGoHome = () => {
-    // 모든 배틀 관련 상태 초기화
-    clearMatching();
-    clearProblem();
-    clearRoom();
-
-    // 세션 정보 삭제 (재접속 방지)
-    sessionStorage.removeItem('battle-session');
-
-    // 홈으로 이동
+    // navigate 호출 시 컴포넌트가 unmount 되면서 위 useEffect의 cleanup 함수가 실행된다.
     navigate('/');
   };
 

--- a/apps/web/src/pages/ResultPage.tsx
+++ b/apps/web/src/pages/ResultPage.tsx
@@ -1,7 +1,7 @@
 import type { BattleResultResponse } from '@shared/types/battle';
 import { Home } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { getBattleResult } from '@/apis/battle';
 import Button from '@/components/Common/Button';
@@ -9,12 +9,20 @@ import Header from '@/components/Header/Header';
 import CodeViewer from '@/components/Result/CodeViewer';
 import PlayerCard from '@/components/Result/PlayerCard';
 import ResultHeader from '@/components/Result/ResultHeader';
+import { useBattleProblemStore } from '@/stores/battleProblemStore';
+import { useMatchingStore } from '@/stores/matchingStore';
+import { useRoomStore } from '@/stores/roomStore';
 
 function ResultPage() {
+  const navigate = useNavigate();
   const [selectedPlayerIndex, setSelectedPlayerIndex] = useState(0);
 
   const { battleId } = useParams<{ battleId: string }>();
   const [battleData, setBattleData] = useState<BattleResultResponse | null>(null);
+
+  const clearMatching = useMatchingStore((state) => state.cleanup);
+  const clearProblem = useBattleProblemStore((state) => state.clearProblem);
+  const clearRoom = useRoomStore((state) => state.clearRoom);
 
   useEffect(() => {
     if (!battleId) return;
@@ -27,6 +35,19 @@ function ResultPage() {
         console.error('배틀 결과 조회 실패:', err);
       });
   }, [battleId]);
+
+  const handleGoHome = () => {
+    // 모든 배틀 관련 상태 초기화
+    clearMatching();
+    clearProblem();
+    clearRoom();
+
+    // 세션 정보 삭제 (재접속 방지)
+    sessionStorage.removeItem('battle-session');
+
+    // 홈으로 이동
+    navigate('/');
+  };
 
   if (!battleData) {
     return null;
@@ -70,7 +91,7 @@ function ResultPage() {
             variant="muted"
             icon={Home}
             iconSize={20}
-            onClick={() => (window.location.href = '/')}
+            onClick={handleGoHome}
             className="gap-2 px-6 py-3 shadow-md"
           >
             홈으로

--- a/apps/web/src/stores/roomStore.ts
+++ b/apps/web/src/stores/roomStore.ts
@@ -12,6 +12,7 @@ export type Player = {
 type CodeMap = Record<string, string>;
 
 type State = {
+  clearRoom: any;
   players: Player[];
   codes: CodeMap;
   me?: Player;
@@ -35,4 +36,5 @@ export const useRoomStore = create<State>((set) => ({
       return { players: next };
     }),
   upsertCode: (userId, code) => set((s) => ({ codes: { ...s.codes, [userId]: code } })),
+  clearRoom: () => set({ players: [], codes: {}, me: undefined }),
 }));

--- a/apps/web/src/stores/roomStore.ts
+++ b/apps/web/src/stores/roomStore.ts
@@ -12,7 +12,7 @@ export type Player = {
 type CodeMap = Record<string, string>;
 
 type State = {
-  clearRoom: any;
+  clearRoom: () => void;
   players: Player[];
   codes: CodeMap;
   me?: Player;


### PR DESCRIPTION
## 🔍 PR 요약

- 배틀 종료 시 해당 배틀에서만 결과 로직이 확실하게 적용될 수 있도록 로직 강화 및 변경
- 배틀 종료 시 Redis 방 데이터 삭제
- 서버에서 배틀 종료 로직이 진행되고 클라이언트에서도 상태관리로 배틀 종료 초기화 로직을 추가
- 새로고침 방식이 아닌 라우팅(SPA) 방식으로도 업데이트 진행이 가능해짐

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #197

## 🛠️ 주요 변경 사항
### 백엔드
**apps/api/src/battle/battle.gateway.ts**
- 타이머 종료시 실패 상황에서 예외 시 roomId가 유효할 때만 이벤트를 브로드 캐스트하도록 방어 로직 강화
 
**apps/api/src/battle/battle.service.ts**
- 배틀 생성 시 기존 Date.now() 기반 ID 생성에 Math.random()을 조합하여 같은 밀리초에 생성된 배틀이라도 고유한 ID를 갖도록 수정
- 배틀 종료 시 redis 방 데이터 삭제 로직 추가

### 프론트엔드
**apps/web/src/pages/BattlePage.tsx**
- BATTLE_ENDED 이벤트를 수신했을 때, 참여 중인 배틀의 ID와 일치하는지 확인하고 일치하지 않는 경우 이벤트를 무시하도록 보완로직 설정

**apps/web/src/pages/ResultPage.tsx**
- 컴포넌트 unmount 시 실행되는 useEffect를 추가
- matchingStore, battleProblemStore, roomStore를 모두 비우고 sessionStorage의 세션 정보까지 삭제
- 새로고침 방식인 href 대신 SPA 방식인 navigate으로 변경

**apps/web/src/stores/roomStore.ts**
- roomStore 초기화: clearRoom 메서드를 추가하여 방 관련 상태를 초기화

**apps/api/test/battle/battle.service.spec.ts**
- endBattle 및 deleteBattle 호출 시 RoomService.deleteRoom이 올바른 roomId와 함께 호출되는지 확인하는 테스트 케이스를 추가


## 🧠 의도 및 배경

- 배틀 종료가 됐을 때 결과 페이지가 여러 상황에서 노출되는 문제를 해결하기 위해 해당 이슈를 진행하며 원인을 파악하고 상태관리에 대한 문제점을 해결함
- navigate를 사용하면 브라우저 새로고침 없이 리액트 컴포넌트만 교체되는데, 이때 Zustand 스토어나 sessionStorage에 남아있는 배틀 세션 정보가 초기화되지 않아 홈 화면에서도 "진행 중인 배틀"로 오인되는 문제가 있었다.
- roomStore에 clearRoom 메서드를 추가하여 방 관련 상태를 초기화할 수 있게 했고, 자동 클린업 로직 (useEffect cleanup)으로 버튼 클릭뿐만 아니라 뒤로가기, 로고 클릭 등으로 페이지를 이탈할 때도 모든 배틀 상태와 세션 정보가 안정적으로 정리되도록 했다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- https://github.com/boostcampwm2025/web30-TADAK/discussions/202
