### PR TITLE
[FEAT] 실제 데이터 연결 및 오류 수정 (#221)

### DIFF
--- a/apps/api/src/battle/battle-redis.service.ts
+++ b/apps/api/src/battle/battle-redis.service.ts
@@ -56,5 +56,7 @@ export class BattleRedisService {
     const key = RedisKeys.battle(battleId);
     const roomKey = RedisKeys.battleByRoom(roomId);
     await this.redis.del(key, roomKey);
+
+    await this.redis.srem(RedisKeys.activeBattles(), battleId);
   }
 }

--- a/apps/api/src/battle/battle.gateway.ts
+++ b/apps/api/src/battle/battle.gateway.ts
@@ -192,7 +192,7 @@ export class BattleGateway {
   // 방 목록을 모든 클라이언트에게 브로드캐스트
   private async broadcastRoomList(): Promise<void> {
     const rooms = await this.roomService.listRooms();
-    const publicRooms = this.roomService.toPublicRooms(rooms);
+    const publicRooms = await this.roomService.toPublicRooms(rooms);
     this.server.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 }

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -343,6 +343,9 @@ export class BattleService {
     await this.redisClient.srem(RedisKeys.activeBattles(), battle.battleId);
     this.logger.log(`[endBattle] 진행 중인 배틀 목록에서 제거 완료`);
 
+    // 6.5. 방 삭제
+    await this.roomService.deleteRoom(battle.roomId);
+
     // 7. 참가자들의 매칭 상태 초기화 (재매칭 가능하도록)
     this.logger.log(
       `[endBattle] 매칭 상태 초기화 시작 - users: ${battle.users.map((u) => u.userId).join(', ')}`,

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -522,6 +522,7 @@ export class BattleService {
       }
 
       const tier = (user?.tier?.tier || 'Bronze') as Tier;
+      const division = user?.tier?.division ?? 4;
 
       const ratingChange =
         index === 0 ? battle.player1RatingChange || 0 : battle.player2RatingChange || 0;
@@ -531,6 +532,7 @@ export class BattleService {
         username: user?.username || 'Unknown',
         avatarUrl: user?.avatarUrl || '',
         tier,
+        division,
         rate: user?.rating || 0,
         score: submission?.passedTestCases || 0,
         totalScore: submission?.totalTestCases || 20,

--- a/apps/api/src/matching/matching.gateway.ts
+++ b/apps/api/src/matching/matching.gateway.ts
@@ -120,7 +120,7 @@ export class MatchingGateway implements OnGatewayDisconnect {
   // Redis I/O 후 방 목록을 모든 클라이언트에게 브로드캐스트
   async broadcastRoomList(): Promise<void> {
     const rooms = await this.roomService.listRooms();
-    const publicRooms = this.roomService.toPublicRooms(rooms);
+    const publicRooms = await this.roomService.toPublicRooms(rooms);
     this.server.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 }

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -46,7 +46,7 @@ export class RoomGateway {
   @SubscribeMessage(SOCKET_EVENT.ROOM_LIST_REQUEST)
   async handleRoomListRequest(@ConnectedSocket() client: Socket) {
     const rooms = await this.roomService.listRooms();
-    const publicRooms = this.roomService.toPublicRooms(rooms);
+    const publicRooms = await this.roomService.toPublicRooms(rooms);
     client.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 
@@ -257,7 +257,7 @@ export class RoomGateway {
     await this.roomService.saveRoom(room);
 
     const rooms = await this.roomService.listRooms();
-    const publicRooms = this.roomService.toPublicRooms(rooms);
+    const publicRooms = await this.roomService.toPublicRooms(rooms);
     this.server.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
   }
 

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -237,13 +237,23 @@ export class RoomService {
 
   // 클라이언트에 노출할 때 socketId 등 민감 정보를 제거한 방 데이터
 
-  toPublicRooms(rooms: Room[]): PublicRoom[] {
-    return rooms
-      .filter((room) => room.status === 'in-battle')
-      .map((room) => ({
-        ...room,
-        currentPlayers: room.currentPlayers.map(({ socketId: _socketId, ...rest }) => rest),
-        currentSpectators: room.currentSpectators.map(({ socketId: _socketId, ...rest }) => rest),
-      }));
+  async toPublicRooms(rooms: Room[]): Promise<PublicRoom[]> {
+    const battleRooms = rooms.filter((room) => room.status === 'in-battle');
+
+    return Promise.all(
+      battleRooms.map(async (room) => {
+        const battle = await this.BattleService.getBattleByRoomId(room.roomId);
+        const progressMap = new Map(battle?.users.map((u) => [u.userId, u.progress]) ?? []);
+
+        return {
+          ...room,
+          currentPlayers: room.currentPlayers.map(({ socketId: _socketId, ...rest }) => ({
+            ...rest,
+            progress: progressMap.get(rest.userId),
+          })),
+          currentSpectators: room.currentSpectators.map(({ socketId: _socketId, ...rest }) => rest),
+        };
+      }),
+    );
   }
 }

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -41,6 +41,7 @@ export class RoomService {
     const newRoom: Room = {
       roomId,
       title: params.title || `배틀룸 ${roomId.substring(8)}`,
+      difficulty: params.difficulty,
       hostId: params.hostId || 'system',
       status: params.status || 'waiting',
       createdAt: new Date(),
@@ -75,6 +76,12 @@ export class RoomService {
         role: 'player',
         avatarUrl: user1.avatarUrl,
         joinedAt: now,
+        stats: {
+          wins: user1.myRate.win,
+          losses: user1.myRate.lose,
+          rating: user1.rating,
+          tier: { tier: user1.tier.tier, division: user1.tier.division ?? 4 },
+        },
       };
 
       const player2: RoomUser = {
@@ -85,6 +92,12 @@ export class RoomService {
         role: 'player',
         avatarUrl: user2.avatarUrl,
         joinedAt: now,
+        stats: {
+          wins: user2.myRate.win,
+          losses: user2.myRate.lose,
+          rating: user2.rating,
+          tier: { tier: user2.tier.tier, division: user2.tier.division ?? 4 },
+        },
       };
 
       // 배틀 생성
@@ -105,6 +118,7 @@ export class RoomService {
       const room = await this.createRoom({
         roomId,
         title: problemEntity.title,
+        difficulty: problemEntity.difficulty,
         status: 'waiting',
         currentPlayers: [player1, player2],
       });

--- a/apps/web/src/apis/user.ts
+++ b/apps/web/src/apis/user.ts
@@ -1,3 +1,5 @@
+import type { TierType } from '@shared/types/user';
+
 import { axiosInstance } from './axios';
 
 export const api = axiosInstance;
@@ -6,6 +8,11 @@ export interface UserProfile {
   id: string;
   username: string;
   avatarUrl: string;
+  tier: { tier: TierType; division: number };
+  rating: number;
+  wins: number;
+  losses: number;
+  draws: number;
 }
 
 export const getUserProfile = async () => {

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -22,8 +22,9 @@ type TestcaseResult = TestcaseUpdateMessage['testcase'] & {
 type TestcaseUpdatePayload = Omit<TestcaseUpdateMessage, 'type'> & {
   results?: TestcaseUpdateMessage['results'];
 };
-type SubmissionResultPayload = Omit<FinalResultMessage, 'type'> & {
+type SubmissionResultPayload = Omit<FinalResultMessage, 'type' | 'status'> & {
   userId?: string;
+  status: FinalResultMessage['status'] | 'SYNC';
 };
 
 // 실행 상태 타입
@@ -46,6 +47,7 @@ function CodeEditor() {
   const socket = useBattleSocketStore((state) => state.socket);
   const connect = useBattleSocketStore((state) => state.connect);
   const upsertProgress = useBattleProgressStore((state) => state.upsertProgress);
+  const syncProgress = useBattleProgressStore((state) => state.syncProgress);
 
   const [code, setCode] = useState(DEFAULT_CODE_TEMPLATE);
   const [statusText, setStatusText] = useState('대기 중');
@@ -158,10 +160,18 @@ function CodeEditor() {
     const handleSubmissionResult = (payload: SubmissionResultPayload) => {
       // 모든 플레이어의 제출 결과를 store에 저장 (ProgressBar용)
       if (payload.userId && payload.result) {
-        upsertProgress(payload.userId, {
-          passed: payload.result.passed,
-          total: payload.result.total,
-        });
+        // SYNC 이벤트는 재접속 시 진행률 동기화용이므로 activity log 추가하지 않음
+        if (payload.status === 'SYNC') {
+          syncProgress(payload.userId, {
+            passed: payload.result.passed,
+            total: payload.result.total,
+          });
+        } else {
+          upsertProgress(payload.userId, {
+            passed: payload.result.passed,
+            total: payload.result.total,
+          });
+        }
       }
 
       const execution = executionRef.current;
@@ -209,7 +219,7 @@ function CodeEditor() {
       socket.off('testcase-update', handleTestcaseUpdate);
       socket.off('submission-result', handleSubmissionResult);
     };
-  }, [me?.userId, roomId, socket, upsertProgress]);
+  }, [me?.userId, roomId, socket, upsertProgress, syncProgress]);
 
   const handleChange = (value: string) => {
     hasEditedRef.current = true;

--- a/apps/web/src/components/Common/TierBadge.tsx
+++ b/apps/web/src/components/Common/TierBadge.tsx
@@ -1,6 +1,8 @@
 import type { TierType } from '@shared/types/user';
 import { Crown, Diamond, Medal, Shield, Star, Trophy } from 'lucide-react';
 
+import { toRomanNumeral } from '@/lib/tier';
+
 interface TierBadgeProps {
   tier: TierType;
   division?: number;
@@ -49,7 +51,7 @@ function TierBadge({ tier, division }: TierBadgeProps) {
       <Icon size={12} className={`${config.fillClass} ${config.colorClass}`} />
       <span className={`font-semibold ${config.colorClass} text-sm`}>
         {tier}
-        {division !== undefined && ` ${division}`}
+        {division !== undefined && ` ${toRomanNumeral(division)}`}
       </span>
     </div>
   );

--- a/apps/web/src/components/Common/TierBadge.tsx
+++ b/apps/web/src/components/Common/TierBadge.tsx
@@ -1,8 +1,9 @@
 import type { TierType } from '@shared/types/user';
-import { Crown, Diamond, Medal, Shield, Sparkles, Star, Trophy } from 'lucide-react';
+import { Crown, Diamond, Medal, Shield, Star, Trophy } from 'lucide-react';
 
 interface TierBadgeProps {
   tier: TierType;
+  division?: number;
 }
 
 // TODO: 티어별 임시 아이콘
@@ -32,11 +33,6 @@ const tierConfig = {
     colorClass: 'text-tier-diamond',
     fillClass: 'fill-tier-diamond',
   },
-  Ruby: {
-    icon: Sparkles,
-    colorClass: 'text-tier-ruby',
-    fillClass: 'fill-tier-ruby',
-  },
   Master: {
     icon: Crown,
     colorClass: 'text-tier-master',
@@ -44,14 +40,17 @@ const tierConfig = {
   },
 };
 
-function TierBadge({ tier }: TierBadgeProps) {
+function TierBadge({ tier, division }: TierBadgeProps) {
   const config = tierConfig[tier];
   const Icon = config.icon;
 
   return (
     <div className="flex items-center gap-1">
       <Icon size={12} className={`${config.fillClass} ${config.colorClass}`} />
-      <span className={`font-semibold ${config.colorClass} text-sm`}>{tier}</span>
+      <span className={`font-semibold ${config.colorClass} text-sm`}>
+        {tier}
+        {division !== undefined && ` ${division}`}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -59,7 +59,12 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
                   onClick={() => setIsMenuOpen(!isMenuOpen)}
                   className="flex items-center transition hover:opacity-80 active:scale-95"
                 >
-                  <UserProfile username={user.username} tier="Gold" avatarUrl={user.avatarUrl} />
+                  <UserProfile
+                    username={user.username}
+                    tier={user.tier?.tier}
+                    division={user.tier?.division}
+                    avatarUrl={user.avatarUrl}
+                  />
                 </button>
 
                 {isMenuOpen && (

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -1,5 +1,8 @@
 import type { Room } from '@shared/types/room';
 import { Eye } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import TierBadge from '@/components/Common/TierBadge';
 
 type Props = {
   rooms: Room[];
@@ -9,7 +12,31 @@ type Props = {
 
 const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
 
+const difficultyColor: Record<string, { bg: string; text: string }> = {
+  Bronze: { bg: 'bg-tier-bronze/20', text: 'text-tier-bronze' },
+  Silver: { bg: 'bg-tier-silver/20', text: 'text-tier-silver' },
+  Gold: { bg: 'bg-tier-gold/20', text: 'text-tier-gold' },
+  Platinum: { bg: 'bg-tier-platinum/20', text: 'text-tier-platinum' },
+  Diamond: { bg: 'bg-tier-diamond/20', text: 'text-tier-diamond' },
+  Master: { bg: 'bg-tier-master/20', text: 'text-tier-master' },
+};
+
+function formatElapsed(createdAt: Date): string {
+  const elapsed = Math.max(0, Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000));
+  const minutes = Math.floor(elapsed / 60);
+  const seconds = elapsed % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
 function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (rooms.length === 0) return;
+    const interval = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, [rooms.length]);
+
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {rooms.map((room) => {
@@ -22,7 +49,7 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
             <div className="mb-4 flex items-center justify-between text-xs text-base-secondary">
               <div className="flex items-center gap-2">
                 <span className="flex items-center font-semibold text-red-01">● LIVE</span>
-                <span className="text-blue-03">12:34</span>
+                <span className="text-blue-03">{formatElapsed(room.createdAt)}</span>
               </div>
               <div className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium">
                 <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} />
@@ -31,9 +58,13 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
             </div>
             <div className="flex items-center gap-2">
               <h3 className="text-xl font-bold text-base-primary">{room.title}</h3>
-              <span className="rounded-full bg-green-01 px-2 py-1 text-[10px] font-bold text-green-06">
-                Gold
-              </span>
+              {room.difficulty && (
+                <span
+                  className={`rounded-full px-2 py-1 text-[10px] font-bold ${difficultyColor[room.difficulty]?.bg ?? 'bg-base-faint'} ${difficultyColor[room.difficulty]?.text ?? 'text-base-secondary'}`}
+                >
+                  {room.difficulty}
+                </span>
+              )}
             </div>
 
             <div className="mt-4 space-y-4">
@@ -53,7 +84,9 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
                     </div>
                     <div className="flex flex-col">
                       <span className="text-sm font-semibold text-base-primary">{p.username}</span>
-                      <span className="text-xs text-base-secondary">🏆 Gold III</span>
+                      {p.stats?.tier && (
+                        <TierBadge tier={p.stats.tier.tier} division={p.stats.tier.division} />
+                      )}
                     </div>
                   </div>
                   <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -91,9 +91,9 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
                   </div>
                   <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
                     <div
-                      className="h-full rounded-full"
+                      className="h-full rounded-full transition-all duration-300"
                       style={{
-                        width: `${idx === 0 ? 75 : 60}%`,
+                        width: `${p.progress && p.progress.totalCount > 0 ? Math.round((p.progress.passedCount / p.progress.totalCount) * 100) : 0}%`,
                         backgroundColor: idx === 0 ? '#00e074' : '#ff6584',
                       }}
                     />

--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -50,7 +50,7 @@ export default function MatchingSuccess() {
   }
 
   const { opponent, myRate } = matchResult;
-  const myTier = { tier: 'Bronze', division: 4 };
+  const myTier = user.tier;
 
   return (
     <div className="flex gap-4 w-full flex-col items-center justify-center select-none">

--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -2,6 +2,7 @@ import { Check } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import TierBadge from '@/components/Common/TierBadge';
 import { playBattleCountdownSound } from '@/lib/sound';
 import { useMatchingStore } from '@/stores/matchingStore';
 import { useUserStore } from '@/stores/userStore';
@@ -73,12 +74,8 @@ export default function MatchingSuccess() {
           </div>
           <div className="flex flex-col items-center">
             <p className="text-2xl font-bold">{user.username}</p>
-            <div className="mt-2 flex items-center justify-center gap-1 text-sm">
-              <span>🏆</span>
-              <span className="font-semibold text-base-secondary capitalize">
-                {myTier.tier}
-                {myTier.division ? ` ${myTier.division}` : ''}
-              </span>
+            <div className="mt-2">
+              <TierBadge tier={myTier.tier} division={myTier.division} />
             </div>
             <p className="mt-1 text-base text-base-secondary">승률: {myRate.winRate.toFixed(0)}%</p>
           </div>
@@ -97,12 +94,8 @@ export default function MatchingSuccess() {
           </div>
           <div className="flex flex-col items-center">
             <p className="text-2xl font-bold">{opponent.username}</p>
-            <div className="mt-2 flex items-center justify-center gap-1 text-sm">
-              <span>🏆</span>
-              <span className="font-semibold text-base-secondary capitalize">
-                {opponent.tier.tier}
-                {opponent.tier.division ? ` ${opponent.tier.division}` : ''}
-              </span>
+            <div className="mt-2">
+              <TierBadge tier={opponent.tier.tier} division={opponent.tier.division} />
             </div>
             <p className="mt-1 text-base text-base-secondary">
               승률: {opponent.rate.winRate.toFixed(0)}%

--- a/apps/web/src/components/Matching/StatCard.tsx
+++ b/apps/web/src/components/Matching/StatCard.tsx
@@ -7,7 +7,7 @@ export default function StatCard({ value, label }: Props) {
   return (
     <div className="flex-1 min-w-50 bg-bg-layer-1 rounded-2xl py-6 px-12 text-center">
       <div className="text-3xl font-bold text-green-05">{value}</div>
-      <div className="text-sm text-base-secondary mt-2">{label}</div>
+      <div className="text-sm text-base-secondary mt-2 whitespace-nowrap">{label}</div>
     </div>
   );
 }

--- a/apps/web/src/components/Profile/UserProfile.tsx
+++ b/apps/web/src/components/Profile/UserProfile.tsx
@@ -1,12 +1,15 @@
-import Gold from '@/components/Bedge/Gold';
+import type { TierType } from '@shared/types/user';
+
+import TierBadge from '@/components/Common/TierBadge';
 
 interface UserProfileProps {
   username: string;
-  tier?: string;
+  tier?: TierType;
+  division?: number;
   avatarUrl?: string;
 }
 
-export function UserProfile({ username, tier = 'Gold', avatarUrl }: UserProfileProps) {
+export function UserProfile({ username, tier, division, avatarUrl }: UserProfileProps) {
   return (
     <div className="flex items-center gap-3 px-4">
       <div className="relative flex h-10 w-10 items-center justify-center">
@@ -26,7 +29,7 @@ export function UserProfile({ username, tier = 'Gold', avatarUrl }: UserProfileP
 
       <div className="flex flex-col">
         <span className="text-base font-bold text-base-primary">{username}</span>
-        <Gold tier={tier} />
+        {tier && <TierBadge tier={tier} division={division} />}
       </div>
     </div>
   );

--- a/apps/web/src/components/Result/CodeViewer.tsx
+++ b/apps/web/src/components/Result/CodeViewer.tsx
@@ -1,27 +1,31 @@
 import BaseCodeEditor from '@/components/Common/BaseCodeEditor';
 
+type BattleResult = 'win' | 'lose' | 'draw';
+
 interface CodeViewerProps {
   username: string;
   avatarUrl: string;
   code: string;
-  isWinner: boolean;
+  result: BattleResult;
 }
 
-function CodeViewer({ username, avatarUrl, code, isWinner }: CodeViewerProps) {
+const resultConfig: Record<BattleResult, { bg: string; label: string }> = {
+  win: { bg: 'bg-green-03', label: '승리' },
+  lose: { bg: 'bg-pink-03', label: '패배' },
+  draw: { bg: 'bg-base-faint', label: '무승부' },
+};
+
+function CodeViewer({ username, avatarUrl, code, result }: CodeViewerProps) {
+  const { bg, label } = resultConfig[result];
+
   return (
     <div className="flex h-full flex-col rounded-2xl shadow-lg overflow-hidden bg-bg-layer-2 border border-border-soft">
-      <div
-        className={`flex items-center border-b border-border-soft px-4 py-3 gap-3 ${
-          isWinner ? 'bg-green-03' : 'bg-pink-03'
-        }`}
-      >
+      <div className={`flex items-center border-b border-border-soft px-4 py-3 gap-3 ${bg}`}>
         <div className="h-8 w-8 overflow-hidden rounded-full bg-white">
           <img src={avatarUrl} alt={username} className="h-full w-full object-cover" />
         </div>
         <span className="font-semibold text-black-static">{username}</span>
-        <span className="ml-auto text-sm font-semibold text-black-static">
-          {isWinner ? '승리' : '패배'}
-        </span>
+        <span className="ml-auto text-sm font-semibold text-black-static">{label}</span>
       </div>
 
       <div className="flex-1 overflow-hidden">

--- a/apps/web/src/components/Result/PlayerCard.tsx
+++ b/apps/web/src/components/Result/PlayerCard.tsx
@@ -24,6 +24,7 @@ interface PlayerCardProps {
 function PlayerCard({ player, isWinner, isSelected, onClick }: PlayerCardProps) {
   const { username, avatarUrl, tier, division, rate, score, totalScore, time, ratingChange } =
     player;
+  const isPositiveChange = ratingChange >= 0;
 
   return (
     <button
@@ -51,15 +52,17 @@ function PlayerCard({ player, isWinner, isSelected, onClick }: PlayerCardProps) 
 
       <div className="flex rounded-2xl bg-bg-layer-1/20 border border-border-soft p-2.5">
         <div className="flex flex-6 justify-center items-center gap-3">
-          <div className={`rounded-full p-2 ${isWinner ? 'bg-green-01' : 'bg-pink-01'}`}>
-            {isWinner ? (
+          <div className={`rounded-full p-2 ${isPositiveChange ? 'bg-green-01' : 'bg-pink-01'}`}>
+            {isPositiveChange ? (
               <ArrowUp className="h-5 w-5 text-green-06" />
             ) : (
               <ArrowDown className="h-5 w-5 text-pink-05" />
             )}
           </div>
           <div>
-            <div className={`text-3xl font-bold ${isWinner ? 'text-green-05' : 'text-pink-05'}`}>
+            <div
+              className={`text-3xl font-bold ${isPositiveChange ? 'text-green-05' : 'text-pink-05'}`}
+            >
               {ratingChange > 0 ? '+' : ''}
               {ratingChange}
             </div>

--- a/apps/web/src/components/Result/PlayerCard.tsx
+++ b/apps/web/src/components/Result/PlayerCard.tsx
@@ -1,3 +1,4 @@
+import type { TierType } from '@shared/types/user';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 
 import TierBadge from '@/components/Common/TierBadge';
@@ -6,7 +7,7 @@ interface PlayerCardProps {
   player: {
     username: string;
     avatarUrl: string;
-    tier: 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond' | 'Ruby' | 'Master';
+    tier: TierType;
     rate: number;
     score: number;
     totalScore: number;

--- a/apps/web/src/components/Result/PlayerCard.tsx
+++ b/apps/web/src/components/Result/PlayerCard.tsx
@@ -8,6 +8,7 @@ interface PlayerCardProps {
     username: string;
     avatarUrl: string;
     tier: TierType;
+    division: number;
     rate: number;
     score: number;
     totalScore: number;
@@ -21,7 +22,8 @@ interface PlayerCardProps {
 }
 
 function PlayerCard({ player, isWinner, isSelected, onClick }: PlayerCardProps) {
-  const { username, avatarUrl, tier, rate, score, totalScore, time, ratingChange } = player;
+  const { username, avatarUrl, tier, division, rate, score, totalScore, time, ratingChange } =
+    player;
 
   return (
     <button
@@ -39,7 +41,7 @@ function PlayerCard({ player, isWinner, isSelected, onClick }: PlayerCardProps) 
         </div>
         <div className="flex-1">
           <h3 className="font-bold text-base-primary text-left">{username}</h3>
-          <TierBadge tier={tier} />
+          <TierBadge tier={tier} division={division} />
         </div>
         <div className="text-right">
           <div className="text-3xl font-bold text-base-primary">{rate}</div>

--- a/apps/web/src/lib/tier.ts
+++ b/apps/web/src/lib/tier.ts
@@ -1,0 +1,10 @@
+const ROMAN_NUMERALS: Record<number, string> = {
+  1: 'I',
+  2: 'II',
+  3: 'III',
+  4: 'IV',
+};
+
+export function toRomanNumeral(division: number): string {
+  return ROMAN_NUMERALS[division] || String(division);
+}

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -15,7 +15,6 @@ const tierFilters = [
   { label: '골드', color: 'bg-tier-gold' },
   { label: '플래티넘', color: 'bg-tier-platinum' },
   { label: '다이아몬드', color: 'bg-tier-diamond' },
-  { label: '루비', color: 'bg-tier-ruby' },
   { label: '마스터', color: 'bg-tier-master' },
 ];
 

--- a/apps/web/src/pages/ResultPage.tsx
+++ b/apps/web/src/pages/ResultPage.tsx
@@ -83,7 +83,13 @@ function ResultPage() {
               username={selectedPlayer.username}
               avatarUrl={selectedPlayer.avatarUrl}
               code={selectedPlayer.code}
-              isWinner={selectedPlayer.userId === battle.winnerId}
+              result={
+                !battle.winnerId
+                  ? 'draw'
+                  : selectedPlayer.userId === battle.winnerId
+                    ? 'win'
+                    : 'lose'
+              }
             />
           </div>
         </div>

--- a/apps/web/src/stores/battleProgressStore.ts
+++ b/apps/web/src/stores/battleProgressStore.ts
@@ -20,6 +20,7 @@ type ProgressMap = Record<string, PlayerProgress>;
 type State = {
   progresses: ProgressMap;
   upsertProgress: (userId: string, progress: { passed: number; total: number }) => void;
+  syncProgress: (userId: string, progress: { passed: number; total: number }) => void;
   addActivityLog: (
     userId: string,
     log: { type: 'TEST' | 'SUBMIT'; passed: number; total: number },
@@ -48,6 +49,20 @@ export const useBattleProgressStore = create<State>()(
                 ...progress,
                 codeLines: current?.codeLines ?? 0,
                 activityLogs: [...(current?.activityLogs ?? []), newLog],
+              },
+            },
+          };
+        }),
+      syncProgress: (userId, progress) =>
+        set((s) => {
+          const current = s.progresses[userId];
+          return {
+            progresses: {
+              ...s.progresses,
+              [userId]: {
+                ...progress,
+                codeLines: current?.codeLines ?? 0,
+                activityLogs: current?.activityLogs ?? [],
               },
             },
           };

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -1,3 +1,5 @@
+import type { TierType } from './user';
+
 export type BattleStatus = 'running' | 'completed';
 
 export type BattleResult = 'win' | 'lose' | 'draw';
@@ -85,7 +87,7 @@ export interface BattleResultResponse {
     userId: string;
     username: string;
     avatarUrl: string;
-    tier: 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond' | 'Ruby' | 'Master';
+    tier: TierType;
     rate: number;
     score: number;
     totalScore: number;

--- a/packages/types/battle.ts
+++ b/packages/types/battle.ts
@@ -88,6 +88,7 @@ export interface BattleResultResponse {
     username: string;
     avatarUrl: string;
     tier: TierType;
+    division: number;
     rate: number;
     score: number;
     totalScore: number;

--- a/packages/types/room.ts
+++ b/packages/types/room.ts
@@ -5,6 +5,7 @@ export type RoomStatus = 'waiting' | 'in-battle' | 'completed';
 export interface Room {
   roomId: string;
   title: string;
+  difficulty?: string;
   hostId: string;
   status: RoomStatus;
   createdAt: Date;

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -1,5 +1,5 @@
 export type UserRole = 'player' | 'spectator';
-export type TierType = 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond' | 'Ruby' | 'Master';
+export type TierType = 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond' | 'Master';
 
 export interface UserStats {
   wins: number;

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -22,4 +22,5 @@ export interface RoomUser extends User {
   role: UserRole;
   joinedAt: Date;
   stats?: UserStats;
+  progress?: { passedCount: number; totalCount: number };
 }


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 하드 코딩된 값을 실제 데이터 연결
- 결과 페이지 무승부 UI 처리
- 배틀 활동 기록 버그 수정
- 메인 페이지 하드코딩 값 수정

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #221
- close #223 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- apps/web/src/components/Battle/Player/CodeEditor.tsx : 재접속 이벤트 SYNC 분기 처리
- TierBadge에서 division 로마 숫자 사용
- 매칭 통계 오류
  - 배틀 종료 후 Room 데이터 삭제 및 활동 배틀에서도 중복 삭제
- apps/web/src/pages/ResultPage.tsx
  - 무승부 시 점수 증감 UI 수정
  - 무승부 시 CodeViewer에 무승부 표시

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

<img width="1288" height="630" alt="image" src="https://github.com/user-attachments/assets/8d05cd35-033e-401b-93a1-0f9f7cbc1dcd" />

<img width="1264" height="698" alt="image" src="https://github.com/user-attachments/assets/f11d98a4-93d0-40b3-b971-4172e3c08e33" />

<img width="1224" height="618" alt="image" src="https://github.com/user-attachments/assets/c1a5eeb6-eb22-4268-ad6d-cc188aedd828" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 여러 에러 수정하여 사용자 경험 개선
- 하드코딩된 값 실제 데이터 연결 필요

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 메인 페이지에서 방 목록 이벤트가 방 생성이나 삭제가 될 경우 업데이트 되기 때문에 각 방마다 progressbar의 실시간 변동이 되지는 않습니다. 새로고침 해야 동작합니다.
