### PR TITLE
[REFACTOR] 불필요 리렌더 줄이기 및 성능 개선 (#254)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 
 # k6
 k6/logs
+
+# scanner work
+.scannerwork

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
     <title>TADAK</title>
   </head>
   <body>

--- a/apps/web/src/components/Battle/Spectator/ChatInput.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatInput.tsx
@@ -1,0 +1,61 @@
+import { type KeyboardEventHandler, memo, useState } from 'react';
+
+interface ChatInputProps {
+  isLoggedIn: boolean;
+  onSend: (message: string) => void;
+  onLoginClick: () => void;
+}
+
+function ChatInput({ isLoggedIn, onSend, onLoginClick }: ChatInputProps) {
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    if (!isLoggedIn) return;
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    onSend(trimmed);
+    setInput('');
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
+    if (event.nativeEvent.isComposing) return;
+    if (!isLoggedIn) return;
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="flex items-end gap-2 border-t border-border-soft bg-[var(--bg-layer-2)] px-3 py-2">
+      <textarea
+        value={input}
+        onChange={(event) => setInput(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={isLoggedIn ? '메시지를 입력하세요...' : '로그인 후 채팅을 이용할 수 있어요.'}
+        className="chat-scroll h-10 max-h-32 min-h-10 flex-1 resize-none overflow-y-auto bg-transparent text-sm text-base-primary placeholder:text-base-secondary focus:outline-none disabled:cursor-not-allowed"
+        disabled={!isLoggedIn}
+      />
+      {!isLoggedIn && (
+        <button
+          type="button"
+          onClick={onLoginClick}
+          className="rounded-lg border border-border-soft px-3 py-2 text-xs font-bold text-base-primary transition hover:bg-base-muted"
+        >
+          로그인
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={handleSend}
+        className="rounded-lg bg-green-05 px-3 py-2 text-xs font-bold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={!isLoggedIn || !input.trim()}
+      >
+        전송
+      </button>
+    </div>
+  );
+}
+
+export default memo(ChatInput);

--- a/apps/web/src/components/Battle/Spectator/ChatMessageItem.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatMessageItem.tsx
@@ -1,0 +1,78 @@
+import { CHAT_TYPE } from '@shared/constants/chat';
+import type { ChatMessage } from '@shared/types/chat';
+import { memo } from 'react';
+
+interface ChatMessageItemProps {
+  msg: ChatMessage;
+  isMine: boolean;
+}
+
+const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
+
+const getAvatarTone = (isMine: boolean) =>
+  isMine ? 'bg-[var(--color-green-04)] text-white' : 'bg-[var(--color-blue-04)] text-white';
+
+const formatTime = (timestamp: string) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+};
+
+function ChatMessageItem({ msg, isMine }: ChatMessageItemProps) {
+  const isSystem = msg.type === CHAT_TYPE.SYSTEM;
+  const displayName = isMine ? '나' : msg.nickname;
+
+  if (isSystem) {
+    return (
+      <div className="flex justify-center">
+        <div className="w-full max-w-[95%] rounded-lg bg-base-muted px-4 py-2 text-center text-xs font-semibold text-base-secondary">
+          {msg.message}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`flex items-start gap-2 ${isMine ? 'justify-end text-right' : 'justify-start text-left'}`}
+    >
+      {!isMine && (
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold overflow-hidden ${getAvatarTone(false)}`}
+        >
+          {msg.avatarUrl ? (
+            <img src={msg.avatarUrl} alt={displayName} className="h-full w-full object-cover" />
+          ) : (
+            getInitial(displayName)
+          )}
+        </div>
+      )}
+      <div className={`max-w-[82%] space-y-1 ${isMine ? 'items-end text-right' : ''}`}>
+        <div className={`flex items-center gap-2 text-xs ${isMine ? 'justify-end' : ''}`}>
+          {!isMine && <span className="font-semibold text-base-primary">{displayName}</span>}
+          <span className="text-[10px] text-base-secondary">{formatTime(msg.timestamp)}</span>
+        </div>
+        <div
+          className={`inline-flex rounded-2xl px-4 py-2 text-sm leading-relaxed ${
+            isMine ? 'bg-green-04 text-black-static' : 'bg-base-muted'
+          }`}
+        >
+          <p className="whitespace-pre-wrap">{msg.message}</p>
+        </div>
+      </div>
+      {isMine && (
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold overflow-hidden ${getAvatarTone(true)}`}
+        >
+          {msg.avatarUrl ? (
+            <img src={msg.avatarUrl} alt={displayName} className="h-full w-full object-cover" />
+          ) : (
+            getInitial(displayName)
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(ChatMessageItem);

--- a/apps/web/src/components/Battle/Spectator/ChatMessageList.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatMessageList.tsx
@@ -1,0 +1,47 @@
+import type { ChatMessage } from '@shared/types/chat';
+import { memo, useEffect, useRef } from 'react';
+
+import ChatMessageItem from './ChatMessageItem';
+
+interface ChatMessageListProps {
+  messages: ChatMessage[];
+  myNickname: string;
+}
+
+function ChatMessageList({ messages, myNickname }: ChatMessageListProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      const list = listRef.current;
+      if (list) {
+        list.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
+      } else {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    });
+  }, [messages.length]);
+
+  return (
+    <div
+      ref={listRef}
+      className="chat-scroll flex-1 min-h-0 space-y-3 overflow-y-auto bg-[var(--bg-layer-2)] px-4 py-4 pb-16"
+    >
+      <div className="flex justify-center">
+        <div className="w-full max-w-[95%] rounded-lg bg-base-muted px-4 py-2 text-center text-xs font-semibold text-base-secondary">
+          관전 모드에 오신 것을 환영합니다!
+        </div>
+      </div>
+      {messages.map((msg, index) => {
+        const key = `${msg.timestamp}-${index}`;
+        const isMine = msg.isMine ?? msg.nickname === myNickname;
+
+        return <ChatMessageItem key={key} msg={msg} isMine={isMine} />;
+      })}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+export default memo(ChatMessageList);

--- a/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ChatSpectator.tsx
@@ -1,13 +1,15 @@
-import { CHAT_TYPE } from '@shared/constants/chat';
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { ChatMessage } from '@shared/types/chat';
 import { MessagesSquare } from 'lucide-react';
-import { type KeyboardEventHandler, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
 import { useUserStore } from '@/stores/userStore';
+
+import ChatInput from './ChatInput';
+import ChatMessageList from './ChatMessageList';
 
 const initialMessages: ChatMessage[] = [];
 
@@ -18,37 +20,34 @@ function ChatSpectator() {
   const user = useUserStore((state) => state.user);
   const socket = useBattleSocketStore((state) => state.socket);
   const connectSocket = useBattleSocketStore((state) => state.connect);
-  const leaveRoom = useBattleSocketStore((state) => state.leaveRoom);
-  const listRef = useRef<HTMLDivElement>(null);
+
+  const roomIdRef = useRef(roomId);
+  const navigateRef = useRef(navigate);
+
+  useEffect(() => {
+    roomIdRef.current = roomId;
+    navigateRef.current = navigate;
+  }, [roomId, navigate]);
 
   const myNickname = useMemo(() => {
     const fallback = socket?.id ? `User-${socket.id.slice(-4)}` : '관전자';
     return me?.username ?? fallback;
   }, [me, socket]);
-  const myAvatar = useMemo(() => me?.avatarUrl, [me]);
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
-  const [input, setInput] = useState('');
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const isLoggedIn = Boolean(user?.id);
-
-  useEffect(() => {
-    // 새 메시지가 추가되면 리스트 하단으로 스크롤
-    requestAnimationFrame(() => {
-      const list = listRef.current;
-      if (list) {
-        list.scrollTo({ top: list.scrollHeight, behavior: 'smooth' });
-      } else {
-        bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      }
-    });
-  }, [messages.length]);
+  const isLoggedIn = useMemo(() => Boolean(user?.id), [user?.id]);
 
   useEffect(() => {
     const activeSocket = socket ?? connectSocket();
     if (!activeSocket) return;
 
     const handleReceiveChat = (msg: ChatMessage) => {
-      setMessages((prev) => [...prev, { ...msg, isMine: msg.nickname === myNickname }]);
+      const currentMe = useRoomStore.getState().me;
+      const currentSocket = useBattleSocketStore.getState().socket;
+      const currentNickname =
+        currentMe?.username ??
+        (currentSocket?.id ? `User-${currentSocket.id.slice(-4)}` : '관전자');
+
+      setMessages((prev) => [...prev, { ...msg, isMine: msg.nickname === currentNickname }]);
     };
 
     activeSocket.on(SOCKET_EVENT.RECEIVE_CHAT, handleReceiveChat);
@@ -56,180 +55,52 @@ function ChatSpectator() {
     return () => {
       activeSocket.off(SOCKET_EVENT.RECEIVE_CHAT, handleReceiveChat);
     };
-  }, [socket, connectSocket, myNickname]);
+  }, [socket, connectSocket]);
 
-  const getInitial = (name?: string) => name?.trim().charAt(0)?.toUpperCase() ?? '?';
+  const handleSend = useCallback((message: string) => {
+    const activeSocket =
+      useBattleSocketStore.getState().socket ?? useBattleSocketStore.getState().connect();
+    const currentMe = useRoomStore.getState().me;
+    const currentSocket = useBattleSocketStore.getState().socket;
+    const currentNickname =
+      currentMe?.username ?? (currentSocket?.id ? `User-${currentSocket.id.slice(-4)}` : '관전자');
+    const currentAvatar = currentMe?.avatarUrl;
 
-  const getAvatarTone = (isMine: boolean) =>
-    isMine ? 'bg-[var(--color-green-04)] text-white' : 'bg-[var(--color-blue-04)] text-white';
-
-  const formatTime = (timestamp: string) => {
-    const date = new Date(timestamp);
-    if (Number.isNaN(date.getTime())) return '';
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  };
-
-  const handleSend = () => {
-    if (!isLoggedIn) return;
-    const trimmed = input.trim();
-    if (!trimmed) return;
-
-    const activeSocket = socket ?? connectSocket();
     activeSocket?.emit(SOCKET_EVENT.SEND_CHAT, {
-      roomId,
-      message: trimmed,
-      nickname: myNickname,
-      avatarUrl: myAvatar,
+      roomId: roomIdRef.current,
+      message,
+      nickname: currentNickname,
+      avatarUrl: currentAvatar,
     });
-    setInput('');
-  };
+  }, []);
 
-  const handleLoginClick = () => {
-    if (roomId) {
-      leaveRoom(roomId);
+  const handleLoginClick = useCallback(() => {
+    const currentRoomId = roomIdRef.current;
+    if (currentRoomId) {
+      useBattleSocketStore.getState().leaveRoom(currentRoomId);
     }
     try {
       sessionStorage.removeItem('battle-session');
     } catch {
       // ignore
     }
-    navigate('/login', { replace: true });
-  };
-
-  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
-    if (event.nativeEvent.isComposing) return; // IME 조합 중일 때는 전송하지 않음
-    if (!isLoggedIn) return;
-    if (event.key === 'Enter' && !event.shiftKey) {
-      event.preventDefault();
-      handleSend();
-    }
-  };
+    navigateRef.current('/login', { replace: true });
+  }, []);
 
   return (
-    <>
-      <section className="relative flex h-full min-h-[60vh] max-h-[70vh] sm:max-h-[60vh] xl:max-h-none flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
-        <div className="flex items-center justify-between border-b border-border-soft bg-[var(--bg-layer-2)] px-4 py-3">
-          <div className="flex items-center gap-3">
-            <div className="flex h-5 w-5 items-center justify-center rounded-full">
-              <MessagesSquare className="h-5 w-5 text-green-05 stroke-[2.5]" />
-            </div>
-            <p className="text-md font-semibold">실시간 채팅</p>
+    <section className="relative flex h-full min-h-[60vh] max-h-[70vh] sm:max-h-[60vh] xl:max-h-none flex-col overflow-hidden rounded-2xl border border-border-soft bg-[var(--bg-layer-2)] text-base-primary shadow-sm">
+      <div className="flex items-center justify-between border-b border-border-soft bg-[var(--bg-layer-2)] px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-5 w-5 items-center justify-center rounded-full">
+            <MessagesSquare className="h-5 w-5 text-green-05 stroke-[2.5]" />
           </div>
+          <p className="text-md font-semibold">실시간 채팅</p>
         </div>
-        <div
-          ref={listRef}
-          className="chat-scroll flex-1 min-h-0 space-y-3 overflow-y-auto bg-[var(--bg-layer-2)] px-4 py-4 pb-16"
-        >
-          <div className="flex justify-center">
-            <div className="w-full max-w-[95%] rounded-lg bg-base-muted px-4 py-2 text-center text-xs font-semibold text-base-secondary">
-              관전 모드에 오신 것을 환영합니다!
-            </div>
-          </div>
-          {messages.map((msg, index) => {
-            const key = `${msg.timestamp}-${index}`;
-            const isSystem = msg.type === CHAT_TYPE.SYSTEM;
-            const isMine = msg.isMine ?? msg.nickname === myNickname;
-            const displayName = isMine ? '나' : msg.nickname;
-
-            if (isSystem) {
-              return (
-                <div key={key} className="flex justify-center">
-                  <div className="w-full max-w-[95%] rounded-lg bg-base-muted px-4 py-2 text-center text-xs font-semibold text-base-secondary">
-                    {msg.message}
-                  </div>
-                </div>
-              );
-            }
-
-            return (
-              <div
-                key={key}
-                className={`flex items-start gap-2 ${isMine ? 'justify-end text-right' : 'justify-start text-left'}`}
-              >
-                {!isMine && (
-                  <div
-                    className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold overflow-hidden ${getAvatarTone(false)}`}
-                  >
-                    {msg.avatarUrl ? (
-                      <img
-                        src={msg.avatarUrl}
-                        alt={displayName}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      getInitial(displayName)
-                    )}
-                  </div>
-                )}
-                <div className={`max-w-[82%] space-y-1 ${isMine ? 'items-end text-right' : ''}`}>
-                  <div className={`flex items-center gap-2 text-xs ${isMine ? 'justify-end' : ''}`}>
-                    {!isMine && (
-                      <span className="font-semibold text-base-primary">{displayName}</span>
-                    )}
-                    <span className="text-[10px] text-base-secondary">
-                      {formatTime(msg.timestamp)}
-                    </span>
-                  </div>
-                  <div
-                    className={`inline-flex rounded-2xl px-4 py-2 text-sm leading-relaxed ${
-                      isMine ? 'bg-green-04 text-black-static' : 'bg-base-muted'
-                    }`}
-                  >
-                    <p className="whitespace-pre-wrap">{msg.message}</p>
-                  </div>
-                </div>
-                {isMine && (
-                  <div
-                    className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold overflow-hidden ${getAvatarTone(true)}`}
-                  >
-                    {msg.avatarUrl ? (
-                      <img
-                        src={msg.avatarUrl}
-                        alt={displayName}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      getInitial(displayName)
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-          <div ref={bottomRef} />
-        </div>
-        <div className="flex items-end gap-2 border-t border-border-soft bg-[var(--bg-layer-2)] px-3 py-2">
-          <textarea
-            value={input}
-            onChange={(event) => setInput(event.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={
-              isLoggedIn ? '메시지를 입력하세요...' : '로그인 후 채팅을 이용할 수 있어요.'
-            }
-            className="chat-scroll h-10 max-h-32 min-h-10 flex-1 resize-none overflow-y-auto bg-transparent text-sm text-base-primary placeholder:text-base-secondary focus:outline-none disabled:cursor-not-allowed"
-            disabled={!isLoggedIn}
-          />
-          {!isLoggedIn && (
-            <button
-              type="button"
-              onClick={handleLoginClick}
-              className="rounded-lg border border-border-soft px-3 py-2 text-xs font-bold text-base-primary transition hover:bg-base-muted"
-            >
-              로그인
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={handleSend}
-            className="rounded-lg bg-green-05 px-3 py-2 text-xs font-bold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={!isLoggedIn || !input.trim()}
-          >
-            전송
-          </button>
-        </div>
-      </section>
-    </>
+      </div>
+      <ChatMessageList messages={messages} myNickname={myNickname} />
+      <ChatInput isLoggedIn={isLoggedIn} onSend={handleSend} onLoginClick={handleLoginClick} />
+    </section>
   );
 }
 
-export default ChatSpectator;
+export default memo(ChatSpectator);

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -19,7 +19,8 @@ function CodeSpectator() {
   const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
   const [searchParams] = useSearchParams();
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? 'room-unknown';
-  const { players, codes } = useRoomStore((state) => state);
+  const players = useRoomStore((state) => state.players);
+  const codes = useRoomStore((state) => state.codes);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const socket = useBattleSocketStore((state) => state.socket);

--- a/apps/web/src/components/Header/Header.tsx
+++ b/apps/web/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import { LogOut, Moon, Settings, Sun, User as UserIcon, Volume2, VolumeX } from 'lucide-react';
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { memo, type ReactNode, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { logout } from '@/apis/auth';
@@ -199,4 +199,4 @@ function Header({ hideUserMenu = false, rightContent }: HeaderProps) {
   );
 }
 
-export default Header;
+export default memo(Header);

--- a/apps/web/src/components/Matching/MatchingCancelButton.tsx
+++ b/apps/web/src/components/Matching/MatchingCancelButton.tsx
@@ -1,17 +1,19 @@
+import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useMatchingStore } from '@/stores/matchingStore';
 import { useUserStore } from '@/stores/userStore';
 
-export function MatchingCancelButton() {
+function MatchingCancelButton() {
   const navigate = useNavigate();
-  const { cancelMatching, unregisterMatchingListeners } = useMatchingStore();
-  const setAllowNavigation = useMatchingStore((s) => s.setAllowNavigation);
-  const user = useUserStore((state) => state.user);
-  const socket = useBattleSocketStore((state) => state.socket);
 
   const handleCancel = async () => {
+    const { cancelMatching, unregisterMatchingListeners, setAllowNavigation } =
+      useMatchingStore.getState();
+    const user = useUserStore.getState().user;
+    const socket = useBattleSocketStore.getState().socket;
+
     if (!user?.id || !socket) return;
 
     try {
@@ -33,3 +35,6 @@ export function MatchingCancelButton() {
     </button>
   );
 }
+
+const MatchingCancelButtonMemo = memo(MatchingCancelButton);
+export { MatchingCancelButtonMemo as MatchingCancelButton };

--- a/apps/web/src/components/Matching/MatchingCountdown.tsx
+++ b/apps/web/src/components/Matching/MatchingCountdown.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { playBattleCountdownSound } from '@/lib/sound';
+
+interface MatchingCountdownProps {
+  onComplete: () => void;
+}
+
+export default function MatchingCountdown({ onComplete }: MatchingCountdownProps) {
+  const [countdown, setCountdown] = useState(5);
+  const hasPlayedReadyRef = useRef(false);
+  const hasPlayedStartRef = useRef(false);
+
+  // 효과음 재생 로직
+  useEffect(() => {
+    if (countdown === 5 && !hasPlayedReadyRef.current) {
+      hasPlayedReadyRef.current = true;
+      playBattleCountdownSound('tick');
+    }
+    if (countdown === 0 && !hasPlayedStartRef.current) {
+      hasPlayedStartRef.current = true;
+      playBattleCountdownSound('end');
+    }
+  }, [countdown]);
+
+  // 카운트다운 타이머 로직
+  useEffect(() => {
+    if (countdown === 0) {
+      onComplete();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setCountdown((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [countdown, onComplete]);
+
+  return (
+    <div className="text-center">
+      {countdown > 0 ? (
+        <div className="text-9xl font-black text-green-05">{countdown}</div>
+      ) : (
+        <div className="text-9xl font-black italic text-green-05 animate-bounce">FIGHT!</div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/Matching/MatchingSuccess.tsx
+++ b/apps/web/src/components/Matching/MatchingSuccess.tsx
@@ -1,21 +1,17 @@
 import { Check } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import TierBadge from '@/components/Common/TierBadge';
-import { playBattleCountdownSound } from '@/lib/sound';
 import { useMatchingStore } from '@/stores/matchingStore';
 import { useUserStore } from '@/stores/userStore';
 
-export default function MatchingSuccess() {
-  const navigate = useNavigate();
-  const [countdown, setCountdown] = useState(5);
-  const hasPlayedReadyRef = useRef(false);
-  const hasPlayedStartRef = useRef(false);
+import MatchingCountdown from './MatchingCountdown';
 
+function MatchingSuccess() {
+  const navigate = useNavigate();
   const matchResult = useMatchingStore((state) => state.matchResult);
   const user = useUserStore((state) => state.user);
-  const setAllowNavigation = useMatchingStore((s) => s.setAllowNavigation);
 
   // 매칭 성공 시 BattlePage와 에디터 prefetch
   useEffect(() => {
@@ -23,34 +19,15 @@ export default function MatchingSuccess() {
     void import('@/components/Common/BaseCodeEditor');
   }, []);
 
-  // 효과음 재생 로직
-  useEffect(() => {
-    if (countdown === 5 && !hasPlayedReadyRef.current) {
-      hasPlayedReadyRef.current = true;
-      playBattleCountdownSound('tick');
-    }
-    if (countdown === 0 && !hasPlayedStartRef.current) {
-      hasPlayedStartRef.current = true;
-      playBattleCountdownSound('end');
-    }
-  }, [countdown]);
+  const handleCountdownComplete = useCallback(() => {
+    const { setAllowNavigation } = useMatchingStore.getState();
+    const currentMatchResult = useMatchingStore.getState().matchResult;
 
-  // 카운트다운 타이머 로직
-  useEffect(() => {
-    if (countdown === 0) {
-      if (matchResult?.roomId) {
-        setAllowNavigation(true);
-        navigate(`/room/${matchResult.roomId}`, { replace: true });
-      }
-      return;
+    if (currentMatchResult?.roomId) {
+      setAllowNavigation(true);
+      navigate(`/room/${currentMatchResult.roomId}`, { replace: true });
     }
-
-    const timer = setTimeout(() => {
-      setCountdown((prev) => prev - 1);
-    }, 1000);
-
-    return () => clearTimeout(timer);
-  }, [countdown, matchResult, navigate, setAllowNavigation]);
+  }, [navigate]);
 
   if (!matchResult || !user) {
     return null;
@@ -111,13 +88,9 @@ export default function MatchingSuccess() {
       </div>
 
       {/* 카운트다운 */}
-      <div className="text-center">
-        {countdown > 0 ? (
-          <div className="text-9xl font-black text-green-05">{countdown}</div>
-        ) : (
-          <div className="text-9xl font-black italic text-green-05 animate-bounce">FIGHT!</div>
-        )}
-      </div>
+      <MatchingCountdown onComplete={handleCountdownComplete} />
     </div>
   );
 }
+
+export default memo(MatchingSuccess);

--- a/apps/web/src/components/Matching/MatchingTimer.tsx
+++ b/apps/web/src/components/Matching/MatchingTimer.tsx
@@ -1,8 +1,16 @@
-interface Props {
-  time: number;
-}
+import { useEffect, useState } from 'react';
 
-export default function MatchingTimer({ time }: Props) {
+export default function MatchingTimer() {
+  const [time, setTime] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTime((prev) => prev + 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
   const minutes = Math.floor(time / 60);
   const seconds = time % 60;
 

--- a/apps/web/src/components/Matching/MatchingWait.tsx
+++ b/apps/web/src/components/Matching/MatchingWait.tsx
@@ -1,10 +1,12 @@
+import { memo } from 'react';
+
 import { useMatchingStore } from '@/stores/matchingStore';
 
 import LoadingSpinner from './LoadingSpinner';
 import MatchingStats from './MatchingStats';
 import MatchingTimer from './MatchingTimer';
 
-export default function MatchingWait() {
+function MatchingWait() {
   const timeoutMessage = useMatchingStore((state) => state.timeoutMessage);
   return (
     <div className="max-w-4xl mx-auto select-none">
@@ -39,3 +41,5 @@ export default function MatchingWait() {
     </div>
   );
 }
+
+export default memo(MatchingWait);

--- a/apps/web/src/components/Matching/MatchingWait.tsx
+++ b/apps/web/src/components/Matching/MatchingWait.tsx
@@ -4,11 +4,7 @@ import LoadingSpinner from './LoadingSpinner';
 import MatchingStats from './MatchingStats';
 import MatchingTimer from './MatchingTimer';
 
-interface Props {
-  waitTime: number;
-}
-
-export default function MatchingWait({ waitTime }: Props) {
+export default function MatchingWait() {
   const timeoutMessage = useMatchingStore((state) => state.timeoutMessage);
   return (
     <div className="max-w-4xl mx-auto select-none">
@@ -30,7 +26,7 @@ export default function MatchingWait({ waitTime }: Props) {
         {/* 대기 시간 */}
         <div className="flex flex-col gap-2">
           <div className="flex flex-col items-center gap-2">
-            <MatchingTimer time={waitTime} />
+            <MatchingTimer />
             <div className="min-h-6">
               {timeoutMessage && <p className="text-sm">{timeoutMessage}</p>}
             </div>

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -13,7 +13,6 @@ import { useUserStore } from '@/stores/userStore';
 
 function MatchingPage() {
   const navigate = useNavigate();
-  const [waitTime, setWaitTime] = useState(0);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const isMatchingStartedRef = useRef(false);
   const user = useUserStore((state) => state.user);
@@ -74,15 +73,6 @@ function MatchingPage() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasToken, user?.id, isLoading]);
-
-  // 타이머
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setWaitTime((prev) => prev + 1);
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, []);
 
   // 페이지 이탈(뒤로가기 등) 시 cleanup
   useEffect(() => {
@@ -194,7 +184,7 @@ function MatchingPage() {
     <div className="flex min-h-screen flex-col">
       <Header rightContent={<MatchingCancelButton />} />
       <div className="flex flex-1 items-center justify-center">
-        <MatchingWait waitTime={waitTime} />
+        <MatchingWait />
       </div>
       {toastMessage && (
         <Toast

--- a/apps/web/src/pages/MatchingPage.tsx
+++ b/apps/web/src/pages/MatchingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useBlocker, useNavigate } from 'react-router-dom';
 
 import Modal from '@/components/Common/Modal';
@@ -28,6 +28,8 @@ function MatchingPage() {
 
   // 토큰 존재 여부 확인
   const hasToken = typeof window !== 'undefined' && !!localStorage.getItem('accessToken');
+
+  const cancelButton = useMemo(() => <MatchingCancelButton />, []);
 
   // 페이지 진입 시 allowNavigation 초기화
   useEffect(() => {
@@ -182,7 +184,7 @@ function MatchingPage() {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Header rightContent={<MatchingCancelButton />} />
+      <Header rightContent={cancelButton} />
       <div className="flex flex-1 items-center justify-center">
         <MatchingWait />
       </div>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig(async ({ mode }) => {
 
   const plugins: PluginOption[] = [react()];
 
+  // 개발 환경에서만 react-scan 활성화 (VITE_REACT_SCAN=false 로 비활성화 가능)
+  if (mode === 'development' && process.env.VITE_REACT_SCAN !== 'false') {
+    const { default: reactScan } = await import('@react-scan/vite-plugin-react-scan');
+    plugins.push(reactScan());
+  }
+
   // analyze 모드일 때만 visualizer 로드
   if (isAnalyze) {
     const { visualizer } = await import('rollup-plugin-visualizer');

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/pnpm-lock.yaml,**/
 
 # 테스트 파일
 sonar.tests=apps/web/src,apps/api/src,apps/judge/src
-sonar.test.inclusions=**/*.spec.ts,**/*.test.ts
+sonar.test.inclusions=**/*.spec.ts,**/*.test.ts,**/*.spec.tsx,**/*.test.tsx
 
 # 커버리지 리포트
 sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,apps/api/coverage/lcov.info,apps/judge/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.projectKey=tadak_web30-tadak
+sonar.organization=tadak
+
+# 소스
+sonar.sources=apps/web/src,apps/api/src,apps/judge/src,packages
+
+# 제외
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/pnpm-lock.yaml,**/.scannerwork/**,**/coverage/**
+
+# 테스트 파일
+sonar.tests=apps/web/src,apps/api/src,apps/judge/src
+sonar.test.inclusions=**/*.spec.ts,**/*.test.ts
+
+# 커버리지 리포트
+sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,apps/api/coverage/lcov.info,apps/judge/coverage/lcov.info
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## 🔍 PR 요약

- 매칭 & 관전자용 배틀 페이지 채팅 리렌더링 최적화

## 🧾 관련 이슈

- close #254 

## 🛠️ 주요 변경 사항

### 매칭 페이지 리렌더링 최적화

**문제**
- 매칭 대기: 타이머 state가 `MatchingPage`에 위치하여, 1초마다 갱신 시 전체 컴포넌트 리렌더 (10개)
- 매칭 완료: 카운트다운 state가 상위에 위치하여, 1초마다 갱신 시 유저 정보, 상대방 정보 등 정적 UI까지 리렌더 (7개)

**해결**
- 타이머 state를 `MatchingTimer` 내부로 이동
- **컴포넌트 분리**: `MatchingCountdown` 분리하여 카운트다운만 리렌더되도록 개선
- **React.memo** 적용: MatchingWait, MatchingSuccess, MatchingCancelButton, Header

**결과**
- 매칭 대기: 10개 → 1개 (90% 감소)
- 매칭 완료: 7개 → 1개 (85% 감소)

### 배틀 채팅 리렌더링 최적화

**문제**
- 채팅 입력 시 메시지 리스트 전체가 리렌더
- 메시지 추가 시 기존 메시지들도 함께 리렌더
- 입력 state와 메시지 리스트가 같은 컴포넌트에서 관리되어 상태 변경 시 전체 리렌더

**해결**
- **컴포넌트 분리**: `ChatInput`, `ChatMessageList`, `ChatMessageItem` 분리
- **React.memo** 적용: 각 컴포넌트에 memo 적용하여 props 미변경 시 리렌더 스킵

**결과**
- 입력 시: 전체 → 입력창만 리렌더
- 메시지 추가 시: 전체 → 새 메시지만 리렌더

## 📸 스크린샷 

### 매칭

**Before** - 입력 시 전체 채팅 영역 리렌더

https://github.com/user-attachments/assets/594d441f-57e6-4144-a778-98a17d90fd93


**After** - 입력창만 리렌더

https://github.com/user-attachments/assets/022244d1-e32b-45b1-a066-970b6b0647f8


### 배틀 채팅

**Before** - 1초마다 전체 컴포넌트 리렌더

https://github.com/user-attachments/assets/153c84fa-56ae-497a-8a48-30f02ae519c4


**After** - 타이머/카운트다운만 리렌더

https://github.com/user-attachments/assets/e5db22ee-b48d-4db1-94ae-8772fd9886dc


## 🧠 의도 및 배경

- react-scan으로 리렌더링 분석 중 반복적인 불필요 리렌더 발견
- 타이머, 채팅은 상태 변경이 빈번하여 최적화 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 스펙테이터 모드에 채팅 기능 추가(메시지 입력창, 전송, 메시지 목록, 로그인 연동)

* **개선 사항**
  * 매칭 과정의 카운트다운 UI 개선 및 전환 흐름 단순화
  * 대기/매칭 화면 구조 리팩토링으로 사용자 흐름 개선

* **최적화**
  * 여러 컴포넌트 렌더링 성능 개선(메모이제이션 적용, 불필요한 리렌더 축소)

* **구성**
  * 프로젝트 메타데이터 및 Sonar 설정 추가
  * .gitignore에 스캐너 관련 항목 추가
  * 개발 환경에서의 스캔 플러그인 통합 조정 (개발 전용)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->