### PR TITLE
[FIX] 관전자 이전 배틀 데이터 보이는 로직 수정 (#209)

### DIFF
--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -37,6 +37,15 @@ function BattlePage() {
 
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? '1';
 
+  // 페이지 나갈 때 배틀 상태 초기화
+  useEffect(() => {
+    return () => {
+      useRoomStore.getState().clearRoom();
+      useBattleProblemStore.getState().clearProblem();
+      useBattleProgressStore.getState().resetProgresses();
+    };
+  }, []);
+
   useEffect(() => {
     const socket = connect();
     const handleProblemInfo = (payload: ProblemDataPayload) => {


### PR DESCRIPTION


## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- BattlePage 언마운트 시 zustand에 저장되어 있는 데이터 초기화

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #209 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- BattlePage 언마운트 시 zustand에 저장되어 있는 데이터 초기화
```tsx
  useEffect(() => {
    return () => {
      useRoomStore.getState().clearRoom();
      useBattleProblemStore.getState().clearProblem();
      useBattleProgressStore.getState().resetProgresses();
    };
  }, []);
```

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

| 변경 전      | 변경 후      |
| ------------ | ------------ |
| ![이전](URL) | ![이후](URL) |

## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 초기 디렉토리 구조를 정리하고, 백엔드/프론트엔드 개발을 위한 공통 기반을 마련하기 위함

## 💬 리뷰 요구사항(선택)

- 로컬에서 배틀을 여러 개 생성하는 확인할 수가 없어서, 일단은 코드만 작성해봤습니다...
