### PR TITLE
[FEAT] Python 언어 채점 지원 추가 (#277)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -66,6 +66,20 @@ docker compose --env-file .env.dev -f docker-compose.dev.yml exec mysql mysql -u
 docker compose --env-file .env.dev -f docker-compose.dev.yml exec redis redis-cli
 ```
 
+## 런너 이미지 빌드
+
+채점 런너 이미지는 docker-compose와 별도로 수동 빌드가 필요합니다.
+
+```bash
+# JavaScript 런너 이미지 빌드
+docker build -t judge-javascript -f apps/judge/runner/Dockerfile apps/judge/runner/
+
+# Python 런너 이미지 빌드
+docker build -t judge-python -f apps/judge/runner/Dockerfile.python apps/judge/runner/
+```
+
+> 런너 이미지(`apps/judge/runner/`) 파일이 변경된 경우 위 명령어로 재빌드해야 합니다.
+
 ## 참고사항
 
 - **Hot Reload**: 개발 환경에서 파일 변경 시 자동 반영 (Web: HMR, API: watch mode)

--- a/apps/judge/runner/Dockerfile.python
+++ b/apps/judge/runner/Dockerfile.python
@@ -1,0 +1,26 @@
+# Base Image (node:20-alpine 기반에 python3 추가)
+FROM node:20-alpine
+
+# Python3 설치
+RUN apk add --no-cache python3
+
+# 2. 일반 사용자 'coder' 계정 생성
+RUN addgroup -S coder && adduser -S coder -G coder
+
+# 3. 불필요한 도구 삭제 (보안 강화)
+RUN rm -rf /usr/local/bin/npm /usr/local/bin/npx /usr/local/lib/node_modules \
+    && rm -rf /opt/yarn* /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
+# 4. 네트워크 도구 삭제
+RUN rm -f /usr/bin/curl /usr/bin/wget
+
+# 5. 작업 디렉토리 설정 및 파일 복사
+WORKDIR /runner
+
+COPY run.js wrapper.py ./
+
+# 6. 소유권 변경
+RUN chown -R coder:coder /runner
+
+# 7. 기본 실행 명령어
+CMD ["node", "run.js"]

--- a/apps/judge/runner/run.js
+++ b/apps/judge/runner/run.js
@@ -61,6 +61,7 @@ async function main() {
   const timeLimit = meta.timeLimit || 2000; // 기본값 2초
   const memoryLimit = meta.memoryLimit || 256; // 기본값 256MB
   const type = meta.type || 'SUBMISSION'; // 'TEST'(테스트실행) 또는 'SUBMISSION'(정답제출)
+  const language = meta.language || 'javascript'; // 기본값 javascript
 
   console.log(
     `[Runner] Problem: ${problemId}, Type: ${type}, TimeLimit: ${timeLimit}ms, memoryLimit: ${memoryLimit}MB `,
@@ -81,12 +82,16 @@ async function main() {
   console.log(`[Runner] Loading cases from: ${casesFileName}`);
 
   const testCasesParent = JSON.parse(fs.readFileSync(casesPath, 'utf8'));
-  const solutionFile = path.join(OUTPUT_DIR, 'solution.js');
   const testCases = testCasesParent.testCases || testCasesParent; // 구조에 따라 적절히 선택
+
+  // 언어별 솔루션 파일명 결정
+  const solutionFileMap = { javascript: 'solution.js', python: 'solution.py' };
+  const solutionFilename = solutionFileMap[language] || 'solution.js';
+  const solutionFile = path.join(OUTPUT_DIR, solutionFilename);
 
   if (!fs.existsSync(solutionFile)) {
     console.error(`[Error] Solution file not found: ${solutionFile}`);
-    process.exit(1); // solution.js 파일 없을 시 즉시 종료
+    process.exit(1);
   }
 
   // 3. 테스트 케이스별 실행 (Execute User Code)
@@ -95,7 +100,13 @@ async function main() {
     console.log(`[Runner] Running Case #${i + 1} (ID: ${testCase.id})...`);
 
     // 개별 케이스 실행
-    const result = await runTestCase(solutionFile, testCase.input, timeLimit, memoryLimit);
+    const result = await runTestCase(
+      solutionFile,
+      testCase.input,
+      timeLimit,
+      memoryLimit,
+      language,
+    );
 
     // 4. 실행 결과 파일 저장 (Save Results)
     // stdout에서 메트릭 정보 분리
@@ -133,26 +144,29 @@ async function main() {
  * @param {string} input - 테스트 케이스 입력값
  * @param {number} timeLimit - 시간 제한 (ms)
  * @param {number} memoryLimit - 메모리 제한 (MB)
+ * @param {string} language - 실행 언어
  */
-function runTestCase(solutionFile, input, timeLimit, memoryLimit) {
+function runTestCase(solutionFile, input, timeLimit, memoryLimit, language) {
   return new Promise((resolve) => {
     const startTime = Date.now();
     let status = 'PENDING';
 
-    // 자식 프로세스 생성 (spawn)
-    // node --max-old-space-size={Limit} wrapper.js solution.js
-    const wrapperPath = IS_DOCKER ? '/runner/wrapper.js' : path.join(__dirname, 'wrapper.js');
-    const child = spawn(
-      'node',
-      [
-        `--max-old-space-size=${memoryLimit}`, // V8 메모리 제한 옵션
-        wrapperPath,
-        solutionFile,
-      ],
-      {
-        stdio: ['pipe', 'pipe', 'pipe'], // 다시 pipe로 복구
-      },
-    );
+    // 언어별 실행 명령어 결정
+    let cmd, args;
+    if (language === 'python') {
+      const wrapperPy = IS_DOCKER ? '/runner/wrapper.py' : path.join(__dirname, 'wrapper.py');
+      cmd = 'python3';
+      args = [wrapperPy, solutionFile];
+    } else {
+      // javascript (기본)
+      const wrapperJs = IS_DOCKER ? '/runner/wrapper.js' : path.join(__dirname, 'wrapper.js');
+      cmd = 'node';
+      args = [`--max-old-space-size=${memoryLimit}`, wrapperJs, solutionFile];
+    }
+
+    const child = spawn(cmd, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
     let stdoutBuffer = '';
     let stderrBuffer = '';

--- a/apps/judge/runner/wrapper.py
+++ b/apps/judge/runner/wrapper.py
@@ -1,0 +1,39 @@
+import sys
+import importlib.util
+import tracemalloc
+
+
+def main():
+    solution_path = sys.argv[1]
+
+    spec = importlib.util.spec_from_file_location("solution", solution_path)
+    module = importlib.util.module_from_spec(spec)
+
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        sys.stderr.write(f"{type(e).__name__}: {e}\n")
+        sys.exit(1)
+
+    if not hasattr(module, 'solution') or not callable(module.solution):
+        sys.stderr.write('Error: solution function missing\n')
+        sys.exit(1)
+
+    input_data = sys.stdin.read()
+
+    try:
+        tracemalloc.start()
+        result = module.solution(input_data)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        if result is not None:
+            sys.stdout.write(str(result))
+
+        sys.stdout.write(f'\n---METRIC---\n{peak}')
+    except Exception as e:
+        sys.stderr.write(f"{type(e).__name__}: {e}\n")
+        sys.exit(1)
+
+
+main()

--- a/apps/judge/src/docker/docker.constants.ts
+++ b/apps/judge/src/docker/docker.constants.ts
@@ -1,4 +1,5 @@
 export const DOCKER_RUNNER_IMAGE = 'judge-javascript';
+export const DOCKER_PYTHON_RUNNER_IMAGE = 'judge-python';
 export const DOCKER_PROBLEMS_PATH = 'judge-data';
 export const DOCKER_SUBMISSIONS_PATH = 'judge-data/submissions';
 export const DOCKER_CONTAINER_NAME = 'submission';

--- a/apps/judge/src/docker/docker.service.ts
+++ b/apps/judge/src/docker/docker.service.ts
@@ -8,6 +8,7 @@ import {
   DOCKER_CONTAINER_NAME,
   DOCKER_CPU_LIMIT,
   DOCKER_DEFAULT_MEMORY_LIMIT_MB,
+  DOCKER_PYTHON_RUNNER_IMAGE,
   DOCKER_RUNNER_IMAGE,
   DOCKER_TMPFS_SIZE_MB,
 } from './docker.constants';
@@ -15,6 +16,7 @@ import {
 export interface DockerRunOptions {
   submissionId: string;
   memoryLimitMb?: number;
+  language?: string;
 }
 
 export interface DockerRunResult {
@@ -63,7 +65,7 @@ export class DockerRunnerService {
   }
 
   private buildRunArgs(options: DockerRunOptions): string[] {
-    const image = this.getString('JUDGE_RUNNER_IMAGE', DOCKER_RUNNER_IMAGE);
+    const image = this.getImageForLanguage(options.language);
 
     // 1. 호스트 경로 가져오기
     const rawHostPath = this.getString('JUDGE_HOST_PATH', '');
@@ -153,6 +155,13 @@ export class DockerRunnerService {
         });
       });
     });
+  }
+
+  private getImageForLanguage(language?: string): string {
+    if (language === 'python') {
+      return this.getString('JUDGE_PYTHON_RUNNER_IMAGE', DOCKER_PYTHON_RUNNER_IMAGE);
+    }
+    return this.getString('JUDGE_RUNNER_IMAGE', DOCKER_RUNNER_IMAGE);
   }
 
   private getString(key: string, fallback: string): string {

--- a/apps/judge/src/judge/judge.types.ts
+++ b/apps/judge/src/judge/judge.types.ts
@@ -7,6 +7,7 @@ export interface Metadata {
   timeLimit: number;
   memoryLimit: number;
   type: SubmissionJobType;
+  language?: string;
   socketId?: string;
 }
 

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -92,13 +92,17 @@ export class SubmissionProcessor extends WorkerHost {
         payload.type,
         payload.problemId,
         payload.code,
+        payload.language,
         payload.socketId,
         payload.battleId,
       );
 
       // 3. Docker 실행과 채점을 병렬로 시작
       const [dockerResult, judgeResult] = await Promise.all([
-        this.dockerRunnerService.runSubmission({ submissionId: executionId }),
+        this.dockerRunnerService.runSubmission({
+          submissionId: executionId,
+          language: payload.language,
+        }),
         this.judgeService.judgeSubmission(executionId),
       ]);
 

--- a/apps/judge/src/submission/submission.service.ts
+++ b/apps/judge/src/submission/submission.service.ts
@@ -65,6 +65,7 @@ export class SubmissionService {
     type: SubmissionJobType,
     problemId: string,
     code: string,
+    language: string,
     socketId?: string,
     battleId?: string,
   ): Promise<void> {
@@ -86,6 +87,7 @@ export class SubmissionService {
       timeLimit: problem.timeLimit,
       memoryLimit: problem.memoryLimit,
       type,
+      language,
       ...(socketId ? { socketId } : {}),
       ...(battleId ? { battleId } : {}),
     };
@@ -96,7 +98,12 @@ export class SubmissionService {
     const metadataPath = path.join(submissionDir, 'meta.json');
     fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
 
-    const solutionPath = path.join(submissionDir, 'solution.js');
+    const solutionFilenameMap: Record<string, string> = {
+      javascript: 'solution.js',
+      python: 'solution.py',
+    };
+    const solutionFilename = solutionFilenameMap[language] ?? 'solution.js';
+    const solutionPath = path.join(submissionDir, solutionFilename);
     fs.writeFileSync(solutionPath, code);
   }
 

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -1,5 +1,11 @@
 import type { OnMount } from '@monaco-editor/react';
-import { BATTLE_CONFIG, BATTLE_EVENTS, DEFAULT_CODE_TEMPLATE } from '@shared/constants/battle';
+import {
+  BATTLE_CONFIG,
+  BATTLE_EVENTS,
+  DEFAULT_CODE_TEMPLATE,
+  LANGUAGE_TEMPLATES,
+  SUPPORTED_LANGUAGES,
+} from '@shared/constants/battle';
 import { SOCKET_EVENT } from '@shared/constants/socket-event';
 import type { FinalResultMessage, TestcaseUpdateMessage } from '@shared/types/pubsub';
 import { Code } from 'lucide-react';
@@ -22,11 +28,17 @@ const LazyBaseCodeEditor = lazy(() => import('@/components/Common/BaseCodeEditor
 
 type EditorPaneProps = {
   code: string;
+  language: string;
   onCodeChange: (value: string) => void;
   onMount: OnMount;
 };
 
-const EditorPane = memo(function EditorPane({ code, onCodeChange, onMount }: EditorPaneProps) {
+const EditorPane = memo(function EditorPane({
+  code,
+  language,
+  onCodeChange,
+  onMount,
+}: EditorPaneProps) {
   return (
     <Suspense
       fallback={
@@ -35,6 +47,7 @@ const EditorPane = memo(function EditorPane({ code, onCodeChange, onMount }: Edi
     >
       <LazyBaseCodeEditor
         value={code}
+        language={language}
         onChange={(nextValue) => {
           const normalized = nextValue || '';
           onCodeChange(normalized);
@@ -94,6 +107,7 @@ function CodeEditor() {
     })),
   );
 
+  const [language, setLanguage] = useState<string>(BATTLE_CONFIG.DEFAULT_LANGUAGE);
   const [code, setCode] = useState(DEFAULT_CODE_TEMPLATE);
   const codeRef = useRef(code);
   const [pasteToastMessage, setPasteToastMessage] = useState<string | null>(null);
@@ -312,8 +326,27 @@ function CodeEditor() {
         roomId,
         userId: me.userId,
         code: value,
-        language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
+        language,
       });
+    },
+    [language, me, roomId, socket],
+  );
+
+  const handleLanguageChange = useCallback(
+    (newLanguage: string) => {
+      setLanguage(newLanguage);
+      const template = LANGUAGE_TEMPLATES[newLanguage] ?? DEFAULT_CODE_TEMPLATE;
+      setCode(template);
+      codeRef.current = template;
+
+      if (socket?.connected && me?.userId) {
+        socket.emit(BATTLE_EVENTS.CODE_CHANGE, {
+          roomId,
+          userId: me.userId,
+          code: template,
+          language: newLanguage,
+        });
+      }
     },
     [me, roomId, socket],
   );
@@ -398,16 +431,13 @@ function CodeEditor() {
     initSubmission('TEST');
 
     try {
-      await createDryRun(
-        { problemId, code: codeRef.current, language: BATTLE_CONFIG.DEFAULT_LANGUAGE },
-        socket.id,
-      );
+      await createDryRun({ problemId, code: codeRef.current, language }, socket.id);
       setStatusText('테스트 대기 중');
     } catch (error) {
       resetOnError('TEST');
       console.error(error);
     }
-  }, [initSubmission, problemId, resetOnError, setStatusText, socket]);
+  }, [initSubmission, language, problemId, resetOnError, setStatusText, socket]);
 
   const handleSubmit = useCallback(async () => {
     // 이미 실행 중이면 무시
@@ -428,7 +458,7 @@ function CodeEditor() {
         {
           problemId,
           code: codeRef.current,
-          language: BATTLE_CONFIG.DEFAULT_LANGUAGE,
+          language,
           ...(battleId ? { battleId } : {}),
         },
         socket.id,
@@ -440,7 +470,7 @@ function CodeEditor() {
       resetOnError('SUBMISSION');
       console.error(error);
     }
-  }, [battleId, initSubmission, problemId, resetOnError, setStatusText, socket]);
+  }, [battleId, initSubmission, language, problemId, resetOnError, setStatusText, socket]);
 
   const handleEditorMount: OnMount = useCallback(
     (editor) => {
@@ -476,11 +506,26 @@ function CodeEditor() {
           <div className="flex items-center gap-1.5">
             <Code className="h-5 w-5 text-green-05" strokeWidth={2.5} />
             <span className="rounded pr-3 text-sm font-bold text-green-05">코드 에디터</span>
-            <button className="rounded-md bg-base-muted px-3 py-1 text-xs">JavaScript</button>
+            <select
+              value={language}
+              onChange={(e) => handleLanguageChange(e.target.value)}
+              className="rounded-md bg-base-muted px-3 py-1 text-xs"
+            >
+              {SUPPORTED_LANGUAGES.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
         <div className="min-h-[320px] h-[40vh] bg-(bg-layer-2) font-mono text-sm text-base-primary xl:h-auto xl:flex-1">
-          <EditorPane code={code} onCodeChange={handleCodeChange} onMount={handleEditorMount} />
+          <EditorPane
+            code={code}
+            language={language}
+            onCodeChange={handleCodeChange}
+            onMount={handleEditorMount}
+          />
         </div>
         <EditorFooter onDryRun={handleDryRun} onSubmit={handleSubmit} />
         <TestcaseResultPanel />

--- a/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectator.tsx
@@ -39,7 +39,6 @@ function CodeSpectator() {
 
   useEffect(() => {
     const client = socket ?? connect();
-    const { upsertCode } = useRoomStore.getState();
 
     const handleCodeUpdate = (payload: {
       roomId: string;
@@ -48,7 +47,9 @@ function CodeSpectator() {
       language: string;
     }) => {
       if (payload.roomId !== roomId) return;
+      const { upsertCode, upsertLanguage } = useRoomStore.getState();
       upsertCode(payload.userId, payload.code);
+      upsertLanguage(payload.userId, payload.language);
       if (!selectedId) {
         setSelectedId(payload.userId);
       }

--- a/apps/web/src/components/Battle/Spectator/CodeSpectatorEditor.tsx
+++ b/apps/web/src/components/Battle/Spectator/CodeSpectatorEditor.tsx
@@ -1,3 +1,4 @@
+import { BATTLE_CONFIG, SUPPORTED_LANGUAGES } from '@shared/constants/battle';
 import { Code } from 'lucide-react';
 import { lazy, memo, Suspense, useMemo } from 'react';
 
@@ -23,6 +24,14 @@ function CodeSpectatorEditor({ activeSelectedId, participants }: CodeSpectatorEd
   const rawSelectedCode = useRoomStore((state) =>
     activeSelectedId ? state.codes[activeSelectedId] : undefined,
   );
+  const selectedLanguage = useRoomStore((state) =>
+    activeSelectedId
+      ? (state.languages[activeSelectedId] ?? BATTLE_CONFIG.DEFAULT_LANGUAGE)
+      : BATTLE_CONFIG.DEFAULT_LANGUAGE,
+  );
+
+  const selectedLanguageLabel =
+    SUPPORTED_LANGUAGES.find((l) => l.value === selectedLanguage)?.label ?? 'JavaScript';
 
   const selectedCode = useMemo(() => {
     const isCodeEmpty = !rawSelectedCode || rawSelectedCode.trim().length === 0;
@@ -41,7 +50,9 @@ function CodeSpectatorEditor({ activeSelectedId, participants }: CodeSpectatorEd
           <span className="text-color-green-05">{selectedName}</span>
         </div>
         <div className="flex items-center gap-2 text-xs text-base-secondary">
-          <span className="rounded-full bg-base-muted px-3 py-1 text-base-primary">JavaScript</span>
+          <span className="rounded-full bg-base-muted px-3 py-1 text-base-primary">
+            {selectedLanguageLabel}
+          </span>
         </div>
       </div>
 
@@ -53,6 +64,7 @@ function CodeSpectatorEditor({ activeSelectedId, participants }: CodeSpectatorEd
         >
           <BaseCodeEditor
             value={selectedCode}
+            language={selectedLanguage}
             options={{
               readOnly: true,
               renderLineHighlight: 'none',

--- a/apps/web/src/components/Common/BaseCodeEditor.tsx
+++ b/apps/web/src/components/Common/BaseCodeEditor.tsx
@@ -9,6 +9,7 @@ type BaseCodeEditorProps = EditorProps;
 const BaseCodeEditor = ({
   theme: _ignoredTheme,
   beforeMount,
+  language,
   options,
   ...props
 }: BaseCodeEditorProps) => {
@@ -50,7 +51,7 @@ const BaseCodeEditor = ({
   return (
     <Editor
       height="100%"
-      defaultLanguage={BATTLE_CONFIG.DEFAULT_LANGUAGE}
+      language={language ?? BATTLE_CONFIG.DEFAULT_LANGUAGE}
       theme={theme === 'dark' ? 'tadak-dark' : 'tadak-light'}
       beforeMount={handleBeforeMount}
       options={{ ...defaultOptions, ...options }}

--- a/apps/web/src/stores/roomStore.ts
+++ b/apps/web/src/stores/roomStore.ts
@@ -15,16 +15,19 @@ type State = {
   clearRoom: () => void;
   players: Player[];
   codes: CodeMap;
+  languages: CodeMap;
   me?: Player;
   setPlayers: (players: Player[]) => void;
   setMe: (me: Player) => void;
   upsertPlayer: (player: Player) => void;
   upsertCode: (userId: string, code: string) => void;
+  upsertLanguage: (userId: string, language: string) => void;
 };
 
 export const useRoomStore = create<State>((set) => ({
   players: [],
   codes: {},
+  languages: {},
   setPlayers: (players) => set({ players }),
   setMe: (me) => set({ me }),
   upsertPlayer: (player) =>
@@ -36,5 +39,7 @@ export const useRoomStore = create<State>((set) => ({
       return { players: next };
     }),
   upsertCode: (userId, code) => set((s) => ({ codes: { ...s.codes, [userId]: code } })),
-  clearRoom: () => set({ players: [], codes: {}, me: undefined }),
+  upsertLanguage: (userId, language) =>
+    set((s) => ({ languages: { ...s.languages, [userId]: language } })),
+  clearRoom: () => set({ players: [], codes: {}, languages: {}, me: undefined }),
 }));

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "@testing-library/jest-dom"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/constants/battle.ts
+++ b/packages/constants/battle.ts
@@ -8,6 +8,20 @@ export const DEFAULT_CODE_TEMPLATE = `function solution(input) {
   // TODO: 문제 풀이 로직 작성
 }`;
 
+export const PYTHON_CODE_TEMPLATE = `def solution(input_str):
+    # TODO: 문제 풀이 로직 작성
+    pass`;
+
+export const LANGUAGE_TEMPLATES: Record<string, string> = {
+  javascript: DEFAULT_CODE_TEMPLATE,
+  python: PYTHON_CODE_TEMPLATE,
+};
+
+export const SUPPORTED_LANGUAGES = [
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'python', label: 'Python' },
+] as const;
+
 export const BATTLE_EVENTS = {
   // 배틀 생성 및 시작
   BATTLE_CREATED: 'battle-created',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3855,6 +3855,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.0:
@@ -3863,7 +3864,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}


### PR DESCRIPTION
## 🔍 PR 요약

- Javascript만 지원하던 채점 시스템에 Python 언어 채점 지원 추가

## 🧾 관련 이슈


- close #277 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.

- runner/Dockerfile.python — Python 런너 Docker 이미지 추가 (node:20-alpine + python3)
- runner/wrapper.py — Python용 실행 래퍼 (solution(input_str) 함수 호출, tracemalloc 메모리 측정)
- docker.service.ts — 언어별 Docker 이미지 선택 (judge-javascript / judge-python)
- submission.service.ts — meta.json에 language 저장, 언어별 솔루션 파일명 분기 (solution.js / solution.py)
- CodeEditor.tsx — 언어 선택 드롭다운 추가, 언어 변경 시 기본 코드 템플릿 초기화

## 📸 스크린샷 (선택)

> [FE] UI나 주요 시각적 변경이 있다면 첨부해주세요.

<img width="1301" height="802" alt="image" src="https://github.com/user-attachments/assets/585d7207-2849-4819-a0d3-072ebf712667" />

<img width="984" height="810" alt="image" src="https://github.com/user-attachments/assets/0cb8598d-16b4-423c-ab8b-c0bf51a22b41" />

## 🧠 의도 및 배경

- 배틀 서비스에서 JavaScript 외 다른 언어 사용자도 참여할 수 있도록 다중 언어 채점 지원이 필요

## 💬 리뷰 요구사항(선택)

- 이전 Javascript 양식에 맞춰 Python도 def 함수를 작성하는 식으로 구현했는데 괜찮을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Python 언어 지원 추가 (기존 JavaScript와 함께)
  * 코드 에디터에 언어 선택 옵션 추가
  * 언어별 코드 템플릿 지원

* **문서화**
  * Docker 러너 이미지 빌드 가이드 추가

* **Chores**
  * TypeScript 설정 업데이트
  * 언어별 실행 환경 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->