### PR TITLE
[REFACTOR] CodeEditor/CodeSpectator 불필요한 리렌더 줄이기 (#261)

### DIFF
--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -3,7 +3,7 @@ import { BATTLE_CONFIG, BATTLE_EVENTS, DEFAULT_CODE_TEMPLATE } from '@shared/con
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { FinalResultMessage, TestcaseUpdateMessage } from '@shared/types/pubsub';
 import { Code } from 'lucide-react';
-import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, memo, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -11,6 +11,7 @@ import { createDryRun, createSubmission } from '@/apis/submission';
 import EditorFooter from '@/components/Battle/Player/EditorFooter';
 import TestcaseResultPanel from '@/components/Battle/Player/TestcaseResultPanel';
 import Toast from '@/components/Common/Toast';
+import { useBattleExecutionStore } from '@/stores/battleExecutionStore';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
@@ -56,10 +57,6 @@ const EditorPane = memo(function EditorPane({
   );
 });
 
-type SubmissionProgress = TestcaseUpdateMessage['progress'];
-type TestcaseResult = TestcaseUpdateMessage['testcase'] & {
-  results?: TestcaseUpdateMessage['results'];
-};
 type TestcaseUpdatePayload = Omit<TestcaseUpdateMessage, 'type'> & {
   results?: TestcaseUpdateMessage['results'];
 };
@@ -104,12 +101,6 @@ function CodeEditor() {
   );
 
   const [editorSeed, setEditorSeed] = useState(DEFAULT_CODE_TEMPLATE);
-  const [statusText, setStatusText] = useState('대기 중');
-  const [progress, setProgress] = useState<SubmissionProgress | null>(null);
-  const [isTesting, setIsTesting] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [testcaseResults, setTestcaseResults] = useState<TestcaseResult[]>([]);
-  const [mode, setMode] = useState<'TEST' | 'SUBMISSION' | null>(null);
   const [pasteToastMessage, setPasteToastMessage] = useState<string | null>(null);
 
   const executionRef = useRef<ExecutionState | null>(null);
@@ -123,6 +114,25 @@ function CodeEditor() {
     useShallow((state) => ({
       problemId: state.problem?.id ?? null,
       battleId: state.problem?.battleId ?? null,
+    })),
+  );
+  const {
+    setStatusText,
+    setProgress,
+    setIsTesting,
+    setIsSubmitting,
+    setMode,
+    setTestcaseResults,
+    upsertTestcaseResult,
+  } = useBattleExecutionStore(
+    useShallow((state) => ({
+      setStatusText: state.setStatusText,
+      setProgress: state.setProgress,
+      setIsTesting: state.setIsTesting,
+      setIsSubmitting: state.setIsSubmitting,
+      setMode: state.setMode,
+      setTestcaseResults: state.setTestcaseResults,
+      upsertTestcaseResult: state.upsertTestcaseResult,
     })),
   );
 
@@ -214,12 +224,7 @@ function CodeEditor() {
         setProgress(payload.progress);
       }
 
-      setTestcaseResults((prev) => {
-        const next = prev.filter((item) => item.index !== payload.testcase.index);
-        next.push({ ...payload.testcase, results: payload.results });
-        next.sort((a, b) => a.index - b.index);
-        return next;
-      });
+      upsertTestcaseResult({ ...payload.testcase, results: payload.results });
 
       setStatusText(execution.type === 'TEST' ? '테스트 진행 중' : '채점 진행 중');
     };
@@ -286,7 +291,18 @@ function CodeEditor() {
       socket.off('testcase-update', handleTestcaseUpdate);
       socket.off('submission-result', handleSubmissionResult);
     };
