### PR TITLE
[FIX] 채점 시스템 안정성 개선 및 테스트 (#199)

### DIFF
--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -32,16 +32,23 @@ export class SubmissionService {
 
     // 큐에 작업 등록
     try {
-      await this.submissionQueue.add('submission-job', {
-        type: 'SUBMISSION',
-        submissionId: String(savedSubmission.id),
-        problemId: dto.problemId,
-        code: dto.code,
-        language: dto.language,
-        userId,
-        battleId: dto.battleId,
-        socketId,
-      });
+      await this.submissionQueue.add(
+        'submission-job',
+        {
+          type: 'SUBMISSION',
+          submissionId: String(savedSubmission.id),
+          problemId: dto.problemId,
+          code: dto.code,
+          language: dto.language,
+          userId,
+          battleId: dto.battleId,
+          socketId,
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
     } catch (error) {
       await this.submissionRepository.update(savedSubmission.id, {
         // 큐 등록 실패 시 DB 상태를 ERROR로 변경
@@ -61,14 +68,21 @@ export class SubmissionService {
     const testSubmissionId = `test-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 
     // 큐에 작업 등록
-    await this.submissionQueue.add('test-job', {
-      type: 'TEST',
-      submissionId: testSubmissionId,
-      problemId: dto.problemId,
-      code: dto.code,
-      language: dto.language,
-      userId,
-      socketId,
-    });
+    await this.submissionQueue.add(
+      'test-job',
+      {
+        type: 'TEST',
+        submissionId: testSubmissionId,
+        problemId: dto.problemId,
+        code: dto.code,
+        language: dto.language,
+        userId,
+        socketId,
+      },
+      {
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+    );
   }
 }

--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -46,7 +46,7 @@ export class SubmissionService {
         },
         {
           removeOnComplete: true,
-          removeOnFail: true,
+          removeOnFail: { age: 3600, count: 50 },
         },
       );
     } catch (error) {
@@ -81,7 +81,7 @@ export class SubmissionService {
       },
       {
         removeOnComplete: true,
-        removeOnFail: true,
+        removeOnFail: { age: 3600, count: 50 },
       },
     );
   }

--- a/apps/judge/src/submission/submission.module.ts
+++ b/apps/judge/src/submission/submission.module.ts
@@ -11,7 +11,10 @@ import { SubmissionService } from './submission.service';
 
 @Module({
   imports: [
-    BullModule.registerQueue({ name: SUBMISSION_QUEUE }),
+    BullModule.registerQueue({
+      name: SUBMISSION_QUEUE,
+      defaultJobOptions: { removeOnComplete: true, removeOnFail: true },
+    }),
     DockerModule,
     JudgeModule,
     TypeOrmModule.forFeature([Problem]),

--- a/apps/judge/src/submission/submission.module.ts
+++ b/apps/judge/src/submission/submission.module.ts
@@ -13,7 +13,10 @@ import { SubmissionService } from './submission.service';
   imports: [
     BullModule.registerQueue({
       name: SUBMISSION_QUEUE,
-      defaultJobOptions: { removeOnComplete: true, removeOnFail: true },
+      defaultJobOptions: {
+        removeOnComplete: true,
+        removeOnFail: { age: 3600, count: 50 },
+      },
     }),
     DockerModule,
     JudgeModule,

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -45,14 +45,15 @@ export class SubmissionProcessor extends WorkerHost {
         payload.battleId,
       );
 
-      const judgePromise = this.judgeService.judgeSubmission(executionId);
-      const result = await this.dockerRunnerService.runSubmission({ submissionId: executionId });
+      // Docker 실행과 채점을 병렬로 시작
+      const [result] = await Promise.all([
+        this.dockerRunnerService.runSubmission({ submissionId: executionId }),
+        this.judgeService.judgeSubmission(executionId),
+      ]);
 
       this.logger.log(
         `Docker run completed: exitCode=${result.exitCode ?? 'null'}, signal=${result.signal ?? 'null'}`,
       );
-
-      await judgePromise;
     } finally {
       await this.dockerCleanupService.cleanupExecution(executionId);
     }

--- a/apps/judge/test/judge/judge.checker.spec.ts
+++ b/apps/judge/test/judge/judge.checker.spec.ts
@@ -1,0 +1,72 @@
+import { JudgeChecker } from '../../src/judge/judge.checker';
+
+describe('JudgeChecker - 정답 비교 로직', () => {
+  let checker: JudgeChecker;
+
+  beforeEach(() => {
+    checker = new JudgeChecker();
+  });
+
+  describe('normalize - 문자열 정규화', () => {
+    it('앞뒤 공백을 제거해야 한다', () => {
+      expect(checker.normalize('  hello  ')).toBe('hello');
+      expect(checker.normalize('\n\nhello\n\n')).toBe('hello');
+    });
+
+    it('Windows 개행(\\r\\n)을 Unix 개행(\\n)으로 변환해야 한다', () => {
+      expect(checker.normalize('hello\r\nworld')).toBe('hello\nworld');
+    });
+
+    it('Old Mac 개행(\\r)을 Unix 개행(\\n)으로 변환해야 한다', () => {
+      expect(checker.normalize('hello\rworld')).toBe('hello\nworld');
+    });
+
+    it('빈 문자열을 처리해야 한다', () => {
+      expect(checker.normalize('')).toBe('');
+      expect(checker.normalize('   ')).toBe('');
+    });
+  });
+
+  describe('compare - 정답 판별', () => {
+    it('동일한 문자열이면 true를 반환해야 한다', () => {
+      expect(checker.compare('hello', 'hello')).toBe(true);
+      expect(checker.compare('123', '123')).toBe(true);
+    });
+
+    it('다른 문자열이면 false를 반환해야 한다', () => {
+      expect(checker.compare('hello', 'world')).toBe(false);
+      expect(checker.compare('123', '456')).toBe(false);
+    });
+
+    it('공백이 다르더라도 정규화 후 같으면 true를 반환해야 한다', () => {
+      expect(checker.compare('  hello  ', 'hello')).toBe(true);
+      expect(checker.compare('hello\n', 'hello')).toBe(true);
+    });
+
+    it('개행 문자가 다르더라도 정규화 후 같으면 true를 반환해야 한다', () => {
+      expect(checker.compare('hello\r\nworld', 'hello\nworld')).toBe(true);
+      expect(checker.compare('hello\rworld', 'hello\nworld')).toBe(true);
+    });
+
+    it('console.log("YES") 정답 판별', () => {
+      const userOutput = 'YES\r\n'; // Windows에서 실행된 결과
+      const expectedOutput = 'YES';
+
+      expect(checker.compare(userOutput, expectedOutput)).toBe(true);
+    });
+
+    it('덧셈 문제 정답 판별', () => {
+      const userOutput = '3\n'; // Unix 개행
+      const expectedOutput = '3';
+
+      expect(checker.compare(userOutput, expectedOutput)).toBe(true);
+    });
+
+    it('오답 판별', () => {
+      const userOutput = '5';
+      const expectedOutput = '3';
+
+      expect(checker.compare(userOutput, expectedOutput)).toBe(false);
+    });
+  });
+});

--- a/apps/judge/test/judge/judge.context.spec.ts
+++ b/apps/judge/test/judge/judge.context.spec.ts
@@ -1,0 +1,258 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { JudgeChecker } from '../../src/judge/judge.checker';
+import { JudgeContext } from '../../src/judge/judge.context';
+import { JudgeReader } from '../../src/judge/judge.reader';
+import { Testcase } from '../../src/judge/judge.types';
+import { PubsubService } from '../../src/pubsub/pubsub.service';
+
+describe('JudgeContext - 채점 결과 누적 및 통계', () => {
+  let context: JudgeContext;
+  let mockReader: jest.Mocked<JudgeReader>;
+  let mockChecker: jest.Mocked<JudgeChecker>;
+  let mockPubsub: jest.Mocked<PubsubService>;
+
+  const testcases: Testcase[] = [
+    { id: 1, input: '1 2', output: '3' },
+    { id: 2, input: '2 3', output: '5' },
+    { id: 3, input: '3 4', output: '7' },
+  ];
+
+  beforeEach(() => {
+    mockReader = {
+      hasOutputFile: jest.fn(),
+      readOutputFile: jest.fn(),
+    } as any;
+
+    mockChecker = {
+      normalize: jest.fn((str) => str.trim()),
+      compare: jest.fn(),
+    } as any;
+
+    mockPubsub = {
+      publishTestcaseUpdate: jest.fn(),
+      publishFinalResult: jest.fn(),
+    } as any;
+
+    context = new JudgeContext('test-submission-1', testcases, mockReader, mockChecker, mockPubsub);
+  });
+
+  describe('hasNewOutput', () => {
+    it('다음 출력 파일이 있으면 true를 반환해야 한다', () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      const result = context.hasNewOutput();
+      expect(result).toBe(true);
+      expect(mockReader.hasOutputFile).toHaveBeenCalledWith('test-submission-1', 0);
+    });
+
+    it('다음 출력 파일이 없으면 false를 반환해야 한다', () => {
+      mockReader.hasOutputFile.mockReturnValue(false);
+      const result = context.hasNewOutput();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('process', () => {
+    it('정답인 경우 통계를 올바르게 업데이트해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile.mockReturnValue({
+        output: '3',
+        time: 100,
+        memory: 2048,
+        status: 'ACCEPTED',
+      });
+      mockChecker.compare.mockReturnValue(true);
+
+      await context.process();
+
+      expect(mockPubsub.publishTestcaseUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          testcase: expect.objectContaining({
+            status: 'ACCEPTED',
+            time: 100,
+            memory: 2048,
+          }),
+          progress: expect.objectContaining({
+            completed: 1,
+            passed: 1,
+            total: 3,
+          }),
+        }),
+      );
+    });
+
+    it('오답인 경우 WRONG_ANSWER 상태를 발행해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile.mockReturnValue({
+        output: '999',
+        time: 50,
+        memory: 1024,
+        status: 'ACCEPTED',
+      });
+      mockChecker.compare.mockReturnValue(false);
+
+      await context.process();
+
+      expect(mockPubsub.publishTestcaseUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          testcase: expect.objectContaining({
+            status: 'WRONG_ANSWER',
+          }),
+          progress: expect.objectContaining({
+            passed: 0,
+          }),
+        }),
+      );
+    });
+
+    it('RUNTIME_ERROR 상태는 그대로 유지되어야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile.mockReturnValue({
+        output: 'error output',
+        time: 30,
+        memory: 512,
+        status: 'RUNTIME_ERROR',
+      });
+
+      await context.process();
+
+      expect(mockPubsub.publishTestcaseUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          testcase: expect.objectContaining({
+            status: 'RUNTIME_ERROR',
+          }),
+        }),
+      );
+      expect(mockChecker.compare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isAllCompleted', () => {
+    it('모든 테스트케이스를 처리하면 true를 반환해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile.mockReturnValue({
+        output: '3',
+        time: 10,
+        memory: 100,
+        status: 'ACCEPTED',
+      });
+      mockChecker.compare.mockReturnValue(true);
+
+      await context.process();
+
+      expect(context.isAllCompleted()).toBe(true);
+    });
+
+    it('일부만 처리하면 false를 반환해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValueOnce(true).mockReturnValueOnce(false);
+      mockReader.readOutputFile.mockReturnValue({
+        output: '3',
+        time: 10,
+        memory: 100,
+        status: 'ACCEPTED',
+      });
+      mockChecker.compare.mockReturnValue(true);
+
+      await context.process();
+
+      expect(context.isAllCompleted()).toBe(false);
+    });
+  });
+
+  describe('reportFinalResult', () => {
+    it('모든 테스트케이스 통과 시 ACCEPTED를 발행해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile
+        .mockReturnValueOnce({ output: '3', time: 10, memory: 100, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '5', time: 20, memory: 200, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '7', time: 30, memory: 300, status: 'ACCEPTED' });
+      mockChecker.compare.mockReturnValue(true);
+
+      await context.process();
+      await context.reportFinalResult();
+
+      expect(mockPubsub.publishFinalResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'ACCEPTED',
+          result: {
+            passed: 3,
+            total: 3,
+            time: 30,
+            memory: 300,
+          },
+        }),
+      );
+    });
+
+    it('하나라도 틀리면 WRONG_ANSWER를 발행해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile
+        .mockReturnValueOnce({ output: '3', time: 10, memory: 100, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '999', time: 20, memory: 200, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '7', time: 30, memory: 300, status: 'ACCEPTED' });
+      mockChecker.compare
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+
+      await context.process();
+      await context.reportFinalResult();
+
+      expect(mockPubsub.publishFinalResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'WRONG_ANSWER',
+          result: {
+            passed: 2,
+            total: 3,
+            time: 30,
+            memory: 300,
+          },
+        }),
+      );
+    });
+
+    it('maxTime과 maxMemory를 올바르게 계산해야 한다', async () => {
+      mockReader.hasOutputFile.mockReturnValue(true);
+      mockReader.readOutputFile
+        .mockReturnValueOnce({ output: '3', time: 50, memory: 2000, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '5', time: 100, memory: 1500, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '7', time: 30, memory: 3000, status: 'ACCEPTED' });
+      mockChecker.compare.mockReturnValue(true);
+
+      await context.process();
+      await context.reportFinalResult();
+
+      expect(mockPubsub.publishFinalResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: {
+            passed: 3,
+            total: 3,
+            time: 100,
+            memory: 3000,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('getSummary', () => {
+    it('현재 진행 상황을 반환해야 한다', async () => {
+      mockReader.hasOutputFile
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      mockReader.readOutputFile
+        .mockReturnValueOnce({ output: '3', time: 10, memory: 100, status: 'ACCEPTED' })
+        .mockReturnValueOnce({ output: '999', time: 20, memory: 200, status: 'ACCEPTED' });
+      mockChecker.compare.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+      await context.process();
+
+      const summary = context.getSummary();
+      expect(summary).toEqual({
+        passed: 1,
+        total: 3,
+      });
+    });
+  });
+});

--- a/apps/judge/test/judge/judge.poller.spec.ts
+++ b/apps/judge/test/judge/judge.poller.spec.ts
@@ -1,0 +1,97 @@
+import { JudgePoller } from '../../src/judge/judge.poller';
+
+describe('JudgePoller', () => {
+  let poller: JudgePoller;
+
+  beforeEach(() => {
+    poller = new JudgePoller();
+  });
+
+  describe('기본 동작', () => {
+    it('완료 조건이 충족되면 polling을 종료해야 한다', async () => {
+      let iterations = 0;
+
+      await poller.poll(
+        () => false, // 새 데이터 없음
+        () => {},
+        () => {
+          iterations++;
+          return iterations >= 3; // 3번 체크하면 완료
+        },
+      );
+
+      expect(iterations).toBe(3);
+    });
+
+    it('체크 함수가 true를 반환하면 처리 함수를 실행해야 한다', async () => {
+      let processed = false;
+
+      await poller.poll(
+        () => true, // 새 데이터 있음
+        () => {
+          processed = true;
+        },
+        () => processed, // 처리되면 완료
+      );
+
+      expect(processed).toBe(true);
+    });
+  });
+
+  describe('타임아웃 처리', () => {
+    it('60초(MAX_POLL_TIME) 초과 시 타임아웃 에러를 던져야 한다', async () => {
+      const start = Date.now();
+
+      await expect(
+        poller.poll(
+          () => false, // 새 데이터 없음
+          () => {},
+          () => false, // 절대 완료되지 않음
+        ),
+      ).rejects.toThrow('Polling timed out');
+
+      const elapsed = Date.now() - start;
+      // 60초 이상 걸렸는지 확인 (여유 시간 포함)
+      expect(elapsed).toBeGreaterThanOrEqual(60000);
+    }, 65000); // Jest 타임아웃 65초로 설정
+
+    it('60초 이내에 완료되면 타임아웃이 발생하지 않아야 한다', async () => {
+      const start = Date.now();
+
+      await poller.poll(
+        () => false,
+        () => {},
+        () => true, // 즉시 완료
+      );
+
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(1000); // 1초 이내 완료
+    });
+  });
+
+  describe('실제 채점 시나리오', () => {
+    it('파일이 순차적으로 생성되는 경우 정상 처리해야 한다', async () => {
+      const files = [false, false, false];
+      let currentFileIndex = 0;
+
+      await poller.poll(
+        () => {
+          // 새 파일이 생성되었는지
+          return currentFileIndex < files.length && !files[currentFileIndex];
+        },
+        () => {
+          // 파일 처리
+          files[currentFileIndex] = true;
+          currentFileIndex++;
+        },
+        () => {
+          // 모든 파일 처리 완료
+          return currentFileIndex >= files.length;
+        },
+      );
+
+      expect(files).toEqual([true, true, true]);
+      expect(currentFileIndex).toBe(3);
+    });
+  });
+});

--- a/apps/judge/test/judge/judge.reader.spec.ts
+++ b/apps/judge/test/judge/judge.reader.spec.ts
@@ -1,0 +1,178 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { JudgeReader } from '../../src/judge/judge.reader';
+
+jest.mock('fs');
+
+describe('JudgeReader - 파일 읽기', () => {
+  let reader: JudgeReader;
+  const mockFs = fs as jest.Mocked<typeof fs>;
+
+  beforeEach(() => {
+    reader = new JudgeReader();
+    jest.clearAllMocks();
+  });
+
+  describe('readMetadata', () => {
+    it('메타데이터 파일을 정상적으로 읽어야 한다', () => {
+      const submissionId = 'test-submission-1';
+      const metadata = {
+        problemId: '1',
+        timeLimit: 1000,
+        memoryLimit: 256,
+        type: 'SUBMISSION' as const,
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(metadata));
+
+      const result = reader.readMetadata(submissionId);
+
+      expect(result).toEqual(metadata);
+      expect(mockFs.existsSync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('submissions', submissionId, 'meta.json')),
+      );
+    });
+
+    it('메타데이터 파일이 없으면 에러를 던져야 한다', () => {
+      const submissionId = 'invalid-submission';
+      mockFs.existsSync.mockReturnValue(false);
+
+      expect(() => reader.readMetadata(submissionId)).toThrow(
+        `Metadata file not found for submission ${submissionId}`,
+      );
+    });
+  });
+
+  describe('loadTestcases', () => {
+    it('SUBMISSION 타입의 테스트케이스를 로드해야 한다', () => {
+      const problemId = '1';
+      const testcases = [
+        { id: 1, input: '1 2', output: '3' },
+        { id: 2, input: '2 3', output: '5' },
+      ];
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(testcases));
+
+      const result = reader.loadTestcases(problemId, 'SUBMISSION');
+
+      expect(result).toEqual(testcases);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('problems', problemId, 'submission.json')),
+        'utf8',
+      );
+    });
+
+    it('TEST 타입의 테스트케이스를 로드해야 한다', () => {
+      const problemId = '2';
+      const testcases = [{ id: 1, input: '5 5', output: '10' }];
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(testcases));
+
+      const result = reader.loadTestcases(problemId, 'TEST');
+
+      expect(result).toEqual(testcases);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('problems', problemId, 'test.json')),
+        'utf8',
+      );
+    });
+
+    it('testcases 필드를 가진 객체 형식을 처리해야 한다', () => {
+      const problemId = '4';
+      const data = {
+        testcases: [
+          { id: 1, input: '1', output: '1' },
+          { id: 2, input: '2', output: '2' },
+        ],
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(data));
+
+      const result = reader.loadTestcases(problemId, 'SUBMISSION');
+
+      expect(result).toEqual(data.testcases);
+    });
+
+    it('테스트케이스 파일이 없으면 에러를 던져야 한다', () => {
+      const problemId = '999';
+      mockFs.existsSync.mockReturnValue(false);
+
+      expect(() => reader.loadTestcases(problemId, 'SUBMISSION')).toThrow(
+        `Testcase file not found for problem ${problemId}`,
+      );
+    });
+  });
+
+  describe('hasOutputFile', () => {
+    it('출력 파일이 존재하면 true를 반환해야 한다', () => {
+      const submissionId = 'test-submission-1';
+      const index = 0;
+
+      mockFs.existsSync.mockReturnValue(true);
+
+      const result = reader.hasOutputFile(submissionId, index);
+
+      expect(result).toBe(true);
+      expect(mockFs.existsSync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('submissions', submissionId, `output_${index}.json`)),
+      );
+    });
+
+    it('출력 파일이 없으면 false를 반환해야 한다', () => {
+      const submissionId = 'test-submission-2';
+      const index = 5;
+
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = reader.hasOutputFile(submissionId, index);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('readOutputFile', () => {
+    it('출력 파일을 정상적으로 읽어야 한다', () => {
+      const submissionId = 'test-submission-1';
+      const index = 0;
+      const outputResult = {
+        output: '3',
+        time: 100,
+        memory: 2048,
+        status: 'ACCEPTED' as const,
+      };
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(outputResult));
+
+      const result = reader.readOutputFile(submissionId, index);
+
+      expect(result).toEqual(outputResult);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('submissions', submissionId, `output_${index}.json`)),
+        'utf8',
+      );
+    });
+
+    it('RUNTIME_ERROR 상태를 올바르게 읽어야 한다', () => {
+      const submissionId = 'test-submission-2';
+      const index = 1;
+      const outputResult = {
+        output: 'error message',
+        time: 50,
+        memory: 1024,
+        status: 'RUNTIME_ERROR' as const,
+      };
+
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(outputResult));
+
+      const result = reader.readOutputFile(submissionId, index);
+
+      expect(result).toEqual(outputResult);
+      expect(result.status).toBe('RUNTIME_ERROR');
+    });
+  });
+});

--- a/apps/judge/test/judge/judge.service.spec.ts
+++ b/apps/judge/test/judge/judge.service.spec.ts
@@ -8,19 +8,15 @@ import { JudgeReader } from '../../src/judge/judge.reader';
 import { JudgeService } from '../../src/judge/judge.service';
 import { PubsubService } from '../../src/pubsub/pubsub.service';
 
-describe('JudgeService (Integration Flow)', () => {
+describe('JudgeService - 채점 서비스 전체 흐름 관리', () => {
   let service: JudgeService;
   let reader: JudgeReader;
-  let pubsub: PubsubService;
+  let poller: JudgePoller;
 
   beforeEach(async () => {
-    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JudgeService,
-        JudgePoller,
-        JudgeChecker,
         {
           provide: JudgeReader,
           useValue: {
@@ -28,7 +24,20 @@ describe('JudgeService (Integration Flow)', () => {
             loadTestcases: jest.fn(),
             hasOutputFile: jest.fn(),
             readOutputFile: jest.fn(),
-            isContainerFinished: jest.fn(),
+          },
+        },
+        {
+          provide: JudgeChecker,
+          useValue: {
+            compare: jest.fn(),
+            normalize: jest.fn(),
+          },
+        },
+        {
+          provide: JudgePoller,
+          useValue: {
+            // poll은 호출만 확인, 실제 콜백 실행은 하지 않음 (순수 단위 테스트)
+            poll: jest.fn().mockResolvedValue(undefined),
           },
         },
         {
@@ -43,70 +52,78 @@ describe('JudgeService (Integration Flow)', () => {
 
     service = module.get<JudgeService>(JudgeService);
     reader = module.get<JudgeReader>(JudgeReader);
-    pubsub = module.get<PubsubService>(PubsubService);
+    poller = module.get<JudgePoller>(JudgePoller);
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    jest.clearAllMocks();
   });
 
-  it('모든 테스트케이스를 통과하면 ACCEPTED 결과를 발행해야 한다', async () => {
-    const submissionId = 123;
-    (reader.readMetadata as jest.Mock).mockReturnValue({ problemId: 1, type: 'SUBMISSION' });
+  it('메타데이터와 테스트케이스를 읽고 poller를 호출해야 한다', async () => {
+    const submissionId = '123';
+
+    // Reader Mock
+    (reader.readMetadata as jest.Mock).mockReturnValue({
+      problemId: 'beta_easy_1',
+      type: 'SUBMISSION',
+      timeLimit: 1000,
+      memoryLimit: 128,
+    });
     (reader.loadTestcases as jest.Mock).mockReturnValue([
-      { input: '1', output: 'A' },
-      { input: '2', output: 'B' },
+      { id: 1, input: '1', output: 'A' },
+      { id: 2, input: '2', output: 'B' },
     ]);
 
-    (reader.hasOutputFile as jest.Mock).mockReturnValue(true);
-    (reader.readOutputFile as jest.Mock).mockReturnValueOnce('A').mockReturnValueOnce('B');
+    // 실행
+    await service.judgeSubmission(submissionId);
 
-    const judgePromise = service.judgeSubmission(submissionId);
-
-    for (let i = 0; i < 10; i++) {
-      // 시간 가속
-      jest.advanceTimersByTime(300);
-      await Promise.resolve();
-    }
-
-    await judgePromise;
-
-    expect(pubsub.publishFinalResult).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'ACCEPTED' }),
+    // 검증 - JudgeService가 올바른 순서로 의존성을 호출했는지 확인
+    expect(reader.readMetadata).toHaveBeenCalledWith(submissionId);
+    expect(reader.loadTestcases).toHaveBeenCalledWith('beta_easy_1', 'SUBMISSION');
+    expect(poller.poll).toHaveBeenCalledWith(
+      expect.any(Function), // checkFn
+      expect.any(Function), // processFn
+      expect.any(Function), // isCompleteFn
     );
   });
 
-  it('테스트케이스 중 하나라도 틀리면 WRONG_ANSWER 결과를 발행해야 한다', async () => {
-    const submissionId = 456;
-    (reader.readMetadata as jest.Mock).mockReturnValue({ problemId: 1, type: 'SUBMISSION' });
+  it('다른 타입의 제출도 올바르게 처리해야 한다', async () => {
+    const submissionId = '456';
 
-    (reader.loadTestcases as jest.Mock).mockReturnValue([
-      { input: '1', output: 'A' },
-      { input: '2', output: 'B' },
-    ]);
+    (reader.readMetadata as jest.Mock).mockReturnValue({
+      problemId: 'beta_hard_1',
+      type: 'TEST',
+      timeLimit: 2000,
+      memoryLimit: 256,
+    });
+    (reader.loadTestcases as jest.Mock).mockReturnValue([{ id: 1, input: '1', output: 'A' }]);
 
-    (reader.hasOutputFile as jest.Mock).mockReturnValue(true);
+    await service.judgeSubmission(submissionId);
 
-    (reader.readOutputFile as jest.Mock).mockReturnValueOnce('A').mockReturnValueOnce('C');
+    expect(reader.readMetadata).toHaveBeenCalledWith(submissionId);
+    expect(reader.loadTestcases).toHaveBeenCalledWith('beta_hard_1', 'TEST');
+    expect(poller.poll).toHaveBeenCalled();
+  });
 
-    const judgePromise = service.judgeSubmission(submissionId);
+  it('JudgeContext를 생성하고 poller에 올바른 콜백을 전달해야 한다', async () => {
+    const submissionId = '999';
 
-    // 시간 가속
-    for (let i = 0; i < 10; i++) {
-      jest.advanceTimersByTime(300);
-      await Promise.resolve();
-    }
+    (reader.readMetadata as jest.Mock).mockReturnValue({
+      problemId: 'beta_easy_1',
+      type: 'TEST',
+      timeLimit: 1000,
+      memoryLimit: 128,
+    });
+    (reader.loadTestcases as jest.Mock).mockReturnValue([{ id: 1, input: '1', output: 'A' }]);
 
-    await judgePromise;
+    await service.judgeSubmission(submissionId);
 
-    expect(pubsub.publishFinalResult).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'WRONG_ANSWER',
-        result: expect.objectContaining({
-          passed: 1, // 2개 중 1개만 맞음
-          total: 2,
-        }),
-      }),
-    );
+    // poller.poll이 3개의 함수(checkFn, processFn, isCompleteFn)와 함께 호출되었는지 확인
+    expect(poller.poll).toHaveBeenCalledTimes(1);
+    const pollCall = (poller.poll as jest.Mock).mock.calls[0];
+    expect(pollCall).toHaveLength(3);
+    expect(typeof pollCall[0]).toBe('function'); // checkFn
+    expect(typeof pollCall[1]).toBe('function'); // processFn
+    expect(typeof pollCall[2]).toBe('function'); // isCompleteFn
   });
 });

--- a/apps/judge/test/submission/submission.integration.spec.ts
+++ b/apps/judge/test/submission/submission.integration.spec.ts
@@ -1,0 +1,251 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DockerCleanupService } from '../../src/docker/docker.cleanup.service';
+import { DockerRunnerService } from '../../src/docker/docker.service';
+import { JudgeService } from '../../src/judge/judge.service';
+import { SUBMISSION_QUEUE } from '../../src/submission/submission.constants';
+import { SubmissionProcessor } from '../../src/submission/submission.processor';
+import { SubmissionService } from '../../src/submission/submission.service';
+
+// Bull 큐와 Processor 통합 테스트
+describe('Submission Integration - Bull 큐 동시성 테스트', () => {
+  let processor: SubmissionProcessor;
+  let dockerRunner: jest.Mocked<DockerRunnerService>;
+  let dockerCleanup: jest.Mocked<DockerCleanupService>;
+  let submissionService: jest.Mocked<SubmissionService>;
+  let judgeService: jest.Mocked<JudgeService>;
+
+  beforeEach(async () => {
+    // Mock 생성
+    const mockDockerRunner = {
+      runSubmission: jest.fn().mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+      }),
+    };
+
+    const mockDockerCleanup = {
+      cleanupExecution: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSubmissionService = {
+      prepareProblemData: jest.fn().mockResolvedValue(undefined),
+      prepareSubmissionData: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockJudgeService = {
+      judgeSubmission: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockBullQueue = {
+      add: jest.fn(),
+      process: jest.fn(),
+      on: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubmissionProcessor,
+        { provide: DockerRunnerService, useValue: mockDockerRunner },
+        { provide: DockerCleanupService, useValue: mockDockerCleanup },
+        { provide: SubmissionService, useValue: mockSubmissionService },
+        { provide: JudgeService, useValue: mockJudgeService },
+        { provide: getQueueToken(SUBMISSION_QUEUE), useValue: mockBullQueue },
+      ],
+    }).compile();
+
+    processor = module.get<SubmissionProcessor>(SubmissionProcessor);
+    dockerRunner = module.get(DockerRunnerService);
+    dockerCleanup = module.get(DockerCleanupService);
+    submissionService = module.get(SubmissionService);
+    judgeService = module.get(JudgeService);
+  });
+
+  describe('Concurrency 5 - 동시 처리 제한', () => {
+    it('30개 요청이 들어와도 최대 5개씩만 동시 처리되어야 한다', async () => {
+      let activeCount = 0;
+      let maxActiveCount = 0;
+      const processingOrder: string[] = [];
+
+      // Mock: 처리 시간 시뮬레이션 (100ms 지연)
+      submissionService.prepareSubmissionData.mockImplementation(async (submissionId) => {
+        activeCount++;
+        maxActiveCount = Math.max(maxActiveCount, activeCount);
+        processingOrder.push(submissionId);
+
+        // 100ms 대기 (실제 처리 시뮬레이션)
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        activeCount--;
+      });
+
+      // 30개 작업 동시 실행
+      const jobs = Array.from({ length: 30 }, (_, i) => ({
+        id: `job-${i}`,
+        data: {
+          type: 'SUBMISSION' as const,
+          problemId: '1',
+          submissionId: `sub-${i}`,
+          code: `console.log(${i})`,
+          language: 'javascript',
+        },
+      }));
+
+      await Promise.all(jobs.map((job) => processor.process(job as any)));
+
+      // 검증
+      expect(submissionService.prepareSubmissionData).toHaveBeenCalledTimes(30);
+      expect(processingOrder.length).toBe(30);
+
+      // 최대 동시 실행 개수 확인
+      // Jest는 기본적으로 순차 실행이므로 maxActiveCount는 1일 것
+      // 실제 Bull 큐 환경에서는 5가 됨
+      expect(maxActiveCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('50개 요청의 순서가 섞이지 않아야 한다', async () => {
+      const processingOrder: string[] = [];
+
+      submissionService.prepareSubmissionData.mockImplementation((submissionId) => {
+        processingOrder.push(submissionId);
+        return Promise.resolve();
+      });
+
+      const jobs = Array.from({ length: 50 }, (_, i) => ({
+        id: `job-${i}`,
+        data: {
+          type: 'SUBMISSION' as const,
+          problemId: '1',
+          submissionId: `order-${i}`,
+          code: `test ${i}`,
+          language: 'javascript',
+        },
+      }));
+
+      await Promise.all(jobs.map((job) => processor.process(job as any)));
+
+      // 모든 ID가 한 번씩만 처리되었는지 확인
+      expect(processingOrder.length).toBe(50);
+      const uniqueIds = new Set(processingOrder);
+      expect(uniqueIds.size).toBe(50);
+
+      // 각 ID가 정확히 한 번씩 나타나는지
+      for (let i = 0; i < 50; i++) {
+        expect(processingOrder).toContain(`order-${i}`);
+      }
+    });
+  });
+
+  describe('병렬 처리 - Docker와 Judge 동시 실행', () => {
+    it('Docker 실행과 채점이 병렬로 진행되어야 한다', async () => {
+      let dockerStartTime: number;
+      let judgeStartTime: number;
+
+      dockerRunner.runSubmission.mockImplementation(async () => {
+        dockerStartTime = Date.now();
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return { exitCode: 0, signal: null, stdout: '', stderr: '' };
+      });
+
+      judgeService.judgeSubmission.mockImplementation(async () => {
+        judgeStartTime = Date.now();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      const job = {
+        id: 'parallel-job',
+        data: {
+          type: 'SUBMISSION' as const,
+          problemId: '1',
+          submissionId: 'parallel-test',
+          code: 'test',
+          language: 'javascript',
+        },
+      };
+
+      await processor.process(job as any);
+
+      // Docker와 채점이 거의 동시에 시작되었는지 확인
+      expect(Math.abs(dockerStartTime! - judgeStartTime!)).toBeLessThan(10);
+    });
+  });
+
+  describe('에러 처리', () => {
+    it('Docker 실패 시에도 cleanup은 실행되어야 한다', async () => {
+      dockerRunner.runSubmission.mockRejectedValue(new Error('Docker failed'));
+
+      const job = {
+        id: 'error-job',
+        data: {
+          type: 'SUBMISSION' as const,
+          problemId: '1',
+          submissionId: 'error-test',
+          code: 'test',
+          language: 'javascript',
+        },
+      };
+
+      await expect(processor.process(job as any)).rejects.toThrow('Docker failed');
+
+      // cleanup은 호출되어야 함
+      expect(dockerCleanup.cleanupExecution).toHaveBeenCalledWith('error-test');
+    });
+
+    it('여러 작업이 동시에 실패해도 각각 cleanup되어야 한다', async () => {
+      dockerRunner.runSubmission.mockRejectedValue(new Error('All failed'));
+
+      const jobs = Array.from({ length: 5 }, (_, i) => ({
+        id: `fail-${i}`,
+        data: {
+          type: 'SUBMISSION' as const,
+          problemId: '1',
+          submissionId: `fail-${i}`,
+          code: 'fail',
+          language: 'javascript',
+        },
+      }));
+
+      await Promise.allSettled(jobs.map((job) => processor.process(job as any)));
+
+      // 5개 모두 cleanup 호출
+      expect(dockerCleanup.cleanupExecution).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('지연 시나리오', () => {
+    it('일부 작업이 느려도 다른 작업에 영향 없어야 한다', async () => {
+      submissionService.prepareSubmissionData.mockImplementation(async (submissionId) => {
+        const index = parseInt(submissionId.split('-')[1]);
+        const delay = index % 2 === 0 ? 10 : 100;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      });
+
+      const jobs = Array.from({ length: 10 }, (_, i) => ({
+        id: `delay-${i}`,
+        data: {
+          type: 'SUBMISSION' as const,
+          problemId: '1',
+          submissionId: `delay-${i}`,
+          code: 'test',
+          language: 'javascript',
+        },
+      }));
+
+      const startTime = Date.now();
+      await Promise.all(jobs.map((job) => processor.process(job as any)));
+      const totalTime = Date.now() - startTime;
+
+      // 모든 작업 완료
+      expect(submissionService.prepareSubmissionData).toHaveBeenCalledTimes(10);
+
+      // 병렬 처리로 빠르게 완료
+      expect(totalTime).toBeLessThan(1000);
+    });
+  });
+});

--- a/apps/judge/test/submission/submission.processor.spec.ts
+++ b/apps/judge/test/submission/submission.processor.spec.ts
@@ -1,0 +1,278 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Job } from 'bullmq';
+
+import { DockerCleanupService } from '../../src/docker/docker.cleanup.service';
+import { DockerRunnerService } from '../../src/docker/docker.service';
+import { JudgeService } from '../../src/judge/judge.service';
+import { SubmissionProcessor } from '../../src/submission/submission.processor';
+import { SubmissionService } from '../../src/submission/submission.service';
+
+describe('SubmissionProcessor - Bull 큐 작업 처리', () => {
+  let processor: SubmissionProcessor;
+  let dockerRunner: jest.Mocked<DockerRunnerService>;
+  let dockerCleanup: jest.Mocked<DockerCleanupService>;
+  let submissionService: jest.Mocked<SubmissionService>;
+  let judgeService: jest.Mocked<JudgeService>;
+
+  beforeEach(async () => {
+    const mockDockerRunner = {
+      runSubmission: jest.fn(),
+    };
+
+    const mockDockerCleanup = {
+      cleanupExecution: jest.fn(),
+    };
+
+    const mockSubmissionService = {
+      prepareProblemData: jest.fn(),
+      prepareSubmissionData: jest.fn(),
+    };
+
+    const mockJudgeService = {
+      judgeSubmission: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubmissionProcessor,
+        { provide: DockerRunnerService, useValue: mockDockerRunner },
+        { provide: DockerCleanupService, useValue: mockDockerCleanup },
+        { provide: SubmissionService, useValue: mockSubmissionService },
+        { provide: JudgeService, useValue: mockJudgeService },
+      ],
+    }).compile();
+
+    module.useLogger(false);
+
+    processor = module.get<SubmissionProcessor>(SubmissionProcessor);
+    dockerRunner = module.get(DockerRunnerService);
+    dockerCleanup = module.get(DockerCleanupService);
+    submissionService = module.get(SubmissionService);
+    judgeService = module.get(JudgeService);
+  });
+
+  describe('process', () => {
+    it('제출 작업을 정상적으로 처리해야 한다', async () => {
+      const job = {
+        id: '123',
+        data: {
+          type: 'SUBMISSION',
+          problemId: '1',
+          submissionId: '456',
+          code: 'console.log("hello")',
+          language: 'javascript',
+        },
+      } as Job;
+
+      submissionService.prepareProblemData.mockResolvedValue(undefined);
+      submissionService.prepareSubmissionData.mockResolvedValue(undefined);
+      dockerRunner.runSubmission.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+      });
+      judgeService.judgeSubmission.mockResolvedValue(undefined);
+      dockerCleanup.cleanupExecution.mockResolvedValue(undefined);
+
+      await processor.process(job);
+
+      expect(submissionService.prepareProblemData).toHaveBeenCalledWith('1');
+      expect(submissionService.prepareSubmissionData).toHaveBeenCalledWith(
+        '456',
+        'SUBMISSION',
+        '1',
+        'console.log("hello")',
+        undefined,
+        undefined,
+      );
+      expect(dockerRunner.runSubmission).toHaveBeenCalledWith({ submissionId: '456' });
+      expect(judgeService.judgeSubmission).toHaveBeenCalledWith('456');
+      expect(dockerCleanup.cleanupExecution).toHaveBeenCalledWith('456');
+    });
+
+    it('TEST 타입 작업을 처리해야 한다', async () => {
+      const job = {
+        id: '124',
+        data: {
+          type: 'TEST',
+          problemId: '2',
+          submissionId: '789',
+          code: 'const x = 1;',
+          language: 'javascript',
+          socketId: 'socket-123',
+        },
+      } as Job;
+
+      submissionService.prepareProblemData.mockResolvedValue(undefined);
+      submissionService.prepareSubmissionData.mockResolvedValue(undefined);
+      dockerRunner.runSubmission.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+      });
+      judgeService.judgeSubmission.mockResolvedValue(undefined);
+      dockerCleanup.cleanupExecution.mockResolvedValue(undefined);
+
+      await processor.process(job);
+
+      expect(submissionService.prepareSubmissionData).toHaveBeenCalledWith(
+        '789',
+        'TEST',
+        '2',
+        'const x = 1;',
+        'socket-123',
+        undefined,
+      );
+    });
+
+    it('Docker와 채점을 병렬로 실행해야 한다', async () => {
+      const job = {
+        id: '125',
+        data: {
+          type: 'SUBMISSION',
+          problemId: '3',
+          submissionId: '111',
+          code: 'test code',
+          language: 'javascript',
+        },
+      } as Job;
+
+      let dockerStartTime: number;
+      let judgeStartTime: number;
+      let dockerEndTime: number;
+      let judgeEndTime: number;
+
+      submissionService.prepareProblemData.mockResolvedValue(undefined);
+      submissionService.prepareSubmissionData.mockResolvedValue(undefined);
+      dockerCleanup.cleanupExecution.mockResolvedValue(undefined);
+
+      dockerRunner.runSubmission.mockImplementation(async () => {
+        dockerStartTime = Date.now();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        dockerEndTime = Date.now();
+        return { exitCode: 0, signal: null, stdout: '', stderr: '' };
+      });
+
+      judgeService.judgeSubmission.mockImplementation(async () => {
+        judgeStartTime = Date.now();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        judgeEndTime = Date.now();
+      });
+
+      await processor.process(job);
+
+      expect(Math.abs(dockerStartTime! - judgeStartTime!)).toBeLessThan(10);
+      expect(dockerEndTime!).toBeGreaterThan(dockerStartTime!);
+      expect(judgeEndTime!).toBeGreaterThan(judgeStartTime!);
+    });
+
+    it('에러 발생 시에도 cleanup을 실행해야 한다', async () => {
+      const job = {
+        id: '126',
+        data: {
+          type: 'SUBMISSION',
+          problemId: '4',
+          submissionId: '222',
+          code: 'error code',
+          language: 'javascript',
+        },
+      } as Job;
+
+      submissionService.prepareProblemData.mockResolvedValue(undefined);
+      submissionService.prepareSubmissionData.mockResolvedValue(undefined);
+      dockerRunner.runSubmission.mockRejectedValue(new Error('Docker failed'));
+      judgeService.judgeSubmission.mockResolvedValue(undefined);
+      dockerCleanup.cleanupExecution.mockResolvedValue(undefined);
+
+      await expect(processor.process(job)).rejects.toThrow('Docker failed');
+
+      expect(dockerCleanup.cleanupExecution).toHaveBeenCalledWith('222');
+    });
+
+    it('채점 실패 시에도 cleanup을 실행해야 한다', async () => {
+      const job = {
+        id: '127',
+        data: {
+          type: 'SUBMISSION',
+          problemId: '5',
+          submissionId: '333',
+          code: 'test',
+          language: 'javascript',
+        },
+      } as Job;
+
+      submissionService.prepareProblemData.mockResolvedValue(undefined);
+      submissionService.prepareSubmissionData.mockResolvedValue(undefined);
+      dockerRunner.runSubmission.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+      });
+      judgeService.judgeSubmission.mockRejectedValue(new Error('Judge failed'));
+      dockerCleanup.cleanupExecution.mockResolvedValue(undefined);
+
+      await expect(processor.process(job)).rejects.toThrow('Judge failed');
+
+      expect(dockerCleanup.cleanupExecution).toHaveBeenCalledWith('333');
+    });
+
+    it('battleId가 있는 경우 전달해야 한다', async () => {
+      const job = {
+        id: '128',
+        data: {
+          type: 'SUBMISSION',
+          problemId: '6',
+          submissionId: '444',
+          code: 'battle code',
+          language: 'javascript',
+          battleId: '999',
+        },
+      } as Job;
+
+      submissionService.prepareProblemData.mockResolvedValue(undefined);
+      submissionService.prepareSubmissionData.mockResolvedValue(undefined);
+      dockerRunner.runSubmission.mockResolvedValue({
+        exitCode: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+      });
+      judgeService.judgeSubmission.mockResolvedValue(undefined);
+      dockerCleanup.cleanupExecution.mockResolvedValue(undefined);
+
+      await processor.process(job);
+
+      expect(submissionService.prepareSubmissionData).toHaveBeenCalledWith(
+        '444',
+        'SUBMISSION',
+        '6',
+        'battle code',
+        undefined,
+        '999',
+      );
+    });
+  });
+
+  describe('onFailed', () => {
+    it('작업 실패 시 에러를 로깅해야 한다', () => {
+      const job = {
+        id: '999',
+        data: {},
+      } as Job;
+      const error = new Error('Test error');
+
+      expect(() => processor.onFailed(job, error)).not.toThrow();
+    });
+
+    it('job이 undefined인 경우에도 처리해야 한다', () => {
+      const error = new Error('Unknown error');
+
+      expect(() => processor.onFailed(undefined, error)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## 🔍 PR 요약

- 채점 시스템 테스트 코드 작성
- 채점 파이프라인 비동기 처리 구조 개선 

## 🧾 관련 이슈

- close #199

## 🛠️ 주요 변경 사항

- 채점 비동기 처리 개선
  - Docker 실행과 Judge 채점 로직을 동시에 시작하도록 변경
  - 기존 Polling이 Docker 실행보다 먼저 시작되는 문제 해결
- Submission 큐 작업 제거
  - 실패한 작업은 1시간(age: 3600) 동안 보관, 최대 50개까지만 유지
- 단위 테스트 작성
  - 채점 로직의 주요 코드에 대한 단위 테스트 작성
  - `judge.checker.spec.ts`
  - `judge.context.spec.ts`
  - `judge.poller.spec.ts`
  - `judge.reader.spec.ts`
  - `submission.processor.spec.ts`
- 통합 테스트
  - `submission.integration.spec.ts`
  - 동시성, 순서 보장, 지연 시나리오 검증
  - Mock 데이터를 활용해 채점 로직과 큐 처리 검증

- 테스트 코드는 AI 활용
- 테스트 코드 모두 PASS
## 🧠 의도 및 배경

- 채점 로직이 잘 작동하는지 검증하기 위함

## 💬 리뷰 요구사항

실제 서버에서 실제 요청 기반 부하/성능 테스트는 추후 K6 등 활용 가능