### PR TITLE
[FEAT]  마이페이지용 배틀 및 제출 이력 조회 API 구현 (#231)

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,4 +1,4 @@
-import apiConfig from '@web30/eslint-config/api';
+import { default as apiConfig, testConfig } from '@web30/eslint-config/api';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -7,6 +7,7 @@ const __dirname = path.dirname(__filename);
 
 export default [
   ...apiConfig,
+  testConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/apps/api/src/submission/submission.controller.ts
+++ b/apps/api/src/submission/submission.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Headers, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { User } from '../user/user.entity';
@@ -29,5 +39,18 @@ export class SubmissionController {
   ) {
     const userId = req.user.id;
     return this.submissionService.executeTest(dto, userId, socketId);
+  }
+
+  @Get(':submissionId')
+  @UseGuards(AuthGuard('jwt'))
+  async getSubmissionDetail(
+    @Req() req: { user: User },
+    @Param('submissionId') submissionId: string,
+  ) {
+    const detail = await this.submissionService.getSubmissionDetail(submissionId, req.user.id);
+    if (!detail) {
+      throw new NotFoundException('존재하지 않는 데이터이거나 내 기록이 아닙니다.');
+    }
+    return detail;
   }
 }

--- a/apps/api/src/submission/submission.module.ts
+++ b/apps/api/src/submission/submission.module.ts
@@ -2,13 +2,15 @@ import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { Problem } from '@/problem/problem.entity';
+
 import { SubmissionController } from './submission.controller';
 import { Submission } from './submission.entity';
 import { SubmissionService } from './submission.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Submission]),
+    TypeOrmModule.forFeature([Submission, Problem]),
     BullModule.registerQueue({
       name: 'submission-queue',
     }),

--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -1,8 +1,11 @@
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { SubmissionDetail } from '@packages/types/submission';
 import type { Queue } from 'bullmq';
 import type { Repository } from 'typeorm';
+
+import { Problem } from '@/problem/problem.entity';
 
 import { CreateSubmissionDto } from './create-submission.dto';
 import { Submission } from './submission.entity';
@@ -12,10 +15,51 @@ export class SubmissionService {
   constructor(
     @InjectRepository(Submission)
     private submissionRepository: Repository<Submission>,
+    @InjectRepository(Problem)
+    private problemRepository: Repository<Problem>,
 
     @InjectQueue('submission-queue')
     private submissionQueue: Queue,
   ) {}
+
+  async getSubmissionDetail(
+    submissionId: string,
+    userId: string,
+  ): Promise<SubmissionDetail | null> {
+    const submission = await this.submissionRepository.findOne({
+      where: { id: submissionId, userId },
+    });
+
+    if (!submission) {
+      return null;
+    }
+
+    const problem = await this.problemRepository.findOne({
+      where: { id: submission.problemId },
+    });
+
+    if (!problem) {
+      return null;
+    }
+
+    return {
+      id: submission.id,
+      code: submission.code,
+      language: submission.language,
+      problem: {
+        title: problem.title,
+        source: problem.source,
+        difficulty: problem.difficulty,
+        tags: problem.tags,
+        timeLimit: problem.timeLimit,
+        memoryLimit: problem.memoryLimit,
+        statement: problem.statement,
+        input: problem.input,
+        output: problem.output,
+        examples: problem.examples,
+      },
+    };
+  }
 
   async submit(dto: CreateSubmissionDto, userId: string, socketId: string) {
     // DB에 저장

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -17,4 +17,10 @@ export class UserController {
       currentRoomId,
     };
   }
+
+  @Get('me/battles')
+  @UseGuards(AuthGuard('jwt'))
+  async getMyBattles(@Req() req: { user: User }) {
+    return this.userService.getBattleHistory(req.user.id);
+  }
 }

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -23,4 +23,10 @@ export class UserController {
   async getMyBattles(@Req() req: { user: User }) {
     return this.userService.getBattleHistory(req.user.id);
   }
+
+  @Get('me/submissions')
+  @UseGuards(AuthGuard('jwt'))
+  async getMySubmissions(@Req() req: { user: User }) {
+    return this.userService.getSubmissionHistory(req.user.id);
+  }
 }

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { Battle } from '@/battle/battle.entity';
+import { Problem } from '@/problem/problem.entity';
+import { Submission } from '@/submission/submission.entity';
+
 import { UserController } from './user.controller';
 import { User } from './user.entity';
 import { UserService } from './user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, Battle, Submission, Problem])],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { clampRating, getTierFromRating, RATING_CONFIG } from '@packages/constants/rating';
-import { BattleHistoryItem } from '@packages/types/user';
+import { BattleHistoryItem, SubmissionHistoryItem } from '@packages/types/user';
 import { Glicko2, newProcedure } from 'glicko2.ts';
 import Redis from 'ioredis';
 import { Repository } from 'typeorm';
@@ -227,5 +227,48 @@ export class UserService {
     );
 
     return historyWithDetails;
+  }
+
+  // 마이페이지 제출 이력 조회
+  async getSubmissionHistory(userId: string): Promise<SubmissionHistoryItem[]> {
+    const submissions = await this.submissionRepository
+      .createQueryBuilder('submission')
+      .innerJoin(Problem, 'problem', 'submission.problemId = problem.id')
+      .select([
+        'submission.id AS id',
+        'submission.problemId AS problemId',
+        'submission.createdAt AS createdAt',
+        'problem.title AS problemTitle',
+        'problem.difficulty AS difficulty',
+      ])
+      .where('submission.userId = :userId', { userId })
+      .andWhere((qb) => {
+        const subQuery = qb
+          .subQuery()
+          .select('MAX(innerSub.id)')
+          .from(Submission, 'innerSub')
+          .where('innerSub.userId = :userId')
+          .groupBy('innerSub.battleId')
+          .getQuery();
+        return `submission.id IN ${subQuery}`;
+      })
+      .orderBy('submission.createdAt', 'DESC')
+      .getRawMany();
+
+    return submissions.map(
+      (sub: {
+        id: string;
+        problemId: string;
+        problemTitle: string;
+        difficulty: string;
+        createdAt: string;
+      }) => ({
+        id: sub.id,
+        problemId: sub.problemId,
+        problemTitle: sub.problemTitle,
+        difficulty: sub.difficulty,
+        createdAt: new Date(sub.createdAt),
+      }),
+    );
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,12 +1,16 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { clampRating, getTierFromRating, RATING_CONFIG } from '@packages/constants/rating';
+import { BattleHistoryItem } from '@packages/types/user';
 import { Glicko2, newProcedure } from 'glicko2.ts';
 import Redis from 'ioredis';
 import { Repository } from 'typeorm';
 
+import { Battle } from '@/battle/battle.entity';
+import { Problem } from '@/problem/problem.entity';
 import { REDIS_CLIENT } from '@/redis/redis.module';
 import { RedisKeys } from '@/redis/redis-key.constant';
+import { Submission } from '@/submission/submission.entity';
 
 import { User } from './user.entity';
 
@@ -35,6 +39,12 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @InjectRepository(Battle)
+    private readonly battleRepository: Repository<Battle>,
+    @InjectRepository(Submission)
+    private readonly submissionRepository: Repository<Submission>,
+    @InjectRepository(Problem)
+    private readonly problemRepository: Repository<Problem>,
     @Inject(REDIS_CLIENT) private readonly redis: Redis,
   ) {
     this.glicko2 = new Glicko2({
@@ -154,5 +164,68 @@ export class UserService {
       this.logger.error(`Error fetching user room status: ${userId}`, error);
       return null;
     }
+  }
+
+  // 사용자 배틀 기록 조회
+  async getBattleHistory(userId: string): Promise<BattleHistoryItem[]> {
+    const battles = await this.battleRepository
+      .createQueryBuilder('battle')
+      .where('FIND_IN_SET(:userId, battle.playerIds) > 0', { userId })
+      .orderBy('battle.createdAt', 'DESC')
+      .getMany();
+
+    const historyWithDetails = await Promise.all(
+      battles.map(async (battle) => {
+        // 결과 판별
+        let result: 'WIN' | 'LOSS' | 'DRAW' = 'DRAW';
+        if (battle.winnerId) {
+          result = battle.winnerId === userId ? 'WIN' : 'LOSS';
+        }
+
+        // 상대방 이름
+        const opponentId = battle.playerIds.find((id) => id !== userId);
+        const opponent = opponentId
+          ? await this.userRepository.findOne({ where: { id: opponentId }, select: ['username'] })
+          : null;
+
+        // 문제 정보
+        const problem = await this.problemRepository.findOne({
+          where: { id: battle.problemId },
+          select: ['title', 'difficulty', 'testcases'],
+        });
+
+        // 내 최종 제출 정보
+        const mySubmission = await this.submissionRepository.findOne({
+          where: { userId, battleId: battle.id },
+          order: { createdAt: 'DESC' },
+        });
+
+        // 점수 변화량
+        const playerIndex = battle.playerIds.indexOf(userId);
+        const ratingChange =
+          playerIndex === 0 ? battle.player1RatingChange : battle.player2RatingChange;
+
+        return {
+          id: battle.id,
+          result,
+          opponentName: opponent?.username || '알 수 없는 유저',
+          problem: {
+            title: problem?.title || '삭제된 문제',
+            difficulty: problem?.difficulty || 'Unknown',
+          },
+          submission: mySubmission
+            ? {
+                language: mySubmission.language,
+                passedTestCases: mySubmission.passedTestCases,
+                totalTestCases: mySubmission.totalTestCases ?? (problem?.testcases?.length || 0),
+              }
+            : null,
+          ratingChange: ratingChange || 0,
+          createdAt: battle.createdAt,
+        };
+      }),
+    );
+
+    return historyWithDetails;
   }
 }

--- a/apps/api/test/battle/battle.service.spec.ts
+++ b/apps/api/test/battle/battle.service.spec.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import RedisMock from 'ioredis-mock';

--- a/apps/api/test/matching/matching-scheduler.service.spec.ts
+++ b/apps/api/test/matching/matching-scheduler.service.spec.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { MatchingUser } from '@packages/types/matching';
 

--- a/apps/api/test/matching/matching.gateway.spec.ts
+++ b/apps/api/test/matching/matching.gateway.spec.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { SOCKET_EVENT } from '@packages/constants/socket-event';
 import { Battle } from '@packages/types/battle';

--- a/apps/api/test/matching/matching.service.spec.ts
+++ b/apps/api/test/matching/matching.service.spec.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { MATCHING_CONFIG } from '@packages/constants/matching';
 import { MatchingUser } from '@packages/types/matching';

--- a/apps/api/test/submission/submission.service.spec.ts
+++ b/apps/api/test/submission/submission.service.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { getQueueToken } from '@nestjs/bullmq';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';

--- a/apps/api/test/submission/submission.service.spec.ts
+++ b/apps/api/test/submission/submission.service.spec.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { Problem } from '@/problem/problem.entity';
+import { Submission } from '@/submission/submission.entity';
+import { SubmissionService } from '@/submission/submission.service';
+
+describe('SubmissionService', () => {
+  let service: SubmissionService;
+  let submissionRepository: any;
+  let problemRepository: any;
+
+  beforeEach(async () => {
+    submissionRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+    problemRepository = {
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubmissionService,
+        {
+          provide: getRepositoryToken(Submission),
+          useValue: submissionRepository,
+        },
+        {
+          provide: getRepositoryToken(Problem),
+          useValue: problemRepository,
+        },
+        {
+          provide: getQueueToken('submission-queue'),
+          useValue: {
+            add: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SubmissionService>(SubmissionService);
+  });
+
+  describe('getSubmissionDetail', () => {
+    it('제출 상세 정보를 정상적으로 반환해야 한다', async () => {
+      const submissionId = 'sub-1';
+      const userId = 'user-1';
+      const mockSubmission = {
+        id: submissionId,
+        userId: userId,
+        problemId: 'prob-1',
+        code: 'console.log("hello")',
+        language: 'javascript',
+      };
+      const mockProblem = {
+        id: 'prob-1',
+        title: 'Problem Title',
+        source: 'Source',
+        difficulty: 'Bronze',
+        tags: ['tag1'],
+        timeLimit: 1,
+        memoryLimit: 256,
+        statement: 'Statement',
+        input: 'Input',
+        output: 'Output',
+        note: 'Note',
+        examples: [{ input: 'ex-in', output: 'ex-out' }],
+      };
+
+      submissionRepository.findOne.mockResolvedValue(mockSubmission);
+      problemRepository.findOne.mockResolvedValue(mockProblem);
+
+      const result = await service.getSubmissionDetail(submissionId, userId);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(submissionId);
+      expect(result?.code).toBe(mockSubmission.code);
+      expect(result?.problem.title).toBe(mockProblem.title);
+      expect(submissionRepository.findOne).toHaveBeenCalledWith({
+        where: { id: submissionId, userId },
+      });
+    });
+
+    it('본인의 제출 기록이 아니면 null을 반환해야 한다', async () => {
+      const submissionId = 'sub-1';
+      const userId = 'other-user';
+
+      submissionRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getSubmissionDetail(submissionId, userId);
+
+      expect(result).toBeNull();
+    });
+
+    it('연관된 문제 정보가 없으면 null을 반환해야 한다', async () => {
+      const submissionId = 'sub-1';
+      const userId = 'user-1';
+      const mockSubmission = {
+        id: submissionId,
+        userId: userId,
+        problemId: 'prob-not-found',
+      };
+
+      submissionRepository.findOne.mockResolvedValue(mockSubmission);
+      problemRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getSubmissionDetail(submissionId, userId);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/test/user/user.service.spec.ts
+++ b/apps/api/test/user/user.service.spec.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { Battle } from '@/battle/battle.entity';
+import { Problem } from '@/problem/problem.entity';
+import { REDIS_CLIENT } from '@/redis/redis.module';
+import { Submission } from '@/submission/submission.entity';
+import { User } from '@/user/user.entity';
+import { UserService } from '@/user/user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+  let userRepository: any;
+  let battleRepository: any;
+  let submissionRepository: any;
+  let problemRepository: any;
+
+  beforeEach(async () => {
+    userRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+    battleRepository = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+    };
+    submissionRepository = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+    };
+    problemRepository = {
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserService,
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: getRepositoryToken(Battle), useValue: battleRepository },
+        { provide: getRepositoryToken(Submission), useValue: submissionRepository },
+        { provide: getRepositoryToken(Problem), useValue: problemRepository },
+        { provide: REDIS_CLIENT, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  describe('getBattleHistory', () => {
+    it('사용자의 배틀 기록 목록을 정상적으로 반환해야 한다', async () => {
+      const userId = 'user-1';
+      const mockBattles = [
+        {
+          id: 'battle-1',
+          playerIds: ['user-1', 'user-2'],
+          winnerId: 'user-1',
+          problemId: 'prob-1',
+          player1RatingChange: 15,
+          player2RatingChange: -15,
+          createdAt: new Date(),
+        },
+      ];
+
+      const queryBuilder: any = {
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockBattles),
+      };
+
+      battleRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+      userRepository.findOne.mockResolvedValue({ username: 'Opponent' });
+      problemRepository.findOne.mockResolvedValue({
+        title: 'Problem Title',
+        difficulty: 'Gold',
+        testcases: [{}, {}, {}],
+      });
+      submissionRepository.findOne.mockResolvedValue({
+        language: 'typescript',
+        passedTestCases: 3,
+        totalTestCases: 3,
+      });
+
+      const result = await service.getBattleHistory(userId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].result).toBe('WIN');
+      expect(result[0].opponentName).toBe('Opponent');
+      expect(result[0].problem.title).toBe('Problem Title');
+      expect(result[0].ratingChange).toBe(15);
+      expect(result[0].submission?.passedTestCases).toBe(3);
+    });
+
+    it('배틀 결과가 무승부일 경우 DRAW로 반환해야 한다', async () => {
+      const userId = 'user-1';
+      const mockBattles = [
+        {
+          id: 'battle-2',
+          playerIds: ['user-1', 'user-2'],
+          winnerId: null,
+          problemId: 'prob-1',
+          player1RatingChange: 0,
+          createdAt: new Date(),
+        },
+      ];
+
+      const queryBuilder: any = {
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockBattles),
+      };
+
+      battleRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+      userRepository.findOne.mockResolvedValue({ username: 'Opponent' });
+      problemRepository.findOne.mockResolvedValue({ title: 'Title' });
+      submissionRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getBattleHistory(userId);
+
+      expect(result[0].result).toBe('DRAW');
+      expect(result[0].submission).toBeNull();
+    });
+  });
+});

--- a/apps/api/test/user/user.service.spec.ts
+++ b/apps/api/test/user/user.service.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 

--- a/apps/api/test/user/user.service.spec.ts
+++ b/apps/api/test/user/user.service.spec.ts
@@ -123,4 +123,40 @@ describe('UserService', () => {
       expect(result[0].submission).toBeNull();
     });
   });
+
+  describe('getSubmissionHistory', () => {
+    it('사용자의 최종 제출 이력을 정상적으로 반환해야 한다 (중복 제거 확인)', async () => {
+      const userId = 'user-1';
+      const mockSubmissions = [
+        {
+          id: 'sub-2',
+          problemId: 'prob-1',
+          problemTitle: 'Problem 1',
+          difficulty: 'Gold',
+          createdAt: new Date(),
+        },
+      ];
+
+      const queryBuilder: any = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(mockSubmissions),
+        subQuery: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getQuery: jest.fn().mockReturnValue('(SELECT MAX(id) FROM submission GROUP BY battleId)'),
+      };
+
+      submissionRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+      const result = await service.getSubmissionHistory(userId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('sub-2');
+      expect(result[0].problemTitle).toBe('Problem 1');
+    });
+  });
 });

--- a/apps/judge/eslint.config.mjs
+++ b/apps/judge/eslint.config.mjs
@@ -1,4 +1,4 @@
-import apiConfig from '@web30/eslint-config/api';
+import { default as apiConfig, testConfig } from '@web30/eslint-config/api';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -7,6 +7,7 @@ const __dirname = path.dirname(__filename);
 
 export default [
   ...apiConfig,
+  testConfig,
   {
     languageOptions: {
       parserOptions: {

--- a/apps/judge/test/judge/judge.context.spec.ts
+++ b/apps/judge/test/judge/judge.context.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/unbound-method */
 import { JudgeChecker } from '../../src/judge/judge.checker';
 import { JudgeContext } from '../../src/judge/judge.context';
 import { JudgeReader } from '../../src/judge/judge.reader';

--- a/apps/judge/test/judge/judge.service.spec.ts
+++ b/apps/judge/test/judge/judge.service.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { JudgeChecker } from '../../src/judge/judge.checker';

--- a/apps/judge/test/submission/submission.integration.spec.ts
+++ b/apps/judge/test/submission/submission.integration.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/unbound-method */
-
 import { getQueueToken } from '@nestjs/bullmq';
 import { Test, TestingModule } from '@nestjs/testing';
 

--- a/apps/judge/test/submission/submission.processor.spec.ts
+++ b/apps/judge/test/submission/submission.processor.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { Job } from 'bullmq';
 

--- a/packages/eslint-config/api.js
+++ b/packages/eslint-config/api.js
@@ -29,3 +29,15 @@ export default [
     },
   },
 ];
+
+export const testConfig = {
+  files: ['**/*.spec.ts', '**/*.test.ts'],
+  rules: {
+    '@typescript-eslint/no-unsafe-assignment': 'off',
+    '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/unbound-method': 'off',
+  },
+};

--- a/packages/types/submission.ts
+++ b/packages/types/submission.ts
@@ -1,0 +1,17 @@
+export interface SubmissionDetail {
+  id: string;
+  code: string;
+  language: string;
+  problem: {
+    title: string;
+    source: string;
+    difficulty: string;
+    tags: string[];
+    timeLimit: number;
+    memoryLimit: number;
+    statement: string;
+    input: string;
+    output: string;
+    examples: { input: string; output: string }[];
+  };
+}

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -41,3 +41,11 @@ export interface BattleHistoryItem {
   ratingChange: number;
   createdAt: Date;
 }
+
+export interface SubmissionHistoryItem {
+  id: string;
+  problemId: string;
+  problemTitle: string;
+  difficulty: string;
+  createdAt: Date;
+}

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -24,3 +24,20 @@ export interface RoomUser extends User {
   stats?: UserStats;
   progress?: { passedCount: number; totalCount: number };
 }
+
+export interface BattleHistoryItem {
+  id: string;
+  result: 'WIN' | 'LOSS' | 'DRAW';
+  opponentName: string;
+  problem: {
+    title: string;
+    difficulty: string;
+  };
+  submission: {
+    language: string;
+    passedTestCases: number;
+    totalTestCases: number;
+  } | null;
+  ratingChange: number;
+  createdAt: Date;
+}


### PR DESCRIPTION
## 🔍 PR 요약

- 마이페이지용 배틀 및 제출 이력 조회 API 구현

## 🧾 관련 이슈

- close #231 

## 🛠️ 주요 변경 사항

- 사용자 배틀 기록 조회 (GET /api/users/me/battles)
  - 유저가 참여한 모든 배틀의 결과(승/패/무), 상대방 정보, 획득한 레이팅 변화량 조회

- 제출 이력 조회 (GET /api/users/me/submissions)
  - 유저가 참여한 각 배틀별 최종 제출본들만을 필터링하여 리스트업
  - DB 서브쿼리를 사용하여 중복된 시도 제거, 각 문제별 가장 마지막 제출한 기록만 노출

- 제출 상세 정보 조회 (GET /api/submissions/:id)
  - 특정 제출 기록의 소스 코드와 해당 문제의 상세 데이터(제목, 설명, 예제 등) 조회
  - 요청한 제출 기록의 소유자가 현재 로그인한 사용자와 일치하는지 검증

- 테스트 코드 추가
  - UserService : 배틀 결과 판별 및 제출 이력 필터링 로직에 대한 단위 테스트 추가
  - SubmissionService : 상세 조회 기능 및 소유권 검증 로직에 대한 단위 테스트 추가

- 테스트용 린트 공통 설정 (/packages/eslint-config/api.js)
  - 기존 테스트 코드에 많은 린트 주석 존재
  - 이에 테스트용에서는 린트 해제 설정 추가

## 🧠 의도 및 배경

- 사용자가 자신의 과거 학습 및 대결 기록을 복기할 수 있도록 마이페이지용 백엔드 API 구현

## 💬 리뷰 요구사항