-  }, [me?.userId, roomId, socket, upsertProgress, syncProgress]);
+  }, [
+    me?.userId,
+    roomId,
+    socket,
+    upsertProgress,
+    syncProgress,
+    setProgress,
+    setStatusText,
+    setIsSubmitting,
+    setIsTesting,
+    upsertTestcaseResult,
+  ]);
 
   const handleCodeChange = useCallback(
     (value: string) => {
@@ -376,7 +392,7 @@ function CodeEditor() {
       resetOnError('TEST');
       console.error(error);
     }
-  }, [battleId, editorSeed, problemId, resetOnError, socket]);
+  }, [battleId, editorSeed, initSubmission, problemId, resetOnError, setStatusText, socket]);
 
   const handleSubmit = useCallback(async () => {
     // 이미 실행 중이면 무시
@@ -410,12 +426,7 @@ function CodeEditor() {
       resetOnError('SUBMISSION');
       console.error(error);
     }
-  }, [battleId, editorSeed, problemId, resetOnError, socket]);
-
-  const progressLabel = useMemo(
-    () => (progress ? `${progress.passed}/${progress.total}` : '0/0'),
-    [progress],
-  );
+  }, [battleId, editorSeed, initSubmission, problemId, resetOnError, setStatusText, socket]);
 
   const handleEditorMount: OnMount = useCallback(
     (editor) => {
@@ -462,15 +473,8 @@ function CodeEditor() {
             onMount={handleEditorMount}
           />
         </div>
-        <EditorFooter
-          statusText={statusText}
-          progressLabel={progressLabel}
-          isTesting={isTesting}
-          isSubmitting={isSubmitting}
-          onDryRun={handleDryRun}
-          onSubmit={handleSubmit}
-        />
-        <TestcaseResultPanel testcaseResults={testcaseResults} mode={mode} />
+        <EditorFooter onDryRun={handleDryRun} onSubmit={handleSubmit} />
+        <TestcaseResultPanel />
       </section>
       {pasteToastMessage && (
         <Toast message={pasteToastMessage} onClose={() => setPasteToastMessage(null)} />

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -3,7 +3,7 @@ import { BATTLE_CONFIG, BATTLE_EVENTS, DEFAULT_CODE_TEMPLATE } from '@shared/con
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { FinalResultMessage, TestcaseUpdateMessage } from '@shared/types/pubsub';
 import { Code } from 'lucide-react';
-import { lazy, memo, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -373,7 +373,10 @@ function CodeEditor() {
     }
   }, [battleId, code, problemId, resetOnError, socket]);
 
-  const progressLabel = progress ? `${progress.passed}/${progress.total}` : '0/0';
+  const progressLabel = useMemo(
+    () => (progress ? `${progress.passed}/${progress.total}` : '0/0'),
+    [progress],
+  );
 
   const handleEditorMount: OnMount = useCallback(
     (editor) => {

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -19,6 +19,43 @@ import { useRoomStore } from '@/stores/roomStore';
 
 const LazyBaseCodeEditor = lazy(() => import('@/components/Common/BaseCodeEditor'));
 
+type EditorPaneProps = {
+  initialValue: string;
+  onCodeChange: (value: string) => void;
+  onMount: OnMount;
+};
+
+const EditorPane = memo(function EditorPane({
+  initialValue,
+  onCodeChange,
+  onMount,
+}: EditorPaneProps) {
+  const [localCode, setLocalCode] = useState(initialValue);
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full items-center justify-center">에디터를 불러오는 중...</div>
+      }
+    >
+      <LazyBaseCodeEditor
+        value={localCode}
+        onChange={(nextValue) => {
+          const normalized = nextValue || '';
+          setLocalCode(normalized);
+          onCodeChange(normalized);
+        }}
+        onMount={onMount}
+        options={{
+          quickSuggestions: false, // 자동 완성 비활성화
+          suggestOnTriggerCharacters: false, // 트리거 문자 입력 시 자동 완성 비활성화
+          snippetSuggestions: 'none', // 스니펫 비활성화
+          wordBasedSuggestions: 'off', // 단어 기반 제안 비활성화
+        }}
+      />
+    </Suspense>
+  );
+});
+
 type SubmissionProgress = TestcaseUpdateMessage['progress'];
 type TestcaseResult = TestcaseUpdateMessage['testcase'] & {
   results?: TestcaseUpdateMessage['results'];
@@ -66,7 +103,7 @@ function CodeEditor() {
     })),
   );
 
-  const [code, setCode] = useState(DEFAULT_CODE_TEMPLATE);
+  const [editorSeed, setEditorSeed] = useState(DEFAULT_CODE_TEMPLATE);
   const [statusText, setStatusText] = useState('대기 중');
   const [progress, setProgress] = useState<SubmissionProgress | null>(null);
   const [isTesting, setIsTesting] = useState(false);
@@ -151,7 +188,7 @@ function CodeEditor() {
       if (hasEditedRef.current || hasSyncedRef.current) return;
       const incomingCode = typeof payload.code === 'string' ? payload.code : '';
       if (incomingCode.trim().length > 0) {
-        setCode(incomingCode);
+        setEditorSeed(incomingCode);
       }
       hasSyncedRef.current = true;
     };
@@ -251,10 +288,9 @@ function CodeEditor() {
     };
   }, [me?.userId, roomId, socket, upsertProgress, syncProgress]);
 
