### PR TITLE
[REFACTOR] Redis KEYS를 SCAN으로 변경하여 비블로킹 처리 (#265)

### DIFF
--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -250,12 +250,23 @@ export class PubsubSubscriberService implements OnModuleInit {
     return null;
   }
 
+  private async scanKeys(pattern: string): Promise<string[]> {
+    const keys: string[] = [];
+    const stream = this.redisClient.scanStream({ match: pattern, count: 100 });
+
+    return new Promise((resolve, reject) => {
+      stream.on('data', (batch: string[]) => keys.push(...batch));
+      stream.on('end', () => resolve(keys));
+      stream.on('error', reject);
+    });
+  }
+
   // socketId로 유저 정보 조회
   private async getUserInfoBySocketId(
     socketId: string,
   ): Promise<{ roomId: string; userId: string; username: string } | null> {
-    // Redis에서 socketId로 userId 찾기 (모든 matching:user:* 키 순회)
-    const keys = await this.redisClient.keys('matching:user:*');
+    // Redis에서 socketId로 userId 찾기 (SCAN으로 비블로킹 조회)
+    const keys = await this.scanKeys('matching:user:*');
 
     for (const key of keys) {
       const userData = await this.redisClient.hgetall(key);

--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -266,7 +266,7 @@ export class PubsubSubscriberService implements OnModuleInit {
     socketId: string,
   ): Promise<{ roomId: string; userId: string; username: string } | null> {
     // Redis에서 socketId로 userId 찾기 (SCAN으로 비블로킹 조회)
-    const keys = await this.scanKeys('matching:user:*');
+    const keys = await this.scanKeys(RedisKeys.matchingUser('*'));
 
     for (const key of keys) {
       const userData = await this.redisClient.hgetall(key);

--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -8,6 +8,7 @@ import { Repository } from 'typeorm';
 import { BattleGateway } from '../battle/battle.gateway';
 import { BattleService } from '../battle/battle.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
+import { scanKeys } from '../redis/redis.util';
 import { RedisKeys } from '../redis/redis-key.constant';
 import { Submission } from '../submission/submission.entity';
 import { PubsubGateway } from './pubsub.gateway';
@@ -250,23 +251,12 @@ export class PubsubSubscriberService implements OnModuleInit {
     return null;
   }
 
-  private async scanKeys(pattern: string): Promise<string[]> {
-    const keys: string[] = [];
-    const stream = this.redisClient.scanStream({ match: pattern, count: 100 });
-
-    return new Promise((resolve, reject) => {
-      stream.on('data', (batch: string[]) => keys.push(...batch));
-      stream.on('end', () => resolve(keys));
-      stream.on('error', reject);
-    });
-  }
-
   // socketId로 유저 정보 조회
   private async getUserInfoBySocketId(
     socketId: string,
   ): Promise<{ roomId: string; userId: string; username: string } | null> {
     // Redis에서 socketId로 userId 찾기 (SCAN으로 비블로킹 조회)
-    const keys = await this.scanKeys(RedisKeys.matchingUser('*'));
+    const keys = await scanKeys(this.redisClient, RedisKeys.matchingUser('*'));
 
     for (const key of keys) {
       const userData = await this.redisClient.hgetall(key);

--- a/apps/api/src/redis/redis.util.ts
+++ b/apps/api/src/redis/redis.util.ts
@@ -1,0 +1,12 @@
+import Redis from 'ioredis';
+
+export async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+  const keys: string[] = [];
+  const stream = redis.scanStream({ match: pattern, count: 100 });
+
+  return new Promise((resolve, reject) => {
+    stream.on('data', (batch: string[]) => keys.push(...batch));
+    stream.on('end', () => resolve(keys));
+    stream.on('error', reject);
+  });
+}

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -189,9 +189,20 @@ export class RoomService {
     await pipeline.exec();
   }
 
+  private async scanKeys(pattern: string): Promise<string[]> {
+    const keys: string[] = [];
+    const stream = this.redis.scanStream({ match: pattern, count: 100 });
+
+    return new Promise((resolve, reject) => {
+      stream.on('data', (batch: string[]) => keys.push(...batch));
+      stream.on('end', () => resolve(keys));
+      stream.on('error', reject);
+    });
+  }
+
   async listRooms(): Promise<Room[]> {
-    // 방 정보를 담고 있는 모든 키 조회
-    const keys = await this.redis.keys(RedisKeys.room('*'));
+    // 방 정보를 담고 있는 모든 키 조회 (SCAN 사용으로 비블로킹)
+    const keys = await this.scanKeys(RedisKeys.room('*'));
     if (!keys.length) return [];
 
     // 파이프라인으로 한 번에 조회 후 파싱

--- a/apps/api/src/room/room.service.ts
+++ b/apps/api/src/room/room.service.ts
@@ -12,6 +12,7 @@ import { ProblemService } from '@/problem/problem.service';
 
 import { BattleService } from '../battle/battle.service';
 import { REDIS_CLIENT } from '../redis/redis.module';
+import { scanKeys } from '../redis/redis.util';
 import { RedisKeys } from '../redis/redis-key.constant';
 import { REDIS_TTL } from '../redis/redis-ttl.constant';
 
@@ -189,20 +190,9 @@ export class RoomService {
     await pipeline.exec();
   }
 
-  private async scanKeys(pattern: string): Promise<string[]> {
-    const keys: string[] = [];
-    const stream = this.redis.scanStream({ match: pattern, count: 100 });
-
-    return new Promise((resolve, reject) => {
-      stream.on('data', (batch: string[]) => keys.push(...batch));
-      stream.on('end', () => resolve(keys));
-      stream.on('error', reject);
-    });
-  }
-
   async listRooms(): Promise<Room[]> {
     // 방 정보를 담고 있는 모든 키 조회 (SCAN 사용으로 비블로킹)
-    const keys = await this.scanKeys(RedisKeys.room('*'));
+    const keys = await scanKeys(this.redis, RedisKeys.room('*'));
     if (!keys.length) return [];
 
     // 파이프라인으로 한 번에 조회 후 파싱


### PR DESCRIPTION


## 🔍 PR 요약

- Redis KEYS를 SCAN으로 변경하여 비블로킹 처리

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #265 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- KEYS 명령어는 모든 키를 한 번에 조회하여 Redis 블로킹 발생
- SCAN은 커서 기반으로 점진적 조회하여 운영 환경에서 안전


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- Redis 조회 데이터가 많을 시 블로킹 상황을 방지하기 위함

## 💬 리뷰 요구사항(선택)

- 사실 조회 키 몇 만개 정도는 기존에도 문제 없이 동작하겠지만, 장애 가능성을 고려하여 분리하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 사용자 정보 조회 및 방 목록 열람이 블로킹 방식에서 비동기 스트리밍 기반 조회로 전환되어 대규모 데이터셋에서 응답성이 향상되었습니다. 서비스 전반에서 더 빠르고 안정적인 사용자 경험을 제공합니다.
* **기능 개선**
  * 키 검색 과정이 비차단 방식으로 개선되어 조회 중 시스템 부담이 줄어들고 동시성 처리 효율이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->