### PR TITLE
[FIX] 실시간 배틀 목록 노출 타이밍 복구(#207)

### DIFF
--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -105,7 +105,7 @@ export class RoomService {
       const room = await this.createRoom({
         roomId,
         title: problemEntity.title,
-        status: 'in-battle',
+        status: 'waiting',
         currentPlayers: [player1, player2],
       });
 


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 매칭 직후 배틀이 바로 노출되던 흐름을 수정하여, 두 플레이어가 실제로 입장(IN_ROOM)했을 때만 관전자 목록에 노출되도록 복구했습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #207 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- `room.service.ts`에서 매칭 방 생성 시 상태를 in-battle → waiting으로 변경
- 방 목록 노출 조건을 기존처럼 “두 플레이어 IN_ROOM 완료 후 in-battle 전환” 흐름에 맞게 복구


## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.


https://github.com/user-attachments/assets/e91fe102-f054-4cd4-a35e-bf45a4b123b3



## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 매칭 직후 아직 입장하지 않은 상태에서도 배틀이 실시간 목록에 노출되는 문제가 있어, 원래 의도대로 “양쪽 입장 완료 시점에만 노출”되도록 되돌렸습니다.