-  const handleChange = useCallback(
+  const handleCodeChange = useCallback(
     (value: string) => {
       hasEditedRef.current = true;
-      setCode(value);
       if (!socket?.connected) return;
       if (!me?.userId) return;
 
@@ -331,13 +367,16 @@ function CodeEditor() {
     initSubmission('TEST');
 
     try {
-      await createDryRun({ problemId, code, language: BATTLE_CONFIG.DEFAULT_LANGUAGE }, socket.id);
+      await createDryRun(
+        { problemId, code: editorSeed, language: BATTLE_CONFIG.DEFAULT_LANGUAGE },
+        socket.id,
+      );
       setStatusText('테스트 대기 중');
     } catch (error) {
       resetOnError('TEST');
       console.error(error);
     }
-  }, [battleId, code, problemId, resetOnError, socket]);
+  }, [battleId, editorSeed, problemId, resetOnError, socket]);
 
   const handleSubmit = useCallback(async () => {
     // 이미 실행 중이면 무시
@@ -357,7 +396,7 @@ function CodeEditor() {
       const response = await createSubmission(
         {
           problemId,
-          code,
+          code: editorSeed,
           language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
           ...(battleId ? { battleId } : {}),
         },
@@ -371,7 +410,7 @@ function CodeEditor() {
       resetOnError('SUBMISSION');
       console.error(error);
     }
-  }, [battleId, code, problemId, resetOnError, socket]);
+  }, [battleId, editorSeed, problemId, resetOnError, socket]);
 
   const progressLabel = useMemo(
     () => (progress ? `${progress.passed}/${progress.total}` : '0/0'),
@@ -416,23 +455,12 @@ function CodeEditor() {
           </div>
         </div>
         <div className="min-h-[320px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
-          <Suspense
-            fallback={
-              <div className="flex h-full items-center justify-center">에디터를 불러오는 중...</div>
-            }
-          >
-            <LazyBaseCodeEditor
-              value={code}
-              onChange={(value) => handleChange(value || '')}
-              onMount={handleEditorMount}
-              options={{
-                quickSuggestions: false, // 자동 완성 비활성화
-                suggestOnTriggerCharacters: false, // 트리거 문자 입력 시 자동 완성 비활성화
-                snippetSuggestions: 'none', // 스니펫 비활성화
-                wordBasedSuggestions: 'off', // 단어 기반 제안 비활성화
-              }}
-            />
-          </Suspense>
+          <EditorPane
+            key={editorSeed}
+            initialValue={editorSeed}
+            onCodeChange={handleCodeChange}
+            onMount={handleEditorMount}
+          />
         </div>
         <EditorFooter
           statusText={statusText}

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -3,7 +3,7 @@ import { BATTLE_CONFIG, BATTLE_EVENTS, DEFAULT_CODE_TEMPLATE } from '@shared/con
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { FinalResultMessage, TestcaseUpdateMessage } from '@shared/types/pubsub';
 import { Code } from 'lucide-react';
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { lazy, memo, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -251,19 +251,22 @@ function CodeEditor() {
     };
   }, [me?.userId, roomId, socket, upsertProgress, syncProgress]);
 
-  const handleChange = (value: string) => {
-    hasEditedRef.current = true;
-    setCode(value);
-    if (!socket?.connected) return;
-    if (!me?.userId) return;
+  const handleChange = useCallback(
+    (value: string) => {
+      hasEditedRef.current = true;
+      setCode(value);
+      if (!socket?.connected) return;
+      if (!me?.userId) return;
 
-    socket.emit(BATTLE_EVENTS.CODE_CHANGE, {
-      roomId,
-      userId: me.userId,
-      code: value,
-      language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
-    });
-  };
+      socket.emit(BATTLE_EVENTS.CODE_CHANGE, {
+        roomId,
+        userId: me.userId,
+        code: value,
+        language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
+      });
+    },
+    [me, roomId, socket],
+  );
 
   const resetExecution = (type: 'TEST' | 'SUBMISSION', statusMessage: string) => {
     clearExecutionTimeout();
@@ -313,7 +316,7 @@ function CodeEditor() {
     setMode(null);
   };
 
-  const handleDryRun = async () => {
+  const handleDryRun = useCallback(async () => {
     // 이미 실행 중이면 무시
     if (executionRef.current) return;
     if (!socket?.connected || !socket.id) {
@@ -334,9 +337,9 @@ function CodeEditor() {
       resetOnError('TEST');
       console.error(error);
     }
-  };
+  }, [battleId, code, problemId, resetOnError, socket]);
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     // 이미 실행 중이면 무시
     if (executionRef.current) return;
     if (!socket?.connected || !socket.id) {
@@ -368,33 +371,36 @@ function CodeEditor() {
       resetOnError('SUBMISSION');
       console.error(error);
     }
-  };
+  }, [battleId, code, problemId, resetOnError, socket]);
 
   const progressLabel = progress ? `${progress.passed}/${progress.total}` : '0/0';
 
-  const handleEditorMount: OnMount = (editor) => {
-    const domNode = editor.getDomNode();
-    if (!domNode) return;
+  const handleEditorMount: OnMount = useCallback(
+    (editor) => {
+      const domNode = editor.getDomNode();
+      if (!domNode) return;
 
-    editorDomRef.current = domNode;
-    const handlePaste = (event: ClipboardEvent) => {
-      if (!isCheatDetectionEnabled) return;
-      event.preventDefault();
-      event.stopPropagation();
-      const now = Date.now();
-      if (now - lastPasteAtRef.current < 1000) return;
-      lastPasteAtRef.current = now;
-      setPasteToastMessage('외부 코드 붙여넣기는 금지되어 있습니다! 🚫');
+      editorDomRef.current = domNode;
+      const handlePaste = (event: ClipboardEvent) => {
+        if (!isCheatDetectionEnabled) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const now = Date.now();
+        if (now - lastPasteAtRef.current < 1000) return;
+        lastPasteAtRef.current = now;
+        setPasteToastMessage('외부 코드 붙여넣기는 금지되어 있습니다! 🚫');
 
-      const activeSocket = socket ?? connect();
-      if (activeSocket?.connected && isCheatDetectionEnabled) {
-        activeSocket.emit(SOCKET_EVENT.CHEAT_WARNING, { roomId, type: 'PASTE' });
-      }
-    };
+        const activeSocket = socket ?? connect();
+        if (activeSocket?.connected && isCheatDetectionEnabled) {
+          activeSocket.emit(SOCKET_EVENT.CHEAT_WARNING, { roomId, type: 'PASTE' });
+        }
+      };
 
-    pasteHandlerRef.current = handlePaste;
-    domNode.addEventListener('paste', handlePaste, true);
-  };
+      pasteHandlerRef.current = handlePaste;
+      domNode.addEventListener('paste', handlePaste, true);
+    },
+    [connect, isCheatDetectionEnabled, roomId, socket],
+  );
 
   return (
     <>
@@ -442,4 +448,4 @@ function CodeEditor() {
   );
 }
 
-export default CodeEditor;
+export default memo(CodeEditor);

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -5,6 +5,7 @@ import type { FinalResultMessage, TestcaseUpdateMessage } from '@shared/types/pu
 import { Code } from 'lucide-react';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 
 import { createDryRun, createSubmission } from '@/apis/submission';
 import EditorFooter from '@/components/Battle/Player/EditorFooter';
@@ -44,14 +45,26 @@ function CodeEditor() {
   const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
   const [searchParams] = useSearchParams();
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? 'room-unknown';
-  const me = useRoomStore((state: { me?: Player }) => state.me);
-  const setMe = useRoomStore((state: { setMe: (me: Player) => void }) => state.setMe);
+  const { me, setMe } = useRoomStore(
+    useShallow((state: { me?: Player; setMe: (me: Player) => void }) => ({
+      me: state.me,
+      setMe: state.setMe,
+    })),
+  );
   const isCheatDetectionEnabled = import.meta.env.VITE_CHEAT_DETECTION_ENABLED !== 'false';
 
-  const socket = useBattleSocketStore((state) => state.socket);
-  const connect = useBattleSocketStore((state) => state.connect);
-  const upsertProgress = useBattleProgressStore((state) => state.upsertProgress);
-  const syncProgress = useBattleProgressStore((state) => state.syncProgress);
+  const { socket, connect } = useBattleSocketStore(
+    useShallow((state) => ({
+      socket: state.socket,
+      connect: state.connect,
+    })),
+  );
+  const { upsertProgress, syncProgress } = useBattleProgressStore(
+    useShallow((state) => ({
+      upsertProgress: state.upsertProgress,
+      syncProgress: state.syncProgress,
+    })),
+  );
 
   const [code, setCode] = useState(DEFAULT_CODE_TEMPLATE);
   const [statusText, setStatusText] = useState('대기 중');
@@ -69,8 +82,12 @@ function CodeEditor() {
   const editorDomRef = useRef<HTMLElement | null>(null);
   const pasteHandlerRef = useRef<((event: ClipboardEvent) => void) | null>(null);
   const lastPasteAtRef = useRef(0);
-  const problemId = useBattleProblemStore((state) => state.problem?.id ?? null);
-  const battleId = useBattleProblemStore((state) => state.problem?.battleId ?? null);
+  const { problemId, battleId } = useBattleProblemStore(
+    useShallow((state) => ({
+      problemId: state.problem?.id ?? null,
+      battleId: state.problem?.battleId ?? null,
+    })),
+  );
 
   const clearExecutionTimeout = () => {
     if (timeoutRef.current) {

--- a/apps/web/src/components/Battle/Player/EditorFooter.tsx
+++ b/apps/web/src/components/Battle/Player/EditorFooter.tsx
@@ -1,20 +1,21 @@
+import { memo, useMemo } from 'react';
+
+import { useBattleExecutionStore } from '@/stores/battleExecutionStore';
+
 type EditorFooterProps = {
-  statusText: string;
-  progressLabel: string;
-  isTesting: boolean;
-  isSubmitting: boolean;
   onDryRun: () => void;
   onSubmit: () => void;
 };
 
-function EditorFooter({
-  statusText,
-  progressLabel,
-  isTesting,
-  isSubmitting,
-  onDryRun,
-  onSubmit,
-}: EditorFooterProps) {
+function EditorFooter({ onDryRun, onSubmit }: EditorFooterProps) {
+  const statusText = useBattleExecutionStore((state) => state.statusText);
+  const progress = useBattleExecutionStore((state) => state.progress);
+  const isTesting = useBattleExecutionStore((state) => state.isTesting);
+  const isSubmitting = useBattleExecutionStore((state) => state.isSubmitting);
+  const progressLabel = useMemo(
+    () => (progress ? `${progress.passed}/${progress.total}` : '0/0'),
+    [progress],
+  );
   const isDisabled = isTesting || isSubmitting;
 
   return (
@@ -44,4 +45,4 @@ function EditorFooter({
   );
 }
 
-export default EditorFooter;
+export default memo(EditorFooter);

--- a/apps/web/src/components/Battle/Player/TestcaseResultPanel.tsx
+++ b/apps/web/src/components/Battle/Player/TestcaseResultPanel.tsx
@@ -1,14 +1,7 @@
-import type { TestcaseStatus, TestcaseUpdateMessage } from '@shared/types/pubsub';
-import { useEffect, useRef } from 'react';
+import type { TestcaseStatus } from '@shared/types/pubsub';
+import { memo, useEffect, useRef } from 'react';
 
-type TestcaseResult = TestcaseUpdateMessage['testcase'] & {
-  results?: TestcaseUpdateMessage['results'];
-};
-
-type TestcaseResultPanelProps = {
-  testcaseResults: TestcaseResult[];
-  mode?: 'TEST' | 'SUBMISSION' | null;
-};
+import { useBattleExecutionStore } from '@/stores/battleExecutionStore';
 
 function getStatusColor(status: TestcaseStatus) {
   switch (status) {
@@ -27,7 +20,9 @@ function getStatusColor(status: TestcaseStatus) {
   }
 }
 
-function TestcaseResultPanel({ testcaseResults, mode }: TestcaseResultPanelProps) {
+function TestcaseResultPanel() {
+  const testcaseResults = useBattleExecutionStore((state) => state.testcaseResults);
+  const mode = useBattleExecutionStore((state) => state.mode);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -117,4 +112,4 @@ function TestcaseResultPanel({ testcaseResults, mode }: TestcaseResultPanelProps
   );
 }
 
-export default TestcaseResultPanel;
+export default memo(TestcaseResultPanel);

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -1,7 +1,7 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
 import type { FinalResultMessage } from '@shared/types/pubsub';
 import { Code } from 'lucide-react';
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { lazy, memo, Suspense, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -181,4 +181,4 @@ function CodeSpectator() {
   );
 }
 
-export default CodeSpectator;
+export default memo(CodeSpectator);

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -20,10 +20,9 @@ function CodeSpectator() {
   const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
   const [searchParams] = useSearchParams();
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? 'room-unknown';
-  const { players, codes } = useRoomStore(
+  const { players } = useRoomStore(
     useShallow((state) => ({
       players: state.players,
-      codes: state.codes,
     })),
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -34,9 +33,8 @@ function CodeSpectator() {
       connect: state.connect,
     })),
   );
-  const { progresses, upsertProgress } = useBattleProgressStore(
+  const { upsertProgress } = useBattleProgressStore(
     useShallow((state) => ({
-      progresses: state.progresses,
       upsertProgress: state.upsertProgress,
     })),
   );
@@ -117,8 +115,12 @@ function CodeSpectator() {
   }, [firstParticipantId, participants, selectedId]);
 
   const activeSelectedId = selectedId ?? firstParticipantId;
-  const selectedProgress = activeSelectedId ? progresses[activeSelectedId] : null;
-  const rawSelectedCode = activeSelectedId ? codes[activeSelectedId] : undefined;
+  const selectedProgress = useBattleProgressStore((state) =>
+    activeSelectedId ? state.progresses[activeSelectedId] : null,
+  );
+  const rawSelectedCode = useRoomStore((state) =>
+    activeSelectedId ? state.codes[activeSelectedId] : undefined,
+  );
   const isCodeEmpty = !rawSelectedCode || rawSelectedCode.trim().length === 0;
   const selectedCode = isCodeEmpty ? '아직 입력된 코드가 없어요 🙂' : rawSelectedCode;
 

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -3,6 +3,7 @@ import type { FinalResultMessage } from '@shared/types/pubsub';
 import { Code } from 'lucide-react';
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 
 import ProgressBarSpectator from '@/components/Battle/Spectator/ProgressBarSpectator';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
@@ -19,14 +20,26 @@ function CodeSpectator() {
   const { roomId: roomIdParam } = useParams<{ roomId?: string }>();
   const [searchParams] = useSearchParams();
   const roomId = roomIdParam ?? searchParams.get('roomId') ?? 'room-unknown';
-  const players = useRoomStore((state) => state.players);
-  const codes = useRoomStore((state) => state.codes);
+  const { players, codes } = useRoomStore(
+    useShallow((state) => ({
+      players: state.players,
+      codes: state.codes,
+    })),
+  );
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const socket = useBattleSocketStore((state) => state.socket);
-  const connect = useBattleSocketStore((state) => state.connect);
-  const progresses = useBattleProgressStore((state) => state.progresses);
-  const upsertProgress = useBattleProgressStore((state) => state.upsertProgress);
+  const { socket, connect } = useBattleSocketStore(
+    useShallow((state) => ({
+      socket: state.socket,
+      connect: state.connect,
+    })),
+  );
+  const { progresses, upsertProgress } = useBattleProgressStore(
+    useShallow((state) => ({
+      progresses: state.progresses,
+      upsertProgress: state.upsertProgress,
+    })),
+  );
 
   useEffect(() => {
     const client = socket ?? connect();

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -1,16 +1,14 @@
 import { BATTLE_EVENTS } from '@shared/constants/battle';
 import type { FinalResultMessage } from '@shared/types/pubsub';
-import { Code } from 'lucide-react';
-import { lazy, memo, Suspense, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 
+import CodeSpectatorEditor from '@/components/Battle/Spectator/CodeSpectatorEditor';
 import ProgressBarSpectator from '@/components/Battle/Spectator/ProgressBarSpectator';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
 import { useRoomStore } from '@/stores/roomStore';
-
-const BaseCodeEditor = lazy(() => import('@/components/Common/BaseCodeEditor'));
 
 type SubmissionResultPayload = Omit<FinalResultMessage, 'type'> & {
   userId?: string;
@@ -115,14 +113,6 @@ function CodeSpectator() {
   }, [firstParticipantId, participants, selectedId]);
 
   const activeSelectedId = selectedId ?? firstParticipantId;
-  const selectedProgress = useBattleProgressStore((state) =>
-    activeSelectedId ? state.progresses[activeSelectedId] : null,
-  );
-  const rawSelectedCode = useRoomStore((state) =>
-    activeSelectedId ? state.codes[activeSelectedId] : undefined,
-  );
-  const isCodeEmpty = !rawSelectedCode || rawSelectedCode.trim().length === 0;
-  const selectedCode = isCodeEmpty ? '아직 입력된 코드가 없어요 🙂' : rawSelectedCode;
 
   return (
     <>
@@ -133,51 +123,7 @@ function CodeSpectator() {
           onSelect={setSelectedId}
         />
 
-        <div className="flex flex-col overflow-hidden rounded-2xl border border-border-soft bg-(bg-layer-2) text-base-primary shadow-inner shadow-slate-950/10 xl:flex-1 xl:min-h-0">
-          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-soft bg-(--bg-layer-2) px-4 py-3 text-sm font-semibold">
-            <div className="flex items-center gap-2">
-              <Code className="h-5 w-5 text-green-05" strokeWidth={2.5} />
-              <span className="rounded pr-3 text-sm font-bold text-green-05">코드 에디터</span>
-              <span className="text-color-green-05">
-                {participants.find((p) => p.userId === selectedId)?.username ?? '관전자'}
-              </span>
-            </div>
-            <div className="flex items-center gap-2 text-xs text-base-secondary">
-              <span className="rounded-full bg-base-muted px-3 py-1 text-base-primary">
-                JavaScript
-              </span>
-            </div>
-          </div>
-
-          <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
-            <Suspense
-              fallback={
-                <div className="flex h-full items-center justify-center">
-                  에디터를 불러오는 중...
-                </div>
-              }
-            >
-              <BaseCodeEditor
-                value={selectedCode}
-                options={{
-                  readOnly: true,
-                  renderLineHighlight: 'none',
-                  contextmenu: false,
-                  folding: false,
-                  hideCursorInOverviewRuler: true,
-                }}
-              />
-            </Suspense>
-          </div>
-          <div className="flex items-center justify-end gap-4 border-t border-border-soft bg-(--bg-layer-2) px-4 py-3 text-xs text-base-secondary">
-            <span className="flex items-center gap-1 text-green-05">
-              ● {selectedProgress?.passed ?? 0}개 테스트 통과
-            </span>
-            <span className="flex items-center gap-1 text-pink-05">
-              ● {(selectedProgress?.total ?? 0) - (selectedProgress?.passed ?? 0)}개 실패
-            </span>
-          </div>
-        </div>
+        <CodeSpectatorEditor activeSelectedId={activeSelectedId} participants={participants} />
       </section>
     </>
   );

--- a/apps/web/src/components/Battle/Spectator/CodeSpectatorEditor.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectatorEditor.tsx
@@ -1,0 +1,78 @@
+import { Code } from 'lucide-react';
+import { lazy, memo, Suspense, useMemo } from 'react';
+
+import { useBattleProgressStore } from '@/stores/battleProgressStore';
+import { useRoomStore } from '@/stores/roomStore';
+
+const BaseCodeEditor = lazy(() => import('@/components/Common/BaseCodeEditor'));
+
+type Participant = {
+  userId: string;
+  username: string;
+};
+
+type CodeSpectatorEditorProps = {
+  activeSelectedId: string | null;
+  participants: Participant[];
+};
+
+function CodeSpectatorEditor({ activeSelectedId, participants }: CodeSpectatorEditorProps) {
+  const selectedProgress = useBattleProgressStore((state) =>
+    activeSelectedId ? state.progresses[activeSelectedId] : null,
+  );
+  const rawSelectedCode = useRoomStore((state) =>
+    activeSelectedId ? state.codes[activeSelectedId] : undefined,
+  );
+
+  const selectedCode = useMemo(() => {
+    const isCodeEmpty = !rawSelectedCode || rawSelectedCode.trim().length === 0;
+    return isCodeEmpty ? '아직 입력된 코드가 없어요 🙂' : rawSelectedCode;
+  }, [rawSelectedCode]);
+
+  const selectedName =
+    participants.find((p) => p.userId === activeSelectedId)?.username ?? '관전자';
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-2xl border border-border-soft bg-(bg-layer-2) text-base-primary shadow-inner shadow-slate-950/10 xl:flex-1 xl:min-h-0">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border-soft bg-(--bg-layer-2) px-4 py-3 text-sm font-semibold">
+        <div className="flex items-center gap-2">
+          <Code className="h-5 w-5 text-green-05" strokeWidth={2.5} />
+          <span className="rounded pr-3 text-sm font-bold text-green-05">코드 에디터</span>
+          <span className="text-color-green-05">{selectedName}</span>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-base-secondary">
+          <span className="rounded-full bg-base-muted px-3 py-1 text-base-primary">JavaScript</span>
+        </div>
+      </div>
+
+      <div className="min-h-[520px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
+        <Suspense
+          fallback={
+            <div className="flex h-full items-center justify-center">에디터를 불러오는 중...</div>
+          }
+        >
+          <BaseCodeEditor
+            value={selectedCode}
+            options={{
+              readOnly: true,
+              renderLineHighlight: 'none',
+              contextmenu: false,
+              folding: false,
+              hideCursorInOverviewRuler: true,
+            }}
+          />
+        </Suspense>
+      </div>
+      <div className="flex items-center justify-end gap-4 border-t border-border-soft bg-(--bg-layer-2) px-4 py-3 text-xs text-base-secondary">
+        <span className="flex items-center gap-1 text-green-05">
+          ● {selectedProgress?.passed ?? 0}개 테스트 통과
+        </span>
+        <span className="flex items-center gap-1 text-pink-05">
+          ● {(selectedProgress?.total ?? 0) - (selectedProgress?.passed ?? 0)}개 실패
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default memo(CodeSpectatorEditor);

--- a/apps/web/src/components/Battle/Spectator/ProgressBarSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/ProgressBarSpectator.tsx
@@ -1,4 +1,5 @@
 import type { UserStats } from '@shared/types/user';
+import { memo } from 'react';
 
 import TierBadge from '@/components/Common/TierBadge';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
@@ -80,4 +81,4 @@ function ProgressBarSpectator({ participants, selectedId, onSelect }: Props) {
   );
 }
 
-export default ProgressBarSpectator;
+export default memo(ProgressBarSpectator);

--- a/apps/web/src/stores/battleExecutionStore.ts
+++ b/apps/web/src/stores/battleExecutionStore.ts
@@ -1,0 +1,58 @@
+import type { TestcaseUpdateMessage } from '@shared/types/pubsub';
+import { create } from 'zustand';
+
+export type ExecutionMode = 'TEST' | 'SUBMISSION' | null;
+export type SubmissionProgress = TestcaseUpdateMessage['progress'];
+export type TestcaseResult = TestcaseUpdateMessage['testcase'] & {
+  results?: TestcaseUpdateMessage['results'];
+};
+
+type BattleExecutionState = {
+  statusText: string;
+  progress: SubmissionProgress | null;
+  isTesting: boolean;
+  isSubmitting: boolean;
+  mode: ExecutionMode;
+  testcaseResults: TestcaseResult[];
+  setStatusText: (text: string) => void;
+  setProgress: (progress: SubmissionProgress | null) => void;
+  setIsTesting: (value: boolean) => void;
+  setIsSubmitting: (value: boolean) => void;
+  setMode: (mode: ExecutionMode) => void;
+  setTestcaseResults: (results: TestcaseResult[]) => void;
+  upsertTestcaseResult: (result: TestcaseResult) => void;
+  reset: () => void;
+};
+
+const DEFAULT_STATUS = '대기 중';
+
+export const useBattleExecutionStore = create<BattleExecutionState>((set) => ({
+  statusText: DEFAULT_STATUS,
+  progress: null,
+  isTesting: false,
+  isSubmitting: false,
+  mode: null,
+  testcaseResults: [],
+  setStatusText: (statusText) => set({ statusText }),
+  setProgress: (progress) => set({ progress }),
+  setIsTesting: (isTesting) => set({ isTesting }),
+  setIsSubmitting: (isSubmitting) => set({ isSubmitting }),
+  setMode: (mode) => set({ mode }),
+  setTestcaseResults: (testcaseResults) => set({ testcaseResults }),
+  upsertTestcaseResult: (result) =>
+    set((state) => {
+      const next = state.testcaseResults.filter((item) => item.index !== result.index);
+      next.push(result);
+      next.sort((a, b) => a.index - b.index);
+      return { testcaseResults: next };
+    }),
+  reset: () =>
+    set({
+      statusText: DEFAULT_STATUS,
+      progress: null,
+      isTesting: false,
+      isSubmitting: false,
+      mode: null,
+      testcaseResults: [],
+    }),
+}));


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

CodeEditor/CodeSpectator에서 불필요한 리렌더가 발생하던 부분을 구조 분리 및 상태 분리로 개선했습니다.

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #261 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- 스토어 구독 최소화: CodeEditor/CodeSpectator에서 필요한 필드만 selector로 구독 (useShallow)
- EditorPane 분리: CodeEditor 입력 영역을 EditorPane으로 분리해 입력 시 에디터 영역만 리렌더
- CodeSpectatorEditor 분리: 관전자 코드 영역을 별도 컴포넌트로 분리하여 codeupdate 시 코드 영역만 리렌더
- 실행 상태 분리: battleExecutionStore 도입으로 실행/진행/결과 상태를 분리, CodeEditor 로컬 상태 제거
- Footer/Panel 상태 직접 구독: EditorFooter/TestcaseResultPanel이 store를 직접 구독하도록 변경
- React.memo + useCallback 적용: 주요 컴포넌트/핸들러 안정화
- React Compiler 경고 수정: handler deps를 정확히 반영하여 memoization 유지

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

### BEFORE

https://github.com/user-attachments/assets/d1919be4-3648-48e5-be11-393c124e24ce


### AFTER

https://github.com/user-attachments/assets/c1d69779-a0fd-4e74-969e-7a27cc96f736


## 🧠 의도 및 배경

> 왜 이 변경이 필요한지, 어떤 문제를 해결하는지 작성해주세요.

- CodeEditor는 입력/제출/실행 시 상태 변화가 많아 전체 렌더가 반복되고 있었고,
- CodeSpectator도 코드 업데이트에 따라 불필요하게 전체가 리렌더되는 문제가 있었습니다.
- 입력/관전 영역을 분리하고 실행 상태를 store로 옮겨 필요한 부분만 갱신되도록 개선했습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 스펙테이터 모드에서 다른 사용자의 코드를 더 명확하게 볼 수 있는 전용 코드 뷰어 추가

* **성능 개선**
  * 코드 에디터와 UI 컴포넌트의 불필요한 리렌더링 최적화
  * 상태 관리 개선으로 애플리케이션 응답성 향상

* **리팩토링**
  * 코드 에디터 상태 관리 구조 개선
  * 전역 상태 관리 시스템 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->