### PR TITLE
[FEAT] 배틀 중 부정행위(치팅) 감지 및 알림 시스템 구현 (#229)

### DIFF
--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -33,6 +33,8 @@ export class RoomGateway {
   @WebSocketServer() server: Server;
   private rateLimitMap: Map<string, { count: number; windowStart: number; blockedUntil: number }> =
     new Map();
+  private cheatWarningMap: Map<string, number> = new Map();
+  private cheatCountMap: Map<string, number> = new Map();
   private readonly chatAuthErrorMessage = '로그인 후 채팅을 이용할 수 있습니다.';
 
   constructor(
@@ -420,6 +422,85 @@ export class RoomGateway {
     this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, chatMessage);
 
     return { success: true };
+  }
+
+  @SubscribeMessage(SOCKET_EVENT.CHEAT_WARNING)
+  async handleCheatWarning(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { roomId: string; type?: 'FOCUS_OUT' | 'PASTE' },
+  ) {
+    const { roomId, type } = data ?? {};
+    if (!roomId) return;
+
+    const room = await this.roomService.getRoom(roomId);
+    if (!room) return;
+
+    const participant =
+      room.currentPlayers.find((user) => user.socketId === client.id) ??
+      room.currentSpectators.find((user) => user.socketId === client.id);
+
+    if (!participant || participant.role !== 'player') {
+      return;
+    }
+
+    const now = Date.now();
+    const throttleKey = `${roomId}:${participant.userId}`;
+    const lastSent = this.cheatWarningMap.get(throttleKey) ?? 0;
+    if (now - lastSent < 1000) return;
+    this.cheatWarningMap.set(throttleKey, now);
+
+    const maxWarnings = 3;
+    const currentCount = this.cheatCountMap.get(throttleKey) ?? 0;
+    const nextCount = Math.min(maxWarnings, currentCount + 1);
+    this.cheatCountMap.set(throttleKey, nextCount);
+
+    const username = participant.username ?? '플레이어';
+    const reason = type === 'PASTE' ? '외부 코드 붙여넣기 시도' : '화면 이탈 감지';
+    const message = `[SYSTEM] ${username}님 부정행위 경고 ${nextCount}/${maxWarnings} (${reason})`;
+
+    const chatMessage: ChatMessage = {
+      type: CHAT_TYPE.SYSTEM,
+      nickname: 'SYSTEM',
+      message,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, chatMessage);
+
+    if (nextCount < maxWarnings) return;
+
+    try {
+      const battle = await this.battleService.getBattleByRoomId(roomId);
+      if (!battle) {
+        return;
+      }
+
+      const result = await this.battleService.forfeitBattle(battle.battleId, participant.userId);
+
+      this.server.to(roomId).emit(BATTLE_EVENTS.BATTLE_ENDED, {
+        battleId: result.id,
+        winnerId: result.winnerId,
+      });
+
+      const finalMessage: ChatMessage = {
+        type: CHAT_TYPE.SYSTEM,
+        nickname: 'SYSTEM',
+        message: `[SYSTEM] ${username}님이 부정행위 누적으로 패배 처리되었습니다.`,
+        timestamp: new Date().toISOString(),
+      };
+      this.server.to(roomId).emit(SOCKET_EVENT.RECEIVE_CHAT, finalMessage);
+
+      await this.roomService.completeBattleRoom(roomId);
+      const rooms = await this.roomService.listRooms();
+      const publicRooms = await this.roomService.toPublicRooms(rooms);
+      this.server.emit(SOCKET_EVENT.ROOM_LIST, publicRooms);
+
+      this.cheatCountMap.delete(throttleKey);
+      this.cheatWarningMap.delete(throttleKey);
+    } catch (error) {
+      console.error('[RoomGateway] cheat forfeit error:', error);
+      // 실패 시 카운트를 유지해 다음 경고에서 재시도
+    }
   }
 
   private sanitizeMessage(message: string): string {

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -1,3 +1,4 @@
+import type { OnMount } from '@monaco-editor/react';
 import { BATTLE_CONFIG, BATTLE_EVENTS, DEFAULT_CODE_TEMPLATE } from '@shared/constants/battle';
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { FinalResultMessage, TestcaseUpdateMessage } from '@shared/types/pubsub';
@@ -9,6 +10,7 @@ import { createDryRun, createSubmission } from '@/apis/submission';
 import EditorFooter from '@/components/Battle/Player/EditorFooter';
 import TestcaseResultPanel from '@/components/Battle/Player/TestcaseResultPanel';
 import BaseCodeEditor from '@/components/Common/BaseCodeEditor';
+import Toast from '@/components/Common/Toast';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
@@ -56,11 +58,15 @@ function CodeEditor() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [testcaseResults, setTestcaseResults] = useState<TestcaseResult[]>([]);
   const [mode, setMode] = useState<'TEST' | 'SUBMISSION' | null>(null);
+  const [pasteToastMessage, setPasteToastMessage] = useState<string | null>(null);
 
   const executionRef = useRef<ExecutionState | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasEditedRef = useRef(false);
   const hasSyncedRef = useRef(false);
+  const editorDomRef = useRef<HTMLElement | null>(null);
+  const pasteHandlerRef = useRef<((event: ClipboardEvent) => void) | null>(null);
+  const lastPasteAtRef = useRef(0);
   const problemId = useBattleProblemStore((state) => state.problem?.id ?? null);
   const battleId = useBattleProblemStore((state) => state.problem?.battleId ?? null);
 
@@ -78,6 +84,11 @@ function CodeEditor() {
   useEffect(() => {
     return () => {
       clearExecutionTimeout();
+      const dom = editorDomRef.current;
+      const handler = pasteHandlerRef.current;
+      if (dom && handler) {
+        dom.removeEventListener('paste', handler, true);
+      }
     };
   }, []);
 
@@ -342,6 +353,29 @@ function CodeEditor() {
 
   const progressLabel = progress ? `${progress.passed}/${progress.total}` : '0/0';
 
+  const handleEditorMount: OnMount = (editor) => {
+    const domNode = editor.getDomNode();
+    if (!domNode) return;
+
+    editorDomRef.current = domNode;
+    const handlePaste = (event: ClipboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const now = Date.now();
+      if (now - lastPasteAtRef.current < 1000) return;
+      lastPasteAtRef.current = now;
+      setPasteToastMessage('외부 코드 붙여넣기는 금지되어 있습니다! 🚫');
+
+      const activeSocket = socket ?? connect();
+      if (activeSocket?.connected) {
+        activeSocket.emit(SOCKET_EVENT.CHEAT_WARNING, { roomId, type: 'PASTE' });
+      }
+    };
+
+    pasteHandlerRef.current = handlePaste;
+    domNode.addEventListener('paste', handlePaste, true);
+  };
+
   return (
     <>
       <section className="flex flex-col overflow-hidden rounded-2xl bg-(--bg-layer-2) border border-border-soft text-base-primary xl:h-full xl:min-h-0">
@@ -356,6 +390,7 @@ function CodeEditor() {
           <BaseCodeEditor
             value={code}
             onChange={(value) => handleChange(value || '')}
+            onMount={handleEditorMount}
             options={{
               quickSuggestions: false, // 자동 완성 비활성화
               suggestOnTriggerCharacters: false, // 트리거 문자 입력 시 자동 완성 비활성화
@@ -374,6 +409,9 @@ function CodeEditor() {
         />
         <TestcaseResultPanel testcaseResults={testcaseResults} mode={mode} />
       </section>
+      {pasteToastMessage && (
+        <Toast message={pasteToastMessage} onClose={() => setPasteToastMessage(null)} />
+      )}
     </>
   );
 }

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -1,7 +1,8 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
-import { SOCKET_ERROR } from '@shared/constants/socket-event';
+import { SOCKET_ERROR, SOCKET_EVENT } from '@shared/constants/socket-event';
+import type { ChatMessage } from '@shared/types/chat';
 import { AlertCircle } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useBlocker, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import BattleFinishOverlay from '@/components/Battle/BattleFinishOverlay';
@@ -9,6 +10,7 @@ import BattleHeader from '@/components/Battle/BattleHeader';
 import BattlePlayer from '@/components/Battle/Player/BattlePlayer';
 import BattleSpectator from '@/components/Battle/Spectator/BattleSpectator';
 import Modal from '@/components/Common/Modal';
+import Toast from '@/components/Common/Toast';
 import { useTheme } from '@/hooks/useTheme';
 import { playCountdownSound } from '@/lib/sound';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
@@ -46,6 +48,8 @@ function BattlePage() {
   const [roleModalReason, setRoleModalReason] = useState<
     'player-to-spectator' | 'spectator-to-player' | 'not-authorized-player' | null
   >(null);
+  const [systemToastMessage, setSystemToastMessage] = useState<string | null>(null);
+  const lastCheatSentAtRef = useRef(0);
 
   const [showFinishOverlay, setShowFinishOverlay] = useState(false);
   const [showLeaveModal, setShowLeaveModal] = useState(false);
@@ -198,6 +202,55 @@ function BattlePage() {
       unsubscribeRoomAvailability();
     };
   }, [requestRoomAvailability, roomId, subscribeRoomAvailability, unsubscribeRoomAvailability]);
+
+  useEffect(() => {
+    if (effectiveRole !== 'player') return;
+    if (!roomId) return;
+
+    const socket = connect();
+    const emitCheatWarning = (type: 'FOCUS_OUT' | 'PASTE') => {
+      if (!socket?.connected) return;
+      const now = Date.now();
+      if (now - lastCheatSentAtRef.current < 1000) return;
+      lastCheatSentAtRef.current = now;
+      socket.emit(SOCKET_EVENT.CHEAT_WARNING, { roomId, type });
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        emitCheatWarning('FOCUS_OUT');
+      }
+    };
+
+    const handleBlur = () => {
+      emitCheatWarning('FOCUS_OUT');
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('blur', handleBlur);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [connect, effectiveRole, roomId]);
+
+  useEffect(() => {
+    const socket = connect();
+    const handleSystemMessage = (message: ChatMessage) => {
+      if (effectiveRole !== 'player') return;
+      if (message.type !== 'SYSTEM') return;
+      if (!message.message.includes('부정행위 경고') && !message.message.includes('패배 처리')) {
+        return;
+      }
+      setSystemToastMessage(message.message);
+    };
+
+    socket.on(SOCKET_EVENT.RECEIVE_CHAT, handleSystemMessage);
+    return () => {
+      socket.off(SOCKET_EVENT.RECEIVE_CHAT, handleSystemMessage);
+    };
+  }, [connect, effectiveRole]);
 
   useEffect(() => {
     if (isRoleModalOpen || isRoleMismatch) return;
@@ -381,6 +434,9 @@ function BattlePage() {
         ]}
         closeOnBackdrop={false}
       />
+      {systemToastMessage && (
+        <Toast message={systemToastMessage} onClose={() => setSystemToastMessage(null)} />
+      )}
     </div>
   );
 }

--- a/packages/constants/socket-event.ts
+++ b/packages/constants/socket-event.ts
@@ -21,6 +21,7 @@ export const SOCKET_EVENT = {
   LEAVE_ROOM: 'leave-room', // 방 나가기
   SEND_CHAT: 'send-chat', // 관전자 채팅 전송
   ROOM_LIST_REQUEST: 'room-list-request', // 방 목록 요청
+  CHEAT_WARNING: 'cheat-warning', // 부정행위(화면 이탈/붙여넣기) 경고 알림
 
   // --- Server -> Client (응답/알림) ---
   ROOM_AVAILABILITY: 'room-availability', // 방 인원 확인 결과


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

배틀 중 화면 이탈/붙여넣기 부정행위를 감지하고 경고 누적 시 패배 처리하는 로직을 추가했습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #229 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- CHEAT_WARNING 소켓 이벤트 정의 및 전송 로직 추가
- 플레이어 화면 이탈(blur/visibilitychange) 감지 후 경고 전송
- 코드 에디터 붙여넣기 차단 + 경고 토스트 표시
- 서버에서 경고 누적 관리 및 3회 누적 시 forfeitBattle로 패배 처리
- 경고/패배 SYSTEM 메시지를 채팅으로 브로드캐스트

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

<img width="1849" height="929" alt="스크린샷 2026-01-29 오후 5 30 38" src="https://github.com/user-attachments/assets/68c12fac-c72d-402e-9b3a-d59fc00d5286" />


<img width="384" height="708" alt="스크린샷 2026-01-29 오후 5 29 13" src="https://github.com/user-attachments/assets/d891842e-4dd8-4969-a303-ea00f405a2cc" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

공정한 배틀 환경을 위해 부정행위를 감지하고 즉시 알림/패널티를 적용하도록 개선했습니다.

## 💬 리뷰 요구사항(선택)

경고 카운트(3회)가 적절한지, 또는 다른 정책이 필요한지 의견 부탁드립니다.