### PR TITLE
[REFACTOR] BattleHeader 불필요한 리렌더 줄이기 (#258)

### DIFF
--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -1,11 +1,9 @@
-import { BATTLE_EVENTS } from '@shared/constants/battle';
-import { motion } from 'framer-motion';
-import { Eye, Moon, Settings, Sun, Timer, Volume2, VolumeX } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { Eye, Moon, Settings, Sun, Volume2, VolumeX } from 'lucide-react';
+import { useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import logo from '@/assets/logo.webp';
-import { playCountdownSound } from '@/lib/sound';
+import BattleTimer from '@/components/Battle/BattleTimer';
 import { playPreviewSound } from '@/lib/sound';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
@@ -41,50 +39,6 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
   const duration = problem?.duration;
   const startedAt = problem?.startedAt;
 
-  const [timeLeft, setTimeLeft] = useState<number>(0);
-  const [hasEmittedEnd, setHasEmittedEnd] = useState(false);
-  const hasPlayedCountdownRef = useRef(false);
-
-  useEffect(() => {
-    if (!startedAt || !duration) return;
-
-    const startTime = new Date(startedAt).getTime();
-    const endTime = startTime + duration * 1000;
-
-    const updateTimer = () => {
-      // 서버 시간 추정: 클라이언트 시간 + 오프셋
-      const now = Date.now() + timeOffset;
-      const remaining = Math.max(0, Math.floor((endTime - now) / 1000));
-      setTimeLeft(remaining);
-
-      // 5초 시점에 효과음 시작 (한 번만)
-      if (remaining === 5 && !hasPlayedCountdownRef.current) {
-        hasPlayedCountdownRef.current = true;
-        playCountdownSound('tick');
-      }
-
-      if (remaining <= 0 && !hasEmittedEnd) {
-        // 타이머 종료 처리
-        const socket = useBattleSocketStore.getState().socket;
-        if (socket && battleId) {
-          socket.emit(BATTLE_EVENTS.TIMER_END, { battleId, roomId });
-          setHasEmittedEnd(true);
-        }
-      }
-    };
-
-    updateTimer();
-    const interval = setInterval(updateTimer, 1000);
-
-    return () => clearInterval(interval);
-  }, [startedAt, duration, timeOffset, hasEmittedEnd, battleId, roomId]);
-
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  };
-
   return (
     <header className="relative z-50 flex w-full items-center justify-between rounded-2xl px-5 text-base-primary backdrop-blur dark:shadow-slate-950/40">
       <div className="flex items-center gap-3">
@@ -93,24 +47,13 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
       </div>
 
       <div className="flex items-center gap-3">
-        <motion.div
-          animate={
-            timeLeft <= 5 && timeLeft > 0
-              ? {
-                  scale: [1, 1.05, 1],
-                  transition: { repeat: Infinity, duration: 0.8 },
-                }
-              : { scale: 1 }
-          }
-          className={`flex items-center gap-2 rounded-3xl px-4 py-1 text-lg font-bold shadow-[1px_1px_4px_rgba(0,0,0,0.05)] transition-colors duration-300 ${
-            timeLeft <= 5 && timeLeft > 0
-              ? 'bg-red-50 text-error-01 dark:bg-error-01/10'
-              : 'bg-green-01 text-green-06'
-          }`}
-        >
-          <Timer className="h-5 w-5" strokeWidth={2.5} />
-          <span className="font-bold leading-7">{formatTime(timeLeft)}</span>
-        </motion.div>
+        <BattleTimer
+          battleId={battleId}
+          duration={duration}
+          startedAt={startedAt}
+          timeOffset={timeOffset}
+          roomId={roomId}
+        />
       </div>
 
       <div className="flex items-center gap-3">

--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -1,13 +1,12 @@
-import { Eye, Moon, Settings, Sun, Volume2, VolumeX } from 'lucide-react';
+import { Moon, Settings, Sun, Volume2, VolumeX } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useShallow } from 'zustand/react/shallow';
 
 import logo from '@/assets/logo.webp';
 import BattleTimer from '@/components/Battle/BattleTimer';
+import SpectatorCountBadge from '@/components/Battle/SpectatorCountBadge';
 import { playPreviewSound } from '@/lib/sound';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
-import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useSoundStore } from '@/stores/soundStore';
 
 interface BattleHeaderProps {
@@ -20,11 +19,6 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
   const { roomId } = useParams<{ roomId: string }>();
   const problem = useBattleProblemStore((state) => state.problem);
   const timeOffset = useBattleProblemStore((state) => state.timeOffset);
-  const { spectatorCount } = useBattleSocketStore(
-    useShallow((state) => ({
-      spectatorCount: state.spectatorCount,
-    })),
-  );
 
   const {
     volume,
@@ -66,10 +60,7 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
       </div>
 
       <div className="flex items-center gap-3">
-        <div className="inline-flex items-center gap-1.5 rounded-full bg-base-faint px-5 py-2 text-sm font-medium text-base-primary">
-          <Eye className="h-4 w-4 text-base-secondary" strokeWidth={2.5} />
-          <span className="text-base-primary">{spectatorCount}</span>
-        </div>
+        <SpectatorCountBadge />
         <button
           onClick={onLeaveClick}
           className="inline-flex h-10 w-20 items-center justify-center rounded-full bg-base-faint text-sm font-bold text-base-primary transition hover:brightness-110"

--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -1,13 +1,11 @@
-import { Moon, Settings, Sun, Volume2, VolumeX } from 'lucide-react';
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import logo from '@/assets/logo.webp';
+import BattleSettingsMenu from '@/components/Battle/BattleSettingsMenu';
 import BattleTimer from '@/components/Battle/BattleTimer';
 import SpectatorCountBadge from '@/components/Battle/SpectatorCountBadge';
-import { playPreviewSound } from '@/lib/sound';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
-import { useSoundStore } from '@/stores/soundStore';
 
 interface BattleHeaderProps {
   theme: 'light' | 'dark';
@@ -20,27 +18,9 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
   const problem = useBattleProblemStore((state) => state.problem);
   const timeOffset = useBattleProblemStore((state) => state.timeOffset);
 
-  const {
-    volume,
-    isMuted,
-    setVolume,
-    toggleMute,
-    bgmVolume,
-    isBgmMuted,
-    setBgmVolume,
-    toggleBgmMute,
-  } = useSoundStore();
-  const isBgmSilent = isBgmMuted || bgmVolume <= 0;
-  const [isSettingOpen, setIsSettingOpen] = useState(false);
-  const settingRef = useRef<HTMLDivElement>(null);
-
   const battleId = problem?.battleId;
   const duration = problem?.duration;
   const startedAt = problem?.startedAt;
-
-  const handleToggleSetting = useCallback(() => {
-    setIsSettingOpen((prev) => !prev);
-  }, []);
 
   return (
     <header className="relative z-50 flex w-full items-center justify-between rounded-2xl px-5 text-base-primary backdrop-blur dark:shadow-slate-950/40">
@@ -67,82 +47,7 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
         >
           나가기
         </button>
-        <div className="relative" ref={settingRef}>
-          <button
-            onClick={handleToggleSetting}
-            className="rounded-full bg-base-faint p-2 text-ink shadow-sm transition hover:scale-110 active:scale-95"
-          >
-            <Settings size={24} className="text-slate-400" />
-          </button>
-          {isSettingOpen && (
-            <div className="absolute right-0 mt-3 w-48 origin-top-right rounded-24 bg-bg-layer-2 p-2 shadow-2xl focus:outline-none transition-all duration-200 ease-out z-[100]">
-              <div className="flex flex-col gap-1">
-                <button
-                  onClick={toggleTheme}
-                  className="flex items-center gap-3 rounded-24 px-4 py-2 text-sm text-ink transition hover:bg-base-muted"
-                  aria-label="Toggle theme"
-                >
-                  {theme === 'dark' ? (
-                    <>
-                      <Sun size={18} />
-                      <span>라이트 모드</span>
-                    </>
-                  ) : (
-                    <>
-                      <Moon size={18} />
-                      <span>다크 모드</span>
-                    </>
-                  )}
-                </button>
-                <div className="my-1 h-[1px] bg-border-soft" />
-                <div className="px-4 pt-2 text-[11px] font-semibold text-base-secondary">
-                  효과음
-                </div>
-                <div className="flex items-center gap-3 px-4 py-2">
-                  <button
-                    onClick={toggleMute}
-                    className="text-ink transition hover:text-brand"
-                    aria-label={isMuted ? 'Unmute' : 'Mute'}
-                  >
-                    {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
-                  </button>
-                  <input
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.01"
-                    value={volume}
-                    onChange={(e) => setVolume(parseFloat(e.target.value))}
-                    onMouseUp={playPreviewSound}
-                    onTouchEnd={playPreviewSound}
-                    className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
-                  />
-                </div>
-                <div className="px-4 pt-1 text-[11px] font-semibold text-base-secondary">
-                  배경음악
-                </div>
-                <div className="flex items-center gap-3 px-4 py-2">
-                  <button
-                    onClick={toggleBgmMute}
-                    className="text-ink transition hover:text-brand"
-                    aria-label={isBgmSilent ? 'Unmute background music' : 'Mute background music'}
-                  >
-                    {isBgmSilent ? <VolumeX size={18} /> : <Volume2 size={18} />}
-                  </button>
-                  <input
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.01"
-                    value={bgmVolume}
-                    onChange={(e) => setBgmVolume(parseFloat(e.target.value))}
-                    className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
-                  />
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
+        <BattleSettingsMenu theme={theme} toggleTheme={toggleTheme} />
       </div>
     </header>
   );

--- a/apps/web/src/components/Battle/BattleHeader.tsx
+++ b/apps/web/src/components/Battle/BattleHeader.tsx
@@ -1,6 +1,7 @@
 import { Eye, Moon, Settings, Sun, Volume2, VolumeX } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 
 import logo from '@/assets/logo.webp';
 import BattleTimer from '@/components/Battle/BattleTimer';
@@ -17,9 +18,13 @@ interface BattleHeaderProps {
 
 function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
   const { roomId } = useParams<{ roomId: string }>();
-  const spectatorCount = useBattleSocketStore((state) => state.spectatorCount);
   const problem = useBattleProblemStore((state) => state.problem);
   const timeOffset = useBattleProblemStore((state) => state.timeOffset);
+  const { spectatorCount } = useBattleSocketStore(
+    useShallow((state) => ({
+      spectatorCount: state.spectatorCount,
+    })),
+  );
 
   const {
     volume,
@@ -38,6 +43,10 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
   const battleId = problem?.battleId;
   const duration = problem?.duration;
   const startedAt = problem?.startedAt;
+
+  const handleToggleSetting = useCallback(() => {
+    setIsSettingOpen((prev) => !prev);
+  }, []);
 
   return (
     <header className="relative z-50 flex w-full items-center justify-between rounded-2xl px-5 text-base-primary backdrop-blur dark:shadow-slate-950/40">
@@ -69,7 +78,7 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
         </button>
         <div className="relative" ref={settingRef}>
           <button
-            onClick={() => setIsSettingOpen(!isSettingOpen)}
+            onClick={handleToggleSetting}
             className="rounded-full bg-base-faint p-2 text-ink shadow-sm transition hover:scale-110 active:scale-95"
           >
             <Settings size={24} className="text-slate-400" />
@@ -148,4 +157,4 @@ function BattleHeader({ theme, toggleTheme, onLeaveClick }: BattleHeaderProps) {
   );
 }
 
-export default BattleHeader;
+export default memo(BattleHeader);

--- a/apps/web/src/components/Battle/BattleSettingsMenu.tsx
+++ b/apps/web/src/components/Battle/BattleSettingsMenu.tsx
@@ -57,9 +57,7 @@ function BattleSettingsMenu({ theme, toggleTheme }: BattleSettingsMenuProps) {
               )}
             </button>
             <div className="my-1 h-[1px] bg-border-soft" />
-            <div className="px-4 pt-2 text-[11px] font-semibold text-base-secondary">
-              효과음
-            </div>
+            <div className="px-4 pt-2 text-[11px] font-semibold text-base-secondary">효과음</div>
             <div className="flex items-center gap-3 px-4 py-2">
               <button
                 onClick={toggleMute}
@@ -80,9 +78,7 @@ function BattleSettingsMenu({ theme, toggleTheme }: BattleSettingsMenuProps) {
                 className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
               />
             </div>
-            <div className="px-4 pt-1 text-[11px] font-semibold text-base-secondary">
-              배경음악
-            </div>
+            <div className="px-4 pt-1 text-[11px] font-semibold text-base-secondary">배경음악</div>
             <div className="flex items-center gap-3 px-4 py-2">
               <button
                 onClick={toggleBgmMute}

--- a/apps/web/src/components/Battle/BattleSettingsMenu.tsx
+++ b/apps/web/src/components/Battle/BattleSettingsMenu.tsx
@@ -1,0 +1,111 @@
+import { Moon, Settings, Sun, Volume2, VolumeX } from 'lucide-react';
+import { memo, useCallback, useRef, useState } from 'react';
+
+import { playPreviewSound } from '@/lib/sound';
+import { useSoundStore } from '@/stores/soundStore';
+
+type BattleSettingsMenuProps = {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+};
+
+function BattleSettingsMenu({ theme, toggleTheme }: BattleSettingsMenuProps) {
+  const {
+    volume,
+    isMuted,
+    setVolume,
+    toggleMute,
+    bgmVolume,
+    isBgmMuted,
+    setBgmVolume,
+    toggleBgmMute,
+  } = useSoundStore();
+  const isBgmSilent = isBgmMuted || bgmVolume <= 0;
+  const [isSettingOpen, setIsSettingOpen] = useState(false);
+  const settingRef = useRef<HTMLDivElement>(null);
+
+  const handleToggleSetting = useCallback(() => {
+    setIsSettingOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <div className="relative" ref={settingRef}>
+      <button
+        onClick={handleToggleSetting}
+        className="rounded-full bg-base-faint p-2 text-ink shadow-sm transition hover:scale-110 active:scale-95"
+      >
+        <Settings size={24} className="text-slate-400" />
+      </button>
+      {isSettingOpen && (
+        <div className="absolute right-0 mt-3 w-48 origin-top-right rounded-24 bg-bg-layer-2 p-2 shadow-2xl focus:outline-none transition-all duration-200 ease-out z-[100]">
+          <div className="flex flex-col gap-1">
+            <button
+              onClick={toggleTheme}
+              className="flex items-center gap-3 rounded-24 px-4 py-2 text-sm text-ink transition hover:bg-base-muted"
+              aria-label="Toggle theme"
+            >
+              {theme === 'dark' ? (
+                <>
+                  <Sun size={18} />
+                  <span>라이트 모드</span>
+                </>
+              ) : (
+                <>
+                  <Moon size={18} />
+                  <span>다크 모드</span>
+                </>
+              )}
+            </button>
+            <div className="my-1 h-[1px] bg-border-soft" />
+            <div className="px-4 pt-2 text-[11px] font-semibold text-base-secondary">
+              효과음
+            </div>
+            <div className="flex items-center gap-3 px-4 py-2">
+              <button
+                onClick={toggleMute}
+                className="text-ink transition hover:text-brand"
+                aria-label={isMuted ? 'Unmute' : 'Mute'}
+              >
+                {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
+              </button>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={volume}
+                onChange={(e) => setVolume(parseFloat(e.target.value))}
+                onMouseUp={playPreviewSound}
+                onTouchEnd={playPreviewSound}
+                className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
+              />
+            </div>
+            <div className="px-4 pt-1 text-[11px] font-semibold text-base-secondary">
+              배경음악
+            </div>
+            <div className="flex items-center gap-3 px-4 py-2">
+              <button
+                onClick={toggleBgmMute}
+                className="text-ink transition hover:text-brand"
+                aria-label={isBgmSilent ? 'Unmute background music' : 'Mute background music'}
+              >
+                {isBgmSilent ? <VolumeX size={18} /> : <Volume2 size={18} />}
+              </button>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={bgmVolume}
+                onChange={(e) => setBgmVolume(parseFloat(e.target.value))}
+                className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(BattleSettingsMenu);

--- a/apps/web/src/components/Battle/BattleTimer.tsx
+++ b/apps/web/src/components/Battle/BattleTimer.tsx
@@ -1,0 +1,88 @@
+import { BATTLE_EVENTS } from '@shared/constants/battle';
+import { motion } from 'framer-motion';
+import { Timer } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { playCountdownSound } from '@/lib/sound';
+import { useBattleSocketStore } from '@/stores/battleSocketStore';
+
+type BattleTimerProps = {
+  battleId?: string;
+  duration?: number;
+  startedAt?: string;
+  timeOffset: number;
+  roomId?: string;
+};
+
+export default function BattleTimer({
+  battleId,
+  duration,
+  startedAt,
+  timeOffset,
+  roomId,
+}: BattleTimerProps) {
+  const [timeLeft, setTimeLeft] = useState<number>(0);
+  const [hasEmittedEnd, setHasEmittedEnd] = useState(false);
+  const hasPlayedCountdownRef = useRef(false);
+
+  useEffect(() => {
+    if (!startedAt || !duration) return;
+
+    const startTime = new Date(startedAt).getTime();
+    const endTime = startTime + duration * 1000;
+
+    const updateTimer = () => {
+      // 서버 시간 추정: 클라이언트 시간 + 오프셋
+      const now = Date.now() + timeOffset;
+      const remaining = Math.max(0, Math.floor((endTime - now) / 1000));
+      setTimeLeft(remaining);
+
+      // 5초 시점에 효과음 시작 (한 번만)
+      if (remaining === 5 && !hasPlayedCountdownRef.current) {
+        hasPlayedCountdownRef.current = true;
+        playCountdownSound('tick');
+      }
+
+      if (remaining <= 0 && !hasEmittedEnd) {
+        // 타이머 종료 처리
+        const socket = useBattleSocketStore.getState().socket;
+        if (socket && battleId) {
+          socket.emit(BATTLE_EVENTS.TIMER_END, { battleId, roomId });
+          setHasEmittedEnd(true);
+        }
+      }
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+
+    return () => clearInterval(interval);
+  }, [startedAt, duration, timeOffset, hasEmittedEnd, battleId, roomId]);
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <motion.div
+      animate={
+        timeLeft <= 5 && timeLeft > 0
+          ? {
+              scale: [1, 1.05, 1],
+              transition: { repeat: Infinity, duration: 0.8 },
+            }
+          : { scale: 1 }
+      }
+      className={`flex items-center gap-2 rounded-3xl px-4 py-1 text-lg font-bold shadow-[1px_1px_4px_rgba(0,0,0,0.05)] transition-colors duration-300 ${
+        timeLeft <= 5 && timeLeft > 0
+          ? 'bg-red-50 text-error-01 dark:bg-error-01/10'
+          : 'bg-green-01 text-green-06'
+      }`}
+    >
+      <Timer className="h-5 w-5" strokeWidth={2.5} />
+      <span className="font-bold leading-7">{formatTime(timeLeft)}</span>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/Battle/SpectatorCountBadge.tsx
+++ b/apps/web/src/components/Battle/SpectatorCountBadge.tsx
@@ -1,0 +1,22 @@
+import { Eye } from 'lucide-react';
+import { memo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+
+import { useBattleSocketStore } from '@/stores/battleSocketStore';
+
+function SpectatorCountBadge() {
+  const { spectatorCount } = useBattleSocketStore(
+    useShallow((state) => ({
+      spectatorCount: state.spectatorCount,
+    })),
+  );
+
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-full bg-base-faint px-5 py-2 text-sm font-medium text-base-primary">
+      <Eye className="h-4 w-4 text-base-secondary" strokeWidth={2.5} />
+      <span className="text-base-primary">{spectatorCount}</span>
+    </div>
+  );
+}
+
+export default memo(SpectatorCountBadge);

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -120,7 +120,7 @@ function BattlePage() {
   const isLeaveModalOpen = blocker.state === 'blocked' || showLeaveModal;
 
   // 나가기 버튼 클릭 핸들러
-  const handleLeaveClick = () => {
+  const handleLeaveClick = useCallback(() => {
     if (isSpectator) {
       if (roomId) {
         leaveRoom(roomId);
@@ -129,7 +129,7 @@ function BattlePage() {
     } else {
       setShowLeaveModal(true);
     }
-  };
+  }, [isSpectator, leaveRoom, navigate, roomId]);
 
   // 모달에서 나가기 확인
   const handleConfirmLeave = () => {


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

BattleHeader의 타이머, 관전자 수, 설정 토글로 인해 발생하던 잦은 리렌더를 줄이기 위해 UI/로직 분리와 memo 최적화를 적용했습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #258 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 타이머 분리: BattleTimer 컴포넌트로 분리하여 1초마다 Header 전체가 리렌더되는 문제 개선
- 관전자 수 분리: SpectatorCountBadge 컴포넌트로 분리하여 관전자 입장/퇴장 시 배지만 리렌더되도록 수정
- 설정 메뉴 분리: BattleSettingsMenu 컴포넌트로 분리하여 토글/볼륨 변경 시 Header 전체 리렌더 방지
- React.memo 적용: BattleHeader 자체에 memo 적용
- props 안정화: BattlePage의 onLeaveClick을 useCallback으로 고정

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### BEFORE


https://github.com/user-attachments/assets/b375163c-a2f4-41b6-9a1b-ca76414b4bbb


### AFTER


https://github.com/user-attachments/assets/f76f7be7-5606-4c61-ad3a-293a6a8bb0cf



## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- BattleHeader는 타이머/관전자 수/설정 토글 등 자주 변하는 상태를 포함하고 있어, 작은 상태 변화에도 전체가 리렌더되는 문제가 있었습니다.
- 리렌더 범위를 줄이기 위해 자주 변하는 영역을 개별 컴포넌트로 분리하고, memo 및 useCallback으로 props 변화를 최소화했습니다.


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 리렌더 최적화 이후 실제 렌더 횟수 감소 여부 확인 부탁드립니다.
- 분리된 컴포넌트들의 책임 분리가 과하지 않은지 의견 부탁드립니다.