### PR TITLE
[FIX] 뒤로가기 처리 및 관전자 진행률 동기화 문제 해결 (#205)

### DIFF
--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -171,6 +171,25 @@ export class BattleService {
     return battle;
   }
 
+  async updateUserProgress(
+    battleId: string,
+    userId: string,
+    passedCount: number,
+    totalCount: number,
+  ): Promise<void> {
+    const battle = await this.battleRedisService.getBattle(battleId);
+    if (!battle) return;
+
+    const user = battle.users.find((u) => u.userId === userId);
+    if (user) {
+      user.progress = {
+        passedCount,
+        totalCount,
+      };
+      await this.battleRedisService.updateBattle(battle);
+    }
+  }
+
   async deleteBattle(roomId: string): Promise<void> {
     const battleId = await this.battleRedisService.getBattleIdByRoomId(roomId);
     if (battleId) {

--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -131,6 +131,23 @@ export class PubsubSubscriberService implements OnModuleInit {
           username: userInfo.username,
         });
 
+        // Redis 배틀 상태 업데이트 (최종 제출 전송 시 진행률 기록)
+        if (submission.battleId) {
+          try {
+            await this.battleService.updateUserProgress(
+              submission.battleId,
+              userInfo.userId,
+              message.result.passed,
+              message.result.total,
+            );
+          } catch (error) {
+            this.logger.error(
+              `[FINAL_RESULT] Failed to update Redis progress for SUBMISSION`,
+              error,
+            );
+          }
+        }
+
         // 모든 테스트 케이스 통과 시 배틀 즉시 종료
         if (message.status === 'ACCEPTED' && submission.battleId) {
           try {

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -214,6 +214,19 @@ export class RoomGateway {
           code: user.code,
           language: user.language,
         });
+
+        // 현재 진행률 스냅샷 전송
+        if (user.progress) {
+          client.emit('submission-result', {
+            submissionId: `sync-${Date.now()}`,
+            status: 'SYNC',
+            userId: user.userId,
+            result: {
+              passed: user.progress.passedCount,
+              total: user.progress.totalCount,
+            },
+          });
+        }
       });
     }
 

--- a/apps/api/src/user/user.entity.ts
+++ b/apps/api/src/user/user.entity.ts
@@ -1,3 +1,4 @@
+import { TierType } from '@packages/types/user';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
@@ -27,7 +28,7 @@ export class User {
   volatility: number = 0.06;
 
   @Column({ type: 'json' })
-  tier: { tier: string; division: number } = { tier: 'Silver', division: 2 };
+  tier: { tier: TierType; division: number } = { tier: 'Silver', division: 2 };
 
   @Column({ type: 'int', default: 0 })
   wins: number;

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -342,7 +342,7 @@ function CodeEditor() {
             <button className="rounded-md bg-base-muted px-3 py-1 text-xs">JavaScript</button>
           </div>
         </div>
-        <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
+        <div className="min-h-[320px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
           <BaseCodeEditor
             value={code}
             onChange={(value) => handleChange(value || '')}

--- a/apps/web/src/components/Battle/Spectator/ProgressBarSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ProgressBarSpectator.tsx
@@ -1,13 +1,13 @@
-import { Trophy } from 'lucide-react';
+import type { UserStats } from '@shared/types/user';
 
+import TierBadge from '@/components/Common/TierBadge';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
-
 type Participant = {
   userId: string;
   username: string;
   avatarUrl?: string;
+  stats?: UserStats;
 };
-
 type Props = {
   participants: Participant[];
   selectedId: string | null;
@@ -25,6 +25,7 @@ function ProgressBarSpectator({ participants, selectedId, onSelect }: Props) {
       percent,
       passed: progress?.passed ?? 0,
       total: progress?.total ?? 0,
+      tier: p.stats?.tier.tier ?? 'Silver',
       color: idx === 0 ? 'var(--color-green-05)' : 'var(--color-pink-05)',
       bg: idx === 0 ? 'bg-[var(--color-green-05)]' : 'bg-[var(--color-pink-05)]',
     };
@@ -61,8 +62,7 @@ function ProgressBarSpectator({ participants, selectedId, onSelect }: Props) {
               <div className="space-y-1">
                 <p className="text-base font-semibold text-base-primary">{player.username}</p>
                 <div className="flex items-center gap-1 text-xs font-semibold text-amber-500">
-                  <Trophy className="h-4 w-4" />
-                  <span>Gold</span>
+                  <TierBadge tier={player.tier} />
                 </div>
               </div>
             </div>

--- a/apps/web/src/components/Common/TierBadge.tsx
+++ b/apps/web/src/components/Common/TierBadge.tsx
@@ -1,6 +1,5 @@
+import type { TierType } from '@shared/types/user';
 import { Crown, Diamond, Medal, Shield, Sparkles, Star, Trophy } from 'lucide-react';
-
-type TierType = 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond' | 'Ruby' | 'Master';
 
 interface TierBadgeProps {
   tier: TierType;

--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -18,7 +18,7 @@ export default function MatchingSuccess() {
     if (countdown === 0) {
       if (matchResult?.roomId) {
         setAllowNavigation(true);
-        navigate(`/room/${matchResult.roomId}`);
+        navigate(`/room/${matchResult.roomId}`, { replace: true });
       }
       return;
     }

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -82,7 +82,7 @@ function BattlePage() {
       resetProgresses();
 
       if (data.battleId) {
-        navigate(`/result/${data.battleId}`);
+        navigate(`/result/${data.battleId}`, { replace: true });
       } else {
         console.error('[BattlePage] battleId missing in BATTLE_ENDED payload');
       }

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -1,10 +1,11 @@
 export type UserRole = 'player' | 'spectator';
+export type TierType = 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond' | 'Ruby' | 'Master';
 
 export interface UserStats {
   wins: number;
   losses: number;
   rating: number;
-  tier: { tier: string; division: number };
+  tier: { tier: TierType; division: number };
 }
 
 // 방에 들어가지 않은 사용자


### PR DESCRIPTION
## 🔍 PR 요약

- 플레이어 배틀 페이지와 결과페이지에서 뒤로가기 시 메인페이지로 이동
- 관전자 페이지에서 플레이어의 실제 티어 설정 및 진행률 동기화 문제 해결
- 배틀 페이지 코드 에디터 최소 높이 줄이기 

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #205

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.


## 📸 스크린샷 (선택)

- 결과페이지에서 메인페이지로 이동

https://github.com/user-attachments/assets/bcf76e55-85cc-412e-99f9-3730d4e0564d

- 관전자 페이지에서 진행률 동기화

https://github.com/user-attachments/assets/0b2513ec-02ad-4d1a-937e-97f2b3f02f5d


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 초기 디렉토리 구조를 정리하고, 백엔드/프론트엔드 개발을 위한 공통 기반을 마련하기 위함

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?💬 리뷰 요구사항(선택)

