### PR TITLE
[FEAT] BullMQ 재시도 전략 적용 및 실패 시 UI 알림 추가 (#279)

### DIFF
--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -89,6 +89,11 @@ export class SubmissionService {
           socketId,
         },
         {
+          attempts: 3,
+          backoff: {
+            type: 'exponential',
+            delay: 1000,
+          },
           removeOnComplete: true,
           removeOnFail: { age: 3600, count: 50 },
         },
@@ -124,6 +129,11 @@ export class SubmissionService {
         socketId,
       },
       {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 1000,
+        },
         removeOnComplete: true,
         removeOnFail: { age: 3600, count: 50 },
       },

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -119,6 +119,23 @@ export class SubmissionProcessor extends WorkerHost {
   @OnWorkerEvent('failed')
   onFailed(job: Job<SubmissionJobPayload> | undefined, error: Error): void {
     const jobId = job?.id ?? 'unknown';
-    this.logger.error(`Job ${jobId} failed: ${error.message}`, error.stack);
+    const attempts = job?.attemptsMade ?? 0;
+    const maxAttempts = job?.opts?.attempts ?? 1;
+    this.logger.error(
+      `Job ${jobId} failed (attempt ${attempts}/${maxAttempts}): ${error.message}`,
+      error.stack,
+    );
+
+    // 모든 재시도 소진 시 UI에 ERROR 알림 → 버튼 활성화
+    if (job && attempts >= maxAttempts) {
+      const payload = job.data;
+      void this.pubsubService.publishFinalResult({
+        type: 'FINAL_RESULT',
+        submissionId: String(payload.submissionId),
+        socketId: payload.socketId,
+        status: 'INTERNAL_ERROR',
+        result: { passed: 0, total: 0, time: 0, memory: 0 },
+      });
+    }
   }
 }

--- a/apps/judge/src/submission/submission.processor.ts
+++ b/apps/judge/src/submission/submission.processor.ts
@@ -129,13 +129,20 @@ export class SubmissionProcessor extends WorkerHost {
     // 모든 재시도 소진 시 UI에 ERROR 알림 → 버튼 활성화
     if (job && attempts >= maxAttempts) {
       const payload = job.data;
-      void this.pubsubService.publishFinalResult({
-        type: 'FINAL_RESULT',
-        submissionId: String(payload.submissionId),
-        socketId: payload.socketId,
-        status: 'INTERNAL_ERROR',
-        result: { passed: 0, total: 0, time: 0, memory: 0 },
-      });
+      this.pubsubService
+        .publishFinalResult({
+          type: 'FINAL_RESULT',
+          submissionId: String(payload.submissionId),
+          socketId: payload.socketId,
+          status: 'INTERNAL_ERROR',
+          result: { passed: 0, total: 0, time: 0, memory: 0 },
+        })
+        .catch((publishError: Error) => {
+          this.logger.error(
+            `Failed to publish FINAL_RESULT for job ${jobId}: ${publishError.message}`,
+            publishError.stack,
+          );
+        });
     }
   }
 }

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -16,6 +16,7 @@ import { useBattleJoin } from '@/hooks/useBattleJoin';
 import { useRoleModalState } from '@/hooks/useRoleModalState';
 import { useTheme } from '@/hooks/useTheme';
 import { playCountdownSound } from '@/lib/sound';
+import { useBattleExecutionStore } from '@/stores/battleExecutionStore';
 import { useBattleProblemStore } from '@/stores/battleProblemStore';
 import { useBattleProgressStore } from '@/stores/battleProgressStore';
 import type { BattleSocketState } from '@/stores/battleSocketStore';
@@ -178,6 +179,7 @@ function BattlePage() {
       useRoomStore.getState().clearRoom();
       useBattleProblemStore.getState().clearProblem();
       useBattleProgressStore.getState().resetProgresses();
+      useBattleExecutionStore.getState().reset();
     };
   }, []);
 


### PR DESCRIPTION
## 🔍 PR 요약

> 어떤 변경을 했는지 간단히 설명해주세요.

- BullMQ 큐에 exponential backoff 재시도 전략 추가 및 모든 재시도 소진 시 UI 알림 처리

## 🧾 관련 이슈

> 이 PR이 관련된 이슈 번호를 명시해주세요.

- close #279 

## 🛠️ 주요 변경 사항

> 핵심 변경사항을 bullet point로 나열해주세요.
- apps/api/src/submission/submission.service.ts: submit(), executeTest() 큐 옵션에 attempts: 3, exponential backoff(delay: 1000ms) 추가
- apps/judge/src/submission/submission.processor.ts: onFailed 핸들러에서 재시도 횟수 로깅 추가, 모든 재시도 소진 시 INTERNAL_ERROR 상태를 pubsub으로 발행해 UI 버튼 활성화
- apps/web/src/pages/BattlePage.tsx: 페이지 언마운트 시 useBattleExecutionStore.reset() 누락 수정 → 배틀 재시작 시 이전 테스트케이스 결과가 남는 버그 수정


## 🧠 의도 및 배경

- Judge 서버에서 Docker 데몬 불안정 등 일시적 인프라 오류 발생 시 Job이 1회 실패로 종료되는 문제 개선
- 재시도 1초 → 2초 → 4초 간격으로 최대 3회 시도하여 복원력 향상
- 모든 재시도 소진 시 UI에 ERROR를 알리지 않아 버튼이 "실행중"으로 고착되는 문제 수정

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 작업 실패 시 자동 재시도(최대 3회, 지수백오프)를 적용하여 일시적 실패에 대한 복원력을 강화했습니다.
  * 재시도 한도 도달 시 시각적 오류 알림과 재시도 흐름을 명확히 제공하도록 개선했습니다(내부 상태와 시도 횟수 로깅 포함).
  * 페이지 종료 시 추가 실행 관련 상태를 초기화해 남아 있는 리소스와 상태를 정리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->