### PR TITLE
[FEAT] 배틀 중 이탈 처리 및 배틀 중인 유저 자동 복귀 (#218)

### DIFF
--- a/apps/api/src/battle/battle.gateway.ts
+++ b/apps/api/src/battle/battle.gateway.ts
@@ -1,7 +1,8 @@
-import { forwardRef, Inject } from '@nestjs/common';
+import { forwardRef, Inject, Logger } from '@nestjs/common';
 import {
   ConnectedSocket,
   MessageBody,
+  OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
@@ -18,19 +19,51 @@ import { type ChatMessage } from '@packages/types/chat';
 import { Server, Socket } from 'socket.io';
 
 import { BattleService } from '@/battle/battle.service';
+import { BattleRedisService } from '@/battle/battle-redis.service';
 import { RoomService } from '@/room/room.service';
 
 @WebSocketGateway({
   namespace: SOCKET_NAMESPACE.GAME,
 })
-export class BattleGateway {
+export class BattleGateway implements OnGatewayDisconnect {
   @WebSocketServer() server: Server;
+  private readonly logger = new Logger(BattleGateway.name);
 
   constructor(
     private readonly battleService: BattleService,
+    private readonly battleRedisService: BattleRedisService,
     @Inject(forwardRef(() => RoomService))
     private readonly roomService: RoomService,
   ) {}
+
+  async handleDisconnect(client: Socket) {
+    try {
+      // 모든 room을 순회하여 disconnect된 소켓이 배틀 중인 플레이어인지 확인
+      const rooms = await this.roomService.listRooms();
+
+      for (const room of rooms) {
+        const player = room.currentPlayers.find((u) => u.socketId === client.id);
+        if (!player) continue;
+
+        // 해당 방에 진행 중인 배틀이 있는지 확인
+        const battleId = await this.battleRedisService.getBattleIdByRoomId(room.roomId);
+        if (!battleId) continue;
+
+        // 배틀 중인 플레이어가 disconnect → 타이머 시작
+        this.battleService.startDisconnectTimer(
+          player.userId,
+          room.roomId,
+          battleId,
+          async (roomId, bId, winnerId) => {
+            await this.emitBattleEnd(roomId, bId, winnerId);
+          },
+        );
+        break;
+      }
+    } catch (error) {
+      this.logger.error('[handleDisconnect] error:', error);
+    }
+  }
 
   @SubscribeMessage(BATTLE_EVENTS.CODE_CHANGE)
   async handleChangeCode(@ConnectedSocket() client: Socket, @MessageBody() dto: UpdateUserCodeDTO) {

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -27,6 +27,7 @@ import { UserService } from '@/user/user.service';
 @Injectable()
 export class BattleService {
   private readonly logger = new Logger(BattleService.name);
+  private readonly disconnectTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
     @Inject(REDIS_CLIENT) private readonly redisClient: Redis,
@@ -204,6 +205,50 @@ export class BattleService {
     const socketId = await this.redisClient.hget(RedisKeys.matchingUser(userId), 'socketId');
 
     return socketId;
+  }
+
+  // 플레이어 disconnect 시 타이머 시작
+  // 10초 내 재접속하지 않으면 배틀 포기 처리
+  startDisconnectTimer(
+    userId: string,
+    roomId: string,
+    battleId: string,
+    onForfeit: (roomId: string, battleId: string, winnerId: string | null) => Promise<void>,
+  ): void {
+    // 이미 타이머가 있으면 중복 방지
+    if (this.disconnectTimers.has(userId)) return;
+
+    this.logger.warn(
+      `[DisconnectTimer] 시작 - userId: ${userId}, battleId: ${battleId} (${BATTLE_CONFIG.DISCONNECT_TIMEOUT_MS / 1000}초)`,
+    );
+
+    const timer = setTimeout(() => {
+      this.disconnectTimers.delete(userId);
+      void this.forfeitBattle(battleId, userId)
+        .then((battle) => onForfeit(roomId, battle.id, battle.winnerId))
+        .then(() => {
+          this.logger.warn(
+            `[DisconnectTimer] 타임아웃 → 배틀 포기 처리 완료 - userId: ${userId}, battleId: ${battleId}`,
+          );
+        })
+        .catch((error) => {
+          this.logger.error(`[DisconnectTimer] forfeit 실패 - userId: ${userId}`, error);
+        });
+    }, Number(BATTLE_CONFIG.DISCONNECT_TIMEOUT_MS));
+
+    this.disconnectTimers.set(userId, timer);
+  }
+
+  // 플레이어 재접속 시 disconnect 타이머 취소
+  cancelDisconnectTimer(userId: string): boolean {
+    const timer = this.disconnectTimers.get(userId);
+    if (timer) {
+      clearTimeout(timer);
+      this.disconnectTimers.delete(userId);
+      this.logger.log(`[DisconnectTimer] 취소 (재접속) - userId: ${userId}`);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -379,10 +379,11 @@ export class BattleService {
     const savedBattle = await this.battleRepository.save(battleEntity);
     this.logger.log(`[endBattle] 배틀 엔티티 저장 완료 - savedBattle.id: ${savedBattle.id}`);
 
-    // 5. Redis에서 배틀 데이터 삭제
+    // 5. Redis에서 배틀 데이터 및 방 정보 삭제
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 시작`);
     await this.battleRedisService.deleteBattle(battle.battleId, battle.roomId);
     this.logger.log(`[endBattle] Redis 배틀 데이터 삭제 완료`);
+    await this.roomService.deleteRoom(battle.roomId);
 
     // 6. 진행 중인 배틀 목록에서 제거
     await this.redisClient.srem(RedisKeys.activeBattles(), battle.battleId);

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -112,6 +112,8 @@ export class RoomGateway {
       existingPlayer.socketId = client.id;
       existingPlayer.username = resolvedUsername;
       existingPlayer.avatarUrl = resolvedAvatar;
+      // 재접속 시 disconnect 타이머 취소
+      this.battleService.cancelDisconnectTimer(resolvedUserId);
     } else if (existingSpectator) {
       existingSpectator.socketId = client.id;
       existingSpectator.username = resolvedUsername;

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -2,12 +2,19 @@ import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { User } from './user.entity';
+import { UserService } from './user.service';
 
 @Controller('users')
 export class UserController {
+  constructor(private readonly userService: UserService) {}
+
   @Get('me')
   @UseGuards(AuthGuard('jwt'))
-  getProfile(@Req() req: { user: User }) {
-    return req.user;
+  async getProfile(@Req() req: { user: User }) {
+    const currentRoomId = await this.userService.getUserCurrentRoomId(req.user.id);
+    return {
+      ...req.user,
+      currentRoomId,
+    };
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,8 +1,12 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { clampRating, getTierFromRating, RATING_CONFIG } from '@packages/constants/rating';
 import { Glicko2, newProcedure } from 'glicko2.ts';
+import Redis from 'ioredis';
 import { Repository } from 'typeorm';
+
+import { REDIS_CLIENT } from '@/redis/redis.module';
+import { RedisKeys } from '@/redis/redis-key.constant';
 
 import { User } from './user.entity';
 
@@ -31,6 +35,7 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
   ) {
     this.glicko2 = new Glicko2({
       tau: RATING_CONFIG.TAU,
@@ -132,5 +137,22 @@ export class UserService {
         tier: loserNewTier,
       },
     };
+  }
+
+  // 유저의 현재 활성 방 ID 조회
+  async getUserCurrentRoomId(userId: string): Promise<string | null> {
+    try {
+      const status = await this.redis.hget(RedisKeys.matchingUser(userId), 'status');
+      const roomId = await this.redis.hget(RedisKeys.matchingUser(userId), 'roomId');
+
+      // 방에 있는 상태(IN_ROOM)이거나 배틀 중인 상태에서 리다이렉트
+      if (status === 'IN_ROOM' && roomId) {
+        return roomId;
+      }
+      return null;
+    } catch (error) {
+      this.logger.error(`Error fetching user room status: ${userId}`, error);
+      return null;
+    }
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,13 +1,11 @@
 import { useEffect } from 'react';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
+import BattleGuard from '@/components/Guards/BattleGuard';
 import { useUserStore } from '@/stores/userStore';
 
 function App() {
-  const navigate = useNavigate();
-  const location = useLocation();
   const fetchUser = useUserStore((state) => state.fetchUser);
-  const user = useUserStore((state) => state.user);
 
   useEffect(() => {
     if (localStorage.getItem('accessToken')) {
@@ -15,23 +13,10 @@ function App() {
     }
   }, [fetchUser]);
 
-  // 활성 배틀이 있는 경우 강제 리다이렉트
-  useEffect(() => {
-    if (user?.currentRoomId) {
-      const currentPath = location.pathname;
-      const targetPath = `/room/${user.currentRoomId}`;
-
-      // 현재 경로가 타겟 경로와 다르고, 결과 페이지가 아닐 때만 이동
-      if (currentPath !== targetPath && !currentPath.startsWith('/result')) {
-        navigate(targetPath, { replace: true });
-      }
-    }
-  }, [user?.currentRoomId, location.pathname, navigate]);
-
   return (
-    <>
+    <BattleGuard>
       <Outlet />
-    </>
+    </BattleGuard>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import BattleGuard from '@/components/Guards/BattleGuard';
 import { useUserStore } from '@/stores/userStore';
 
 function App() {
@@ -13,11 +12,7 @@ function App() {
     }
   }, [fetchUser]);
 
-  return (
-    <BattleGuard>
-      <Outlet />
-    </BattleGuard>
-  );
+  return <Outlet />;
 }
 
 export default App;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,16 +1,32 @@
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useUserStore } from '@/stores/userStore';
 
 function App() {
+  const navigate = useNavigate();
+  const location = useLocation();
   const fetchUser = useUserStore((state) => state.fetchUser);
+  const user = useUserStore((state) => state.user);
 
   useEffect(() => {
     if (localStorage.getItem('accessToken')) {
       fetchUser();
     }
   }, [fetchUser]);
+
+  // 활성 배틀이 있는 경우 강제 리다이렉트
+  useEffect(() => {
+    if (user?.currentRoomId) {
+      const currentPath = location.pathname;
+      const targetPath = `/room/${user.currentRoomId}`;
+
+      // 현재 경로가 타겟 경로와 다르고, 결과 페이지가 아닐 때만 이동
+      if (currentPath !== targetPath && !currentPath.startsWith('/result')) {
+        navigate(targetPath, { replace: true });
+      }
+    }
+  }, [user?.currentRoomId, location.pathname, navigate]);
 
   return (
     <>

--- a/apps/web/src/apis/user.ts
+++ b/apps/web/src/apis/user.ts
@@ -6,6 +6,7 @@ export interface UserProfile {
   id: string;
   username: string;
   avatarUrl: string;
+  currentRoomId?: string | null;
 }
 
 export const getUserProfile = async () => {

--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -1,38 +1,31 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
 import { motion } from 'framer-motion';
-import { AlertCircle, Eye, Moon, Sun, Timer } from 'lucide-react';
+import { Eye, Moon, Sun, Timer } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import logo from '@/assets/logo.png';
-import Modal from '@/components/Common/Modal';
 import { playCountdownSound } from '@/lib/sound';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
-import { useRoomStore } from '@/stores/roomStore';
 
 interface BattleHeaderProps {
   theme: 'light' | 'dark';
   onToggleTheme: () => void;
-  showLeaveConfirm?: boolean;
+  onLeaveClick: () => void;
 }
 
-function BattleHeader({ theme, onToggleTheme, showLeaveConfirm = true }: BattleHeaderProps) {
-  const navigate = useNavigate();
+function BattleHeader({ theme, onToggleTheme, onLeaveClick }: BattleHeaderProps) {
   const { roomId } = useParams<{ roomId: string }>();
-  const leaveRoom = useBattleSocketStore((state) => state.leaveRoom);
-  const leaveBattle = useBattleSocketStore((state) => state.leaveBattle);
   const spectatorCount = useBattleSocketStore((state) => state.spectatorCount);
   const problem = useBattleProblemStore((state) => state.problem);
   const timeOffset = useBattleProblemStore((state) => state.timeOffset);
-  const me = useRoomStore((state) => state.me);
 
   const battleId = problem?.battleId;
   const duration = problem?.duration;
   const startedAt = problem?.startedAt;
 
   const [timeLeft, setTimeLeft] = useState<number>(0);
-  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
   const [hasEmittedEnd, setHasEmittedEnd] = useState(false);
   const hasPlayedCountdownRef = useRef(false);
 
@@ -74,34 +67,6 @@ function BattleHeader({ theme, onToggleTheme, showLeaveConfirm = true }: BattleH
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  };
-
-  const handleLeaveClick = () => {
-    if (showLeaveConfirm) {
-      setIsLeaveModalOpen(true);
-    } else {
-      handleConfirmLeave();
-    }
-  };
-
-  const handleConfirmLeave = () => {
-    if (!roomId) {
-      navigate('/');
-      return;
-    }
-
-    // 플레이어가 배틀 중이면 배틀 포기
-    if (showLeaveConfirm && battleId && me?.userId) {
-      // BATTLE_ENDED 이벤트에서 정리 및 페이지 이동 처리
-      leaveBattle(roomId, battleId, me.userId);
-    } else {
-      leaveRoom(roomId);
-      navigate('/');
-    }
-  };
-
-  const handleCancelLeave = () => {
-    setIsLeaveModalOpen(false);
   };
 
   return (
@@ -146,37 +111,12 @@ function BattleHeader({ theme, onToggleTheme, showLeaveConfirm = true }: BattleH
           {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
         </button>
         <button
-          onClick={handleLeaveClick}
+          onClick={onLeaveClick}
           className="inline-flex h-10 w-20 items-center justify-center rounded-full bg-base-faint text-sm font-bold text-base-primary transition hover:brightness-110"
         >
           나가기
         </button>
       </div>
-
-      {showLeaveConfirm && (
-        <Modal
-          isOpen={isLeaveModalOpen}
-          onClose={handleCancelLeave}
-          icon={AlertCircle}
-          iconColor="text-error-01"
-          iconBgColor="bg-error-01/20"
-          title="대결에서 나가시겠습니까?"
-          description="진행 중인 문제 풀이가 모두 사라집니다."
-          buttons={[
-            {
-              label: '취소',
-              onClick: handleCancelLeave,
-              variant: 'muted',
-            },
-            {
-              label: '나가기',
-              onClick: handleConfirmLeave,
-              variant: 'black',
-            },
-          ]}
-          closeOnBackdrop={false}
-        />
-      )}
     </header>
   );
 }

--- a/apps/web/src/components/Guards/BattleGuard.tsx
+++ b/apps/web/src/components/Guards/BattleGuard.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { useUserStore } from '@/stores/userStore';
+
+interface BattleGuardProps {
+  children: React.ReactNode;
+}
+
+// 활성 배틀이 있는 유저를 해당 배틀 페이지로 리다이렉트
+function BattleGuard({ children }: BattleGuardProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const user = useUserStore((state) => state.user);
+
+  useEffect(() => {
+    if (user?.currentRoomId) {
+      const currentPath = location.pathname;
+      const targetPath = `/room/${user.currentRoomId}`;
+
+      // 현재 경로가 타겟 경로와 다르고, 결과 페이지가 아닐 때만 이동
+      if (currentPath !== targetPath && !currentPath.startsWith('/result')) {
+        navigate(targetPath, { replace: true });
+      }
+    }
+  }, [user?.currentRoomId, location.pathname, navigate]);
+
+  return <>{children}</>;
+}
+
+export default BattleGuard;

--- a/apps/web/src/components/Guards/BattleGuard.tsx
+++ b/apps/web/src/components/Guards/BattleGuard.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useUserStore } from '@/stores/userStore';
 
@@ -7,23 +7,23 @@ interface BattleGuardProps {
   children: React.ReactNode;
 }
 
-// 활성 배틀이 있는 유저를 해당 배틀 페이지로 리다이렉트
+// 배틀 중인 유저를 해당 배틀 페이지로 리다이렉트
 function BattleGuard({ children }: BattleGuardProps) {
   const navigate = useNavigate();
-  const location = useLocation();
   const user = useUserStore((state) => state.user);
+  const isLeavingRoom = useUserStore((state) => state.isLeavingRoom);
 
   useEffect(() => {
-    if (user?.currentRoomId) {
-      const currentPath = location.pathname;
-      const targetPath = `/room/${user.currentRoomId}`;
-
-      // 현재 경로가 타겟 경로와 다르고, 결과 페이지가 아닐 때만 이동
-      if (currentPath !== targetPath && !currentPath.startsWith('/result')) {
-        navigate(targetPath, { replace: true });
-      }
+    // 배틀 중이고 이탈 중이 아닐 때만 리다이렉트
+    if (user?.currentRoomId && !isLeavingRoom) {
+      navigate(`/room/${user.currentRoomId}`, { replace: true });
     }
-  }, [user?.currentRoomId, location.pathname, navigate]);
+  }, [user?.currentRoomId, isLeavingRoom, navigate]);
+
+  // 리다이렉트 전 깜빡임 방지
+  if (user?.currentRoomId && !isLeavingRoom) {
+    return null;
+  }
 
   return <>{children}</>;
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,9 +2,10 @@ import './index.css';
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom';
 
 import App from '@/App.tsx';
+import BattleGuard from '@/components/Guards/BattleGuard.tsx';
 import BattlePage from '@/pages/BattlePage.tsx';
 import LoginErrorPage from '@/pages/Error/LoginErrorPage';
 import LoginPage from '@/pages/LoginPage.tsx';
@@ -18,28 +19,37 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        index: true,
-        element: <MainPage />,
-      },
-      {
-        path: '/matching',
-        element: <MatchingPage />,
-      },
-      {
-        path: '/login',
-        element: <LoginPage />,
+        element: (
+          <BattleGuard>
+            <Outlet />
+          </BattleGuard>
+        ),
+        children: [
+          {
+            index: true,
+            element: <MainPage />,
+          },
+          {
+            path: '/matching',
+            element: <MatchingPage />,
+          },
+        ],
       },
       {
         path: '/room/:roomId',
         element: <BattlePage />,
       },
       {
-        path: '/error',
-        element: <LoginErrorPage />,
-      },
-      {
         path: '/result/:battleId',
         element: <ResultPage />,
+      },
+      {
+        path: '/login',
+        element: <LoginPage />,
+      },
+      {
+        path: '/error',
+        element: <LoginErrorPage />,
       },
     ],
   },

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -82,10 +82,12 @@ function BattlePage() {
 
     // 플레이어가 배틀 중이면 배틀 포기
     if (battleId && me?.userId) {
+      useUserStore.getState().setIsLeavingRoom(true);
       leaveBattle(roomId, battleId, me.userId);
       useUserStore.getState().clearCurrentRoomId();
       if (blocker.state === 'blocked') blocker.proceed?.();
     } else {
+      useUserStore.getState().setIsLeavingRoom(true);
       leaveRoom(roomId);
       if (blocker.state === 'blocked') blocker.proceed?.();
       else navigate('/');
@@ -131,6 +133,9 @@ function BattlePage() {
       clearProblem();
       clearRoom();
       resetProgresses();
+      if (isLeaving) {
+        useUserStore.getState().setIsLeavingRoom(true);
+      }
       useUserStore.getState().clearCurrentRoomId();
       useBattleSocketStore.setState({ isLeavingBattle: false });
       try {

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -1,11 +1,13 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
+import { AlertCircle } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useBlocker, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import BattleFinishOverlay from '@/components/Battle/BattleFinishOverlay';
 import BattleHeader from '@/components/Battle/BattleHeader';
 import BattlePlayer from '@/components/Battle/Player/BattlePlayer';
 import BattleSpectator from '@/components/Battle/Spectator/BattleSpectator';
+import Modal from '@/components/Common/Modal';
 import { useTheme } from '@/hooks/useTheme';
 import { playCountdownSound } from '@/lib/sound';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
@@ -23,6 +25,8 @@ function BattlePage() {
   const resumeSession = useBattleSocketStore((state) => state.resumeSession);
   const connect = useBattleSocketStore((state) => state.connect);
   const joinRoom = useBattleSocketStore((state) => state.joinRoom);
+  const leaveRoom = useBattleSocketStore((state) => state.leaveRoom);
+  const leaveBattle = useBattleSocketStore((state) => state.leaveBattle);
   const subscribeRoomAvailability = useBattleSocketStore(
     (state) => state.subscribeRoomAvailability,
   );
@@ -31,16 +35,74 @@ function BattlePage() {
   );
   const clearProblem = useBattleProblemStore((state) => state.clearProblem);
   const clearRoom = useRoomStore((state) => state.clearRoom);
+  const problem = useBattleProblemStore((state) => state.problem);
   const user = useUserStore((state) => state.user);
   const me = useRoomStore((state) => state.me);
   const resetProgresses = useBattleProgressStore((state) => state.resetProgresses);
 
   const [showFinishOverlay, setShowFinishOverlay] = useState(false);
+  const [showLeaveModal, setShowLeaveModal] = useState(false);
 
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? '1';
+  const battleId = problem?.battleId;
+  const isLeavingBattle = useBattleSocketStore((state) => state.isLeavingBattle);
 
-  // 페이지 나갈 때 배틀 상태 초기화
+  // 뒤로가기 차단 (플레이어 + 배틀 중 + 나가기 미확인 시)
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      !isSpectator &&
+      !!battleId &&
+      !isLeavingBattle &&
+      currentLocation.pathname !== nextLocation.pathname,
+  );
+
+  const isLeaveModalOpen = blocker.state === 'blocked' || showLeaveModal;
+
+  // 나가기 버튼 클릭 핸들러
+  const handleLeaveClick = () => {
+    if (isSpectator) {
+      if (roomId) {
+        leaveRoom(roomId);
+      }
+      navigate('/');
+    } else {
+      setShowLeaveModal(true);
+    }
+  };
+
+  // 모달에서 나가기 확인
+  const handleConfirmLeave = () => {
+    setShowLeaveModal(false);
+
+    if (!roomId) {
+      if (blocker.state === 'blocked') blocker.proceed?.();
+      else navigate('/');
+      return;
+    }
+
+    // 플레이어가 배틀 중이면 배틀 포기
+    if (battleId && me?.userId) {
+      leaveBattle(roomId, battleId, me.userId);
+      if (blocker.state === 'blocked') blocker.proceed?.();
+    } else {
+      leaveRoom(roomId);
+      if (blocker.state === 'blocked') blocker.proceed?.();
+      else navigate('/');
+    }
+  };
+
+  // 모달에서 취소
+  const handleCancelLeave = () => {
+    setShowLeaveModal(false);
+    if (blocker.state === 'blocked') {
+      blocker.reset?.();
+    }
+  };
+
+  // 페이지 진입/나갈 때 상태 초기화
   useEffect(() => {
+    useBattleSocketStore.setState({ isLeavingBattle: false });
+
     return () => {
       useRoomStore.getState().clearRoom();
       useBattleProblemStore.getState().clearProblem();
@@ -162,12 +224,35 @@ function BattlePage() {
   return (
     <div className="min-h-svh overflow-auto xl:h-screen xl:overflow-hidden">
       <div className="flex min-h-svh flex-col gap-3 px-3 py-3 xl:h-full xl:w-full xl:gap-4 xl:px-6 xl:py-4">
-        <BattleHeader theme={theme} onToggleTheme={toggleTheme} showLeaveConfirm={!isSpectator} />
+        <BattleHeader theme={theme} onToggleTheme={toggleTheme} onLeaveClick={handleLeaveClick} />
         <div className="flex-1 min-h-0 overflow-visible xl:overflow-hidden">
           {isSpectator ? <BattleSpectator /> : <BattlePlayer />}
         </div>
       </div>
       <BattleFinishOverlay isVisible={showFinishOverlay} />
+
+      <Modal
+        isOpen={isLeaveModalOpen}
+        onClose={handleCancelLeave}
+        icon={AlertCircle}
+        iconColor="text-error-01"
+        iconBgColor="bg-error-01/20"
+        title="대결에서 나가시겠습니까?"
+        description="진행 중인 문제 풀이가 모두 사라집니다."
+        buttons={[
+          {
+            label: '취소',
+            onClick: handleCancelLeave,
+            variant: 'muted',
+          },
+          {
+            label: '나가기',
+            onClick: handleConfirmLeave,
+            variant: 'black',
+          },
+        ]}
+        closeOnBackdrop={false}
+      />
     </div>
   );
 }

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -83,6 +83,7 @@ function BattlePage() {
     // 플레이어가 배틀 중이면 배틀 포기
     if (battleId && me?.userId) {
       leaveBattle(roomId, battleId, me.userId);
+      useUserStore.getState().clearCurrentRoomId();
       if (blocker.state === 'blocked') blocker.proceed?.();
     } else {
       leaveRoom(roomId);
@@ -130,6 +131,7 @@ function BattlePage() {
       clearProblem();
       clearRoom();
       resetProgresses();
+      useUserStore.getState().clearCurrentRoomId();
       useBattleSocketStore.setState({ isLeavingBattle: false });
       try {
         sessionStorage.removeItem('battle-session');

--- a/apps/web/src/stores/userStore.ts
+++ b/apps/web/src/stores/userStore.ts
@@ -5,19 +5,27 @@ import { getUserProfile, type UserProfile } from '@/apis/user';
 interface UserStore {
   user: UserProfile | null;
   isLoading: boolean;
+  isLeavingRoom: boolean;
   fetchUser: () => Promise<void>;
   clearUser: () => void;
   clearCurrentRoomId: () => void;
+  setIsLeavingRoom: (val: boolean) => void;
 }
 
 export const useUserStore = create<UserStore>((set) => ({
   user: null,
   isLoading: false,
+  isLeavingRoom: false,
   fetchUser: async () => {
     set({ isLoading: true });
     try {
       const user = await getUserProfile();
-      set({ user });
+      // 서버에서 방 정보가 지워진 것이 확인되면 이탈 중 플래그 해제
+      if (user.currentRoomId === null) {
+        set({ user, isLeavingRoom: false });
+      } else {
+        set({ user });
+      }
     } catch {
       set({ user: null });
     } finally {
@@ -29,4 +37,5 @@ export const useUserStore = create<UserStore>((set) => ({
     set((state) => ({
       user: state.user ? { ...state.user, currentRoomId: null } : null,
     })),
+  setIsLeavingRoom: (val) => set({ isLeavingRoom: val }),
 }));

--- a/apps/web/src/stores/userStore.ts
+++ b/apps/web/src/stores/userStore.ts
@@ -7,6 +7,7 @@ interface UserStore {
   isLoading: boolean;
   fetchUser: () => Promise<void>;
   clearUser: () => void;
+  clearCurrentRoomId: () => void;
 }
 
 export const useUserStore = create<UserStore>((set) => ({
@@ -24,4 +25,8 @@ export const useUserStore = create<UserStore>((set) => ({
     }
   },
   clearUser: () => set({ user: null }),
+  clearCurrentRoomId: () =>
+    set((state) => ({
+      user: state.user ? { ...state.user, currentRoomId: null } : null,
+    })),
 }));

--- a/packages/constants/battle.ts
+++ b/packages/constants/battle.ts
@@ -1,6 +1,7 @@
 export const BATTLE_CONFIG = {
   DURATION: 30 * 60, // 기본 배틀 시간: 30분 (초 단위)
   DEFAULT_LANGUAGE: 'javascript',
+  DISCONNECT_TIMEOUT_MS: 10_000, // 재접속 대기 시간: 10초
 } as const;
 
 export const DEFAULT_CODE_TEMPLATE = `function solution(input) {


### PR DESCRIPTION
## 🔍 PR 요약

- 배틀 중 이탈 시나리오(뒤로가기, 창 닫기) 제어, 활성화된 배틀이 있는 경우 다른 페이지 접속을 차단

## 🧾 관련 이슈

- close #218
- close #225

## 🛠️ 주요 변경 사항

- 소켓 연결 끊김 시 10초 대기 후 배틀 종료
  - 유저가 창을 닫거나 새로고침을 할 때 소켓 연결이 끊기는데, 창 닫기 시 바로 배틀을 종료하면 단순 새로고침을 하는 짧은 시간에도 배틀 포기 처리가 되는 문제
  - 이에 재접속하는 시간을 10초로 설정하여 10초 이내 재접속하지 않을 경우 배틀 종료
  - 창을 닫으면 연결 끊김 처리 - 10초 카운트다운 시작 → 10초 이내 `localhost:5173` 으로 이동하면 → 배틀 가드 작동 → 현재 배틀 진행 중인 배틀 페이지로 이동 → 10초 이내 재접속 처리가 되어서 타이머 취소

- 브라우저 뒤로가기 시 모달 표시 및 나가기 로직 적용
  - `useBlocker`를 활용하여 배틀 중 브라우저 뒤로가기 버튼을 누를 경우 페이지 이동을 즉시 차단
  - '나가기' 버튼을 눌렀을 때와 동일한 확인 모달
  - 모달에서 '나가기' 버튼 클릭 시 즉시 배틀 종료, 남은 사용자는 배틀 페이지, 나간 사용자는 메인 페이지로 이동

- 배틀 진행 중인 유저 강제 리다이렉트
  - 서버에서 해당 유저의 Redis 상태가 `IN_ROOM`인지 확인, 현재 참여 중인 `currentRoomId` 확인
  - 서버에서 받아온 `currentRoomId`가 존재할 경우, 프론트엔드 전역에서 감지하여 유저가 메인 등으로 이동할 시에 배틀 페이지로 리다이렉트
  - 유저의 `accessToken`은 `localStorage`에 남아있으므로 브라우저를 껐다 켜거나 새 탭을 열어도 서버로부터 현재 진행 중인 배틀 정보를 받아옴
  - Guards/BattleGuard.tsx 에 해당 로직을 추가하였고, 추후 AuthGuard 등 로그인 가드 확장 고려
  - 메인페이지, 매칭페이지로 이동 시에만 강제 리다이렉트

- 페이지 전환 시 깜빡임 현상
  - 배틀 중인 유저가 새 탭을 통해 메인 페이지로 이동할 때, 가드가 작동하기 전까지 아주 짧은 순간 메인 페이지가 보였다가 사라지는 깜빡임 현상 발생

- 수정 예정 사항
  - 위 깜빡임 현상
  - 탭 여러개 띄우고 강제 리다이렉트로 모두 배틀페이지일 경우, 한 페이지라도 삭제하면 종료 타이머가 발생해 바로 배틀이 종료되는 현상 발생
    - 존재하는 탭이 있으면 작동 안하도록??

## 📸 스크린샷 

https://github.com/user-attachments/assets/d1305339-fbd4-47d0-86d5-79802e529a16

## 🧠 의도 및 배경

- 유저가 창을 닫거나 뒤로가기 버튼 클릭 시에도 배틀 종료 처리 추가
- 유저의 중복 배틀 참여 방지

## 💬 리뷰 요구사항

### 1. 테스트 어려움

초기에는 사용자가 배틀 진행 중이더라도 다른 페이지로 이동할 수 있도록 허용하고, 대신 메인 페이지에서만 게임 시작하기 버튼을 비활성화하는 방식을 고려했습니다.

그러나 재접속 대기 시간(10초) 정책을 함께 고려하면서 문제가 발생했습니다.
사용자가 배틀 도중 게임 창을 닫으면 10초간 재접속 타이머가 동작하게 되는데, 이 상태에서 사용자가 메인 페이지로 이동할 경우 10초 동안 버튼이 비활성화된 상태로 대기하게 되는 UX가 발생합니다. 그 초 동안은 아무것도 못 하는 상태가 됩니다.

이를 방지하기 위해, 사용자가 배틀 중일 경우 항상 해당 배틀 페이지로 강제 리다이렉트하도록 변경했습니다. 

다만 이 방식에는 테스트 측면에서의 제약이 존재합니다.
예를 들어, 로컬 환경에서 사용자1과 사용자2 계정으로 동시에 배틀을 진행할 경우, 사용자 토큰이 로컬스토리지에 저장되어 있기 때문에 새로운 탭을 열어도 즉시 배틀 페이지로 리다이렉트됩니다. 그 결과, 관전 페이지 등 배틀 외 페이지로 이동하여 테스트하는 것이 어려운 상황입니다.

해당 문제를 해결하기 위해 어떤 대안이 있을지 함께 고민해주시면 감사하겠습니다.

### 2. 연결 끊김 대기 시간

현재 배틀 도중 소켓 연결이 끊긴 경우, 즉시 배틀을 종료하지 않고 10초의 재접속 대기 시간을 두고 있습니다.

이는 단순 창 닫기뿐 아니라 새로고침, 일시적인 네트워크 끊김과 같은 상황에서도 사용자가 배틀에 정상적으로 복귀할 수 있도록 하기 위한 설정입니다.

대기 시간이 5초 등 더 짧을 경우, 일시적인 네트워크 끊김이나 브라우저 새로고침 상황에서도 사용자가 재접속하기 전에 배틀이 종료되어 버릴 가능성이 있습니다.

이에 재접속을 고려한 유예 시간으로 10초를 설정했는데,
이 값이 적절한지, 혹은 더 나은 기준이 있을지에 대해 의견을 부탁드립니다.
