### PR TITLE
[FEAT] 문제 난이도에 따른 랜덤 선택 구현 (#224)

### DIFF
--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -50,7 +50,7 @@ export class BattleService {
     const battleId = `battle-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 
     // 임시 문제 선택
-    const problem = await this.problemService.findFirst();
+    const problem = await this.problemService.findRandomByDifficulty('Bronze');
     if (!problem) {
       throw new Error('No problems available.');
     }

--- a/apps/api/src/problem/problem.service.ts
+++ b/apps/api/src/problem/problem.service.ts
@@ -86,6 +86,15 @@ export class ProblemService implements OnModuleInit {
     });
   }
 
+  // 문제 난이도에 따른 랜덤 문제 조회
+  async findRandomByDifficulty(difficulty: string): Promise<Problem | null> {
+    return await this.problemRepository
+      .createQueryBuilder('problem')
+      .where('problem.difficulty = :difficulty', { difficulty })
+      .orderBy('RAND()')
+      .getOne();
+  }
+
   async findOne(id: string): Promise<Problem | null> {
     return this.problemRepository.findOne({ where: { id } });
   }


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 문제 난이도에 따른 랜덤 문제 선택

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- related to #224 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- apps/api/src/problem/problem.service.ts
  - `findRandomByDifficulty` : 난이도에 따른 문제 랜덤 선택 함수 구현


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 배틀 시작시 참가자의 실력에 맞는 문제를 선택하기 위함

## 💬 리뷰 요구사항(선택)

- 같은 난이도라도 백준처럼 1-4 티어가 있기 때문에 문제 난이도를 레이팅 값으로 해야 할지 고민입니다. 
