### PR TITLE
[REFACTOR] 메인 페이지 성능 개선 (#253)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,9 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://avatars.githubusercontent.com" />
+    <link rel="dns-prefetch" href="https://avatars.githubusercontent.com" />
     <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
     <title>TADAK</title>
   </head>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://avatars.githubusercontent.com" />
+    <link rel="preconnect" href="https://avatars.githubusercontent.com" crossorigin />
     <link rel="dns-prefetch" href="https://avatars.githubusercontent.com" />
     <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
     <title>TADAK</title>

--- a/apps/web/src/components/Common/TierBadge.tsx
+++ b/apps/web/src/components/Common/TierBadge.tsx
@@ -15,7 +15,7 @@ function TierBadge({ tier, division }: TierBadgeProps) {
 
   return (
     <div className="flex items-center gap-1">
-      <Icon size={12} className={`${config.fillClass} ${config.colorClass}`} />
+      <Icon size={12} className={`${config.fillClass} ${config.colorClass}`} aria-hidden="true" />
       <span className={`font-semibold ${config.colorClass} text-sm`}>
         {tier}
         {division !== undefined && ` ${toRomanNumeral(division)}`}

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -64,7 +64,7 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
     <header className="relative z-50 border-b border-border-soft bg-bg-layer-2 shadow-sm">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-8 py-2">
         <Link to="/" className="flex items-center gap-3">
-          <img src={LogoImage} alt="TADAK 로고" className="h-12 w-auto" />
+          <img src={LogoImage} alt="TADAK 로고" width={48} height={48} className="h-12 w-auto" />
           <span className="text-2xl font-black tracking-tight">TADAK</span>
         </Link>
         <div className="flex items-center gap-4">
@@ -74,8 +74,11 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
             isLoggedIn && user ? (
               <div className="relative" ref={menuRef}>
                 <button
+                  type="button"
                   onClick={() => setIsMenuOpen(!isMenuOpen)}
                   className="cursor-pointer flex items-center transition hover:opacity-80 active:scale-95"
+                  aria-label="사용자 메뉴 열기"
+                  aria-expanded={isMenuOpen}
                 >
                   <UserProfile
                     username={user.username}
@@ -86,22 +89,29 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
                 </button>
 
                 {isMenuOpen && (
-                  <div className="absolute mt-3 w-48 origin-top-right rounded-24 bg-bg-layer-2 p-2 shadow-2xl focus:outline-none transition-all duration-200 ease-out z-50">
+                  <div
+                    className="absolute mt-3 w-48 origin-top-right rounded-24 bg-bg-layer-2 p-2 shadow-2xl focus:outline-none transition-all duration-200 ease-out z-50"
+                    role="menu"
+                    aria-orientation="vertical"
+                  >
                     <div className="flex flex-col gap-1">
                       <Link
                         to="/mypage"
                         onClick={() => setIsMenuOpen(false)}
                         className="flex items-center gap-3 rounded-24 px-4 py-2 text-sm text-ink transition hover:bg-base-muted"
+                        role="menuitem"
                       >
-                        <UserIcon size={18} className="text-slate-400" />
+                        <UserIcon size={18} className="text-slate-400" aria-hidden="true" />
                         마이페이지
                       </Link>
                       <div className="my-1 h-[1px] bg-border-soft" />
                       <button
+                        type="button"
                         onClick={handleLogout}
                         className="cursor-pointer flex items-center gap-3 rounded-24 px-4 py-2 text-sm text-red-500 transition hover:bg-red-50"
+                        role="menuitem"
                       >
-                        <LogOut size={18} />
+                        <LogOut size={18} aria-hidden="true" />
                         로그아웃
                       </button>
                     </div>
@@ -119,27 +129,35 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
           ) : null}
           <div className="relative" ref={settingRef}>
             <button
+              type="button"
               onClick={() => setIsSettingOpen(!isSettingOpen)}
               className="cursor-pointer rounded-full bg-base-muted p-2 text-ink shadow-sm transition hover:scale-110 active:scale-95"
+              aria-label="설정 메뉴 열기"
+              aria-expanded={isSettingOpen}
             >
-              <Settings size={24} className="text-slate-400" />
+              <Settings size={24} className="text-slate-400" aria-hidden="true" />
             </button>
             {isSettingOpen && (
-              <div className="absolute right-0 mt-3 w-48 origin-top-right rounded-24 bg-bg-layer-2 p-2 shadow-2xl focus:outline-none transition-all duration-200 ease-out z-[100]">
+              <div
+                className="absolute right-0 mt-3 w-48 origin-top-right rounded-24 bg-bg-layer-2 p-2 shadow-2xl focus:outline-none transition-all duration-200 ease-out z-[100]"
+                role="menu"
+                aria-orientation="vertical"
+              >
                 <div className="flex flex-col gap-1">
                   <button
+                    type="button"
                     onClick={toggleTheme}
                     className="cursor-pointer flex items-center gap-3 rounded-24 px-4 py-2 text-sm text-ink transition hover:bg-base-muted"
-                    aria-label="Toggle theme"
+                    role="menuitem"
                   >
                     {theme === 'dark' ? (
                       <>
-                        <Sun size={18} />
+                        <Sun size={18} aria-hidden="true" />
                         <span>라이트 모드</span>
                       </>
                     ) : (
                       <>
-                        <Moon size={18} />
+                        <Moon size={18} aria-hidden="true" />
                         <span>다크 모드</span>
                       </>
                     )}
@@ -150,11 +168,16 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
                   </div>
                   <div className="flex items-center gap-3 px-4 py-2">
                     <button
+                      type="button"
                       onClick={toggleMute}
                       className="cursor-pointer text-ink transition hover:text-brand"
-                      aria-label={isMuted ? 'Unmute' : 'Mute'}
+                      aria-label={isMuted ? '효과음 켜기' : '효과음 끄기'}
                     >
-                      {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                      {isMuted ? (
+                        <VolumeX size={18} aria-hidden="true" />
+                      ) : (
+                        <Volume2 size={18} aria-hidden="true" />
+                      )}
                     </button>
                     <input
                       type="range"
@@ -166,6 +189,7 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
                       onMouseUp={playPreviewSound}
                       onTouchEnd={playPreviewSound}
                       className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
+                      aria-label="효과음 볼륨"
                     />
                   </div>
                   <div className="px-4 pt-1 text-[11px] font-semibold text-base-secondary">
@@ -173,11 +197,16 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
                   </div>
                   <div className="flex items-center gap-3 px-4 py-2">
                     <button
+                      type="button"
                       onClick={toggleBgmMute}
                       className="cursor-pointer text-ink transition hover:text-brand"
-                      aria-label={isBgmSilent ? 'Unmute background music' : 'Mute background music'}
+                      aria-label={isBgmSilent ? '배경음악 켜기' : '배경음악 끄기'}
                     >
-                      {isBgmSilent ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                      {isBgmSilent ? (
+                        <VolumeX size={18} aria-hidden="true" />
+                      ) : (
+                        <Volume2 size={18} aria-hidden="true" />
+                      )}
                     </button>
                     <input
                       type="range"
@@ -187,6 +216,7 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
                       value={bgmVolume}
                       onChange={(e) => setBgmVolume(parseFloat(e.target.value))}
                       className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border-soft accent-brand"
+                      aria-label="배경음악 볼륨"
                     />
                   </div>
                 </div>

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -3,6 +3,7 @@ import { Eye } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import TierBadge from '@/components/Common/TierBadge';
+import { getOptimizedAvatarUrl } from '@/lib/avatar';
 
 type Props = {
   rooms: Room[];
@@ -48,12 +49,17 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
           >
             <div className="mb-4 flex items-center justify-between text-xs text-base-secondary">
               <div className="flex items-center gap-2">
-                <span className="flex items-center font-semibold text-red-01">● LIVE</span>
+                <span className="flex items-center font-semibold text-red-01">
+                  <span aria-hidden="true">●</span> LIVE
+                </span>
                 <span className="text-blue-03">{formatElapsed(room.createdAt)}</span>
               </div>
-              <div className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium">
-                <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} />
-                {room.currentSpectators?.length ?? 0}
+              <div
+                className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium"
+                aria-label={`관전자 ${room.currentSpectators?.length ?? 0}명`}
+              >
+                <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} aria-hidden="true" />
+                <span>{room.currentSpectators?.length ?? 0}</span>
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -74,12 +80,15 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
                     <div className="flex h-9 w-9 items-center justify-center rounded-full bg-base-muted text-sm font-bold text-base-primary">
                       {p.avatarUrl ? (
                         <img
-                          src={p.avatarUrl}
-                          alt={p.username}
+                          src={getOptimizedAvatarUrl(p.avatarUrl, 72)}
+                          alt={`${p.username} 프로필`}
+                          width={36}
+                          height={36}
+                          loading="lazy"
                           className="h-full w-full rounded-full object-cover"
                         />
                       ) : (
-                        getInitial(p.username)
+                        <span aria-hidden="true">{getInitial(p.username)}</span>
                       )}
                     </div>
                     <div className="flex flex-col">
@@ -89,7 +98,18 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
                       )}
                     </div>
                   </div>
-                  <div className="h-2 w-full overflow-hidden rounded-full bg-base-muted">
+                  <div
+                    className="h-2 w-full overflow-hidden rounded-full bg-base-muted"
+                    role="progressbar"
+                    aria-label={`${p.username} 진행률`}
+                    aria-valuenow={
+                      p.progress && p.progress.totalCount > 0
+                        ? Math.round((p.progress.passedCount / p.progress.totalCount) * 100)
+                        : 0
+                    }
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  >
                     <div
                       className="h-full rounded-full transition-all duration-300"
                       style={{

--- a/apps/web/src/components/Main/RoomCardList.tsx
+++ b/apps/web/src/components/Main/RoomCardList.tsx
@@ -56,6 +56,7 @@ function RoomCardList({ rooms, onSpectate, joiningRoomId }: Props) {
               </div>
               <div
                 className="inline-flex items-center gap-1.5 text-blue-03 text-sm font-medium"
+                role="group"
                 aria-label={`관전자 ${room.currentSpectators?.length ?? 0}명`}
               >
                 <Eye className="h-4 w-4 text-blue-03" strokeWidth={1.5} aria-hidden="true" />

--- a/apps/web/src/components/Profile/UserProfile.tsx
+++ b/apps/web/src/components/Profile/UserProfile.tsx
@@ -1,6 +1,7 @@
 import type { TierType } from '@shared/types/user';
 
 import TierBadge from '@/components/Common/TierBadge';
+import { getOptimizedAvatarUrl } from '@/lib/avatar';
 
 interface UserProfileProps {
   username: string;
@@ -10,19 +11,23 @@ interface UserProfileProps {
 }
 
 export function UserProfile({ username, tier, division, avatarUrl }: UserProfileProps) {
+  const optimizedAvatarUrl = getOptimizedAvatarUrl(avatarUrl, 80);
+
   return (
     <div className="flex items-center gap-3 px-4">
       <div className="relative flex h-10 w-10 items-center justify-center">
         <div className="absolute inset-0 rounded-full border-2 border-green-500" />
         <div className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-white bg-slate-800 text-lg font-bold text-green-500 shadow-sm">
-          {avatarUrl ? (
+          {optimizedAvatarUrl ? (
             <img
-              src={avatarUrl}
-              alt={username}
+              src={optimizedAvatarUrl}
+              alt={`${username} 프로필`}
+              width={40}
+              height={40}
               className="h-full w-full rounded-full object-cover"
             />
           ) : (
-            username.charAt(0).toUpperCase()
+            <span aria-hidden="true">{username.charAt(0).toUpperCase()}</span>
           )}
         </div>
       </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -26,13 +26,13 @@
   --color-pink-05: #ff3b5c;
 
   /* --- Primitives (Tier) --- */
-  --color-tier-bronze: #a16207;
-  --color-tier-silver: #6b7280;
-  --color-tier-gold: #eab308;
-  --color-tier-platinum: #06b6d4;
-  --color-tier-diamond: #60a5fa;
-  --color-tier-ruby: #f43f5e;
-  --color-tier-master: #a855f7;
+  --color-tier-bronze: #92400e;
+  --color-tier-silver: #4b5563;
+  --color-tier-gold: #a16207;
+  --color-tier-platinum: #0891b2;
+  --color-tier-diamond: #2563eb;
+  --color-tier-ruby: #e11d48;
+  --color-tier-master: #9333ea;
 
   /* --- Primitives (Etc) --- */
   --color-red-01: #ff3b5c;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -135,6 +135,15 @@
 
   --white: var(--color-black-static);
   --black: var(--color-white-static);
+
+  /* 다크모드 티어 색상 (어두운 배경과 대비를 위해 밝게) */
+  --color-tier-bronze: #d97706;
+  --color-tier-silver: #9ca3af;
+  --color-tier-gold: #facc15;
+  --color-tier-platinum: #22d3ee;
+  --color-tier-diamond: #93c5fd;
+  --color-tier-ruby: #fb7185;
+  --color-tier-master: #c084fc;
 }
 
 * {

--- a/apps/web/src/lib/avatar.ts
+++ b/apps/web/src/lib/avatar.ts
@@ -1,0 +1,17 @@
+/**
+ * GitHub 아바타 URL을 최적화하여 원하는 크기로 요청
+ * @param url 아바타 URL
+ * @param size 요청할 이미지 크기 (기본값: 80)
+ * @returns 최적화된 URL 또는 원본 URL
+ */
+export const getOptimizedAvatarUrl = (url?: string, size = 80): string | undefined => {
+  if (!url) return undefined;
+
+  // GitHub avatar URL optimization
+  if (url.includes('githubusercontent.com') || url.includes('github.com')) {
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}s=${size}`;
+  }
+
+  return url;
+};

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -111,29 +111,36 @@ function MainPage() {
         {/* 상단 헤더 */}
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
-            <div className="h-2 w-2 rounded-full bg-red-01" />
+            <div className="h-2 w-2 rounded-full bg-red-01" aria-hidden="true" />
             <h1 className="text-3xl font-bold">LIVE</h1>
             <h1 className="text-3xl font-bold text-brand">BATTLES</h1>
             <button
               type="button"
               onClick={handleStartBattle}
-              className="cursor-pointer ml-auto rounded-3xl bg-brand px-6 py-3 text-lg font-semibold shadow-md transition hover:scale-[1.02]"
+              className="cursor-pointer ml-auto rounded-3xl bg-brand px-6 py-3 text-lg font-semibold shadow-md transition hover:scale-[1.02] text-gray-900"
             >
               게임 시작하기
             </button>
           </div>
           <p className="text-sm text-base-primary flex items-center gap-2">
             현재 진행 중인 배틀을 관전하고 고수들의 코딩을 배워보세요
-            <div className="group relative flex items-center">
+            <button
+              type="button"
+              onClick={() => navigate('/landing')}
+              className="group relative flex items-center"
+              aria-label="서비스 소개 페이지로 이동"
+            >
               <Info
                 size={16}
-                onClick={() => navigate('/landing')}
                 className="cursor-pointer text-base-secondary transition hover:text-brand"
               />
-              <span className="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg bg-bg-layer-2 border border-border-soft px-2 py-1 text-[10px] font-bold text-ink opacity-0 transition-all group-hover:opacity-100 shadow-sm">
+              <span
+                className="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg bg-bg-layer-2 border border-border-soft px-2 py-1 text-[10px] font-bold text-ink opacity-0 transition-all group-hover:opacity-100 shadow-sm"
+                aria-hidden="true"
+              >
                 서비스 소개
               </span>
-            </div>
+            </button>
           </p>
         </div>
 
@@ -147,7 +154,7 @@ function MainPage() {
                 type="button"
                 onClick={() => setSelectedFilter(tier.value)}
                 className={`cursor-pointer rounded-full px-4 py-2 text-xs font-semibold shadow-sm transition ${
-                  isSelected ? 'bg-green-01 text-green-06' : 'bg-base-faint text-base-secondary'
+                  isSelected ? 'bg-green-01 text-green-800' : 'bg-base-faint text-base-secondary'
                 }`}
               >
                 <span className={`mr-2 inline-block h-2 w-2 rounded-full ${tier.color}`} />

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -4,7 +4,7 @@ export default {
     'type-enum': [
       2,
       'always',
-      ['chore', 'feat', 'fix', 'refactor', 'test', 'docs', 'style', 'design', 'hotfix', 'merge'],
+      ['chore', 'feat', 'fix', 'refactor', 'test', 'docs', 'style', 'design', 'hotfix', 'merge', 'perf'],
     ],
     'type-case': [2, 'always', 'lower-case'],
     'subject-case': [0],


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- 메인 페이지 lighthouse 개선

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #253 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 웹 접근성 aria 속성 설정 및 개선
- 색상 대비 설정
- Github 아바타 이미지 최적화 및 로딩 성능 개선
  - `preconnect`를 추가하여 브라우저가 GitHub 서버에 미리 연결하여 이미지 요청 시 지연 시간 제거
  ```html
    <link rel="preconnect" href="https://avatars.githubusercontent.com" />
    <link rel="dns-prefetch" href="https://avatars.githubusercontent.com" />
  ```
  - 이미지를 불러올 때 사이즈를 추가하여 이미지 최적화

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

**개선 전**
<img width="4064" height="2168" alt="image" src="https://github.com/user-attachments/assets/40620ece-4ca8-4f3c-9524-7901b689937c" />

**개선 후**
<img width="1908" height="929" alt="image" src="https://github.com/user-attachments/assets/db61de03-73ef-4e8a-a3a6-6100ec48ed12" />


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- 메인 페이지 접근 시 사용자의 경험 개선을 위함

## 💬 리뷰 요구사항(선택)

- SEO 개선은 다연님이 해주셔서 따로 작업하지 않았습니다.
- 라이트모드에서 접근성이 95가 나오는데, color-brand의 색상이 충분한 대비가 없다고 나와서 이 부분을 어떻게 할지 의견이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 아바타 이미지 최적화 적용

* **스타일**
  * 라이트/다크 테마 티어 색상 팔레트 업데이트
  * HTML 기본 언어를 한국어로 변경
  * 아바타 리소스에 대한 사전 연결/도메인 프리패치 추가

* **개선 사항**
  * 전반적인 접근성 향상(아이콘 장식 표기, 메뉴·버튼·진행바·레이블 등)
  * 프로필·룸 목록의 아바타 렌더링 및 로딩 최적화, 대체 표시 개선
  * 버튼 및 인터랙션 의미론 강화

* **잡무**
  * 커밋 타입에 'perf' 추가 허용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->